### PR TITLE
issue #8 - Kuzzle constructor called without new keyword

### DIFF
--- a/src/kuzzle.js
+++ b/src/kuzzle.js
@@ -27,6 +27,10 @@ var
  * @constructor
  */
 module.exports = Kuzzle = function (url, options, cb) {
+  if (!(this instanceof Kuzzle)) {
+    return new Kuzzle(url, options, cb);
+  }
+
   if (!cb && typeof options === 'function') {
     cb = options;
     options = null;


### PR DESCRIPTION
Fixes #8.
Forces Kuzzle constructor to return a valid Kuzzle instance if not called using the new keyword.