### PR TITLE
checkToken does not take options

### DIFF
--- a/src/kuzzle.js
+++ b/src/kuzzle.js
@@ -498,7 +498,13 @@ Kuzzle.prototype.checkToken = function (token, callback) {
 
   this.callbackRequired('Kuzzle.checkToken', callback);
 
-  this.query({controller: 'auth', action: 'checkToken'}, request, {queuable: false}, callback);
+  this.query({controller: 'auth', action: 'checkToken'}, request, {queuable: false}, function (err, response) {
+    if (err) {
+      return callback(err);
+    }
+
+    callback(null, response.result);
+  });
 
   return self;
 };

--- a/src/kuzzle.js
+++ b/src/kuzzle.js
@@ -498,7 +498,7 @@ Kuzzle.prototype.checkToken = function (token, callback) {
 
   this.callbackRequired('Kuzzle.checkToken', callback);
 
-  this.query({controller: 'auth', action: 'checkToken'}, request, {}, callback);
+  this.query({controller: 'auth', action: 'checkToken'}, request, {queuable: false}, callback);
 
   return self;
 };

--- a/test/kuzzle/methods.test.js
+++ b/test/kuzzle/methods.test.js
@@ -1,6 +1,7 @@
 var
   should = require('should'),
   rewire = require('rewire'),
+  proxyquire = require('proxyquire'),
   Kuzzle = rewire('../../src/kuzzle'),
   KuzzleDataCollection = require('../../src/kuzzleDataCollection'),
   KuzzleSecurity = require('../../src/security/kuzzleSecurity'),
@@ -511,14 +512,15 @@ describe('Kuzzle methods', function () {
         connect: 'manual'
       });
 
-      kuzzle.queuing = true;
+      kuzzle.query = function (args, query) {
+        should(args.action).be.eql('checkToken');
+        should(args.controller).be.eql('auth');
+        should(query.body.token).be.eql(token);
+      };
+
+      kuzzle.state = 'connected';
 
       kuzzle.checkToken(token, function (err, res) {});
-
-      should(kuzzle.offlineQueue.length).be.exactly(1);
-      should(kuzzle.offlineQueue[0].query.action).be.exactly('checkToken');
-      should(kuzzle.offlineQueue[0].query.controller).be.exactly('auth');
-      should(kuzzle.offlineQueue[0].query.body.token).be.exactly(token);
     });
 
     it('should throw an error when it is called with no callback', function (done) {

--- a/test/kuzzle/methods.test.js
+++ b/test/kuzzle/methods.test.js
@@ -504,6 +504,7 @@ describe('Kuzzle methods', function () {
     it('should send the checkToken after call', function () {
       var
         kuzzle,
+        stubResults = { foo: 'bar' },
         token = 'fakeToken-eoijaodmowifnw8h';
 
       this.timeout(200);
@@ -512,15 +513,46 @@ describe('Kuzzle methods', function () {
         connect: 'manual'
       });
 
-      kuzzle.query = function (args, query) {
+      kuzzle.query = function (args, query, opts, cb) {
         should(args.action).be.eql('checkToken');
         should(args.controller).be.eql('auth');
         should(query.body.token).be.eql(token);
+        cb(null, {result: stubResults });
       };
 
       kuzzle.state = 'connected';
 
-      kuzzle.checkToken(token, function (err, res) {});
+      kuzzle.checkToken(token, function (err, res) {
+        should(err).be.null();
+        should(res).be.eql(stubResults);
+      });
+    });
+
+    it('should resolve to an error if Kuzzle respond with one', function () {
+      var
+        kuzzle,
+        stubError = { foo: 'bar' },
+        token = 'fakeToken-eoijaodmowifnw8h';
+
+      this.timeout(200);
+
+      kuzzle = new Kuzzle('nowhere', {
+        connect: 'manual'
+      });
+
+      kuzzle.query = function (args, query, opts, cb) {
+        should(args.action).be.eql('checkToken');
+        should(args.controller).be.eql('auth');
+        should(query.body.token).be.eql(token);
+        cb({error: stubError });
+      };
+
+      kuzzle.state = 'connected';
+
+      kuzzle.checkToken(token, function (err, res) {
+        should(err.error).be.eql(stubError);
+        should(res).be.undefined();
+      });
     });
 
     it('should throw an error when it is called with no callback', function (done) {


### PR DESCRIPTION
The `Kuzzle.checkToken` method should not take options, and it should always be non-queuable.
Moreover, instead of returning the raw API response, it now returns only the informations concerning the token check.

The SDK documentation will be updated accordingly.