### PR TITLE
[MASTER] KUZ-683 allow changing host

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/kuzzle.js
+++ b/src/kuzzle.js
@@ -315,9 +315,11 @@ module.exports = Kuzzle = function (host, options, cb) {
 Kuzzle.prototype.connect = function () {
   var self = this;
 
-  if (!self.network) {
-    self.network = networkWrapper(self.host, self.wsPort, self.ioPort, self.sslConnection);
+  if (self.network) {
+    self.disconnect();
   }
+
+  self.network = networkWrapper(self.host, self.wsPort, self.ioPort, self.sslConnection);
 
   if (['initializing', 'ready', 'disconnected', 'error', 'offline'].indexOf(this.state) === -1) {
     if (self.connectCB) {

--- a/src/kuzzle.js
+++ b/src/kuzzle.js
@@ -114,11 +114,13 @@ module.exports = Kuzzle = function (host, options, cb) {
     },
     wsPort: {
       value: (options && typeof options.wsPort === 'number') ? options.wsPort : 7513,
-      enumerable: true
+      enumerable: true,
+      writable: true
     },
     ioPort: {
       value: (options && typeof options.ioPort === 'number') ? options.ioPort : 7512,
-      enumerable: true
+      enumerable: true,
+      writable: true
     },
     sslConnection: {
       value: (options && typeof options.sslConnection === 'boolean') ? options.sslConnection : false,

--- a/src/kuzzle.js
+++ b/src/kuzzle.js
@@ -109,6 +109,7 @@ module.exports = Kuzzle = function (host, options, cb) {
     },
     host: {
       value: host,
+      writable: true,
       enumerable: true
     },
     wsPort: {
@@ -1003,6 +1004,7 @@ Kuzzle.prototype.disconnect = function () {
 
   this.state = 'disconnected';
   this.network.close();
+  this.network = null;
 
   for (collection in this.collections) {
     if (this.collections.hasOwnProperty(collection)) {

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -69,8 +69,8 @@ describe('Kuzzle constructor', () => {
       should(kuzzle).have.propertyWithDescriptor('reconnectionDelay', { enumerable: true, writable: false, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('jwtToken', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('offlineQueueLoader', { enumerable: true, writable: true, configurable: false });
-      should(kuzzle).have.propertyWithDescriptor('wsPort', { enumerable: true, writable: false, configurable: false });
-      should(kuzzle).have.propertyWithDescriptor('ioPort', { enumerable: true, writable: false, configurable: false });
+      should(kuzzle).have.propertyWithDescriptor('wsPort', { enumerable: true, writable: true, configurable: false });
+      should(kuzzle).have.propertyWithDescriptor('ioPort', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('sslConnection', { enumerable: true, writable: false, configurable: false });
     });
 

--- a/test/kuzzle/methods.test.js
+++ b/test/kuzzle/methods.test.js
@@ -399,7 +399,7 @@ describe('Kuzzle methods', function () {
       kuzzle.collections = { foo: {}, bar: {}, baz: {} };
       kuzzle.disconnect();
 
-      should(kuzzle.network.close.called).be.true();
+      should(kuzzle.network).be.null();
       should(kuzzle.collections).be.empty();
       should(function () { kuzzle.isValid(); }).throw(Error);
     });


### PR DESCRIPTION
Instead of being read-only, the `host`, `ioPort` and `wsPort` attributes from the `Kuzzle` object should be writable to allow changing them between connections.
And when invoking `Kuzzle.connect`, if a network connection has previously been established, then `Kuzzle.disconnect` is called beforehand.