### PR TITLE
make subscribe.onDone foolproof

### DIFF
--- a/src/kuzzleSubscribeResult.js
+++ b/src/kuzzleSubscribeResult.js
@@ -4,6 +4,8 @@
  */
 function KuzzleSubscribeResult() {
   this.cbs = [];
+  this.error = null;
+  this.room = null;
 }
 
 /**
@@ -11,7 +13,13 @@ function KuzzleSubscribeResult() {
  * @param {Function} cb
  */
 KuzzleSubscribeResult.prototype.onDone = function (cb) {
-  this.cbs.push(cb);
+  if (this.error || this.room) {
+    cb(this.error, this.room);
+  }
+  else {
+    this.cbs.push(cb);
+  }
+  
   return this;
 };
 
@@ -22,6 +30,9 @@ KuzzleSubscribeResult.prototype.onDone = function (cb) {
  * @param {KuzzleRoom} room
  */
 KuzzleSubscribeResult.prototype.done = function (error, room) {
+  this.error = error;
+  this.room = room;
+
   this.cbs.forEach(function (cb) {
     cb(error, room);
   });

--- a/src/kuzzleSubscribeResult.js
+++ b/src/kuzzleSubscribeResult.js
@@ -19,7 +19,7 @@ KuzzleSubscribeResult.prototype.onDone = function (cb) {
   else {
     this.cbs.push(cb);
   }
-  
+
   return this;
 };
 

--- a/test/kuzzleSubscribeResult/kuzzleSubscribeResult.test.js
+++ b/test/kuzzleSubscribeResult/kuzzleSubscribeResult.test.js
@@ -34,6 +34,8 @@ describe('KuzzleSubscribeResult object', function () {
         count++;
         should(err).be.eql(foo);
         should(res).be.eql(bar);
+        should(ksr.error).be.eql(err);
+        should(ksr.room).be.eql(res);
         if (count === 3) {
           done();
         }
@@ -48,6 +50,23 @@ describe('KuzzleSubscribeResult object', function () {
     ksr.onDone(cb);
 
     ksr.done(foo, bar);
+  });
+
+  it('should invoke the provided callback directly if Kuzzle response is already stored', function (done) {
+    var
+      cb = function (err, res) {
+        should(err).be.eql('foo');
+        should(res).be.eql('bar');
+        should(ksr.cbs).be.empty();
+        done();
+      };
+
+    this.timeout(50);
+
+    ksr.error = 'foo';
+    ksr.room = 'bar';
+
+    ksr.onDone(cb);
   });
 });
 


### PR DESCRIPTION
This PR ensures the subscription callbacks are correctly called in the unlikely event of invoking the `onDone` method _after_ Kuzzle responds.
For instance, if one stores the `KuzzleDataCollection.subscribe` or the `KuzzleDocument.subscribe` result, and then invokes its `onDone` method a few milliseconds after that.
