### PR TITLE
fix #168 - now rejects requests when no other option is possible

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -1339,16 +1339,18 @@ Kuzzle.prototype.query = function (queryArgs, query, options, cb) {
   if (self.state === 'connected' || (options && options.queuable === false)) {
     if (self.state === 'connected') {
       emitRequest.call(this, object, cb);
-    } else if (cb) {
-      cb(new Error('Unable to execute request: not connected to a Kuzzle server.\nDiscarded request: ' + JSON.stringify(object)));
+    } else {
+      discardRequest(object, cb);
     }
-  } else if (self.queuing || ['initializing', 'connecting'].indexOf(self.state) !== -1) {
+  } else if (self.queuing || (options && options.queuable === true) || ['initializing', 'connecting'].indexOf(self.state) !== -1) {
     cleanQueue.call(this, object, cb);
-
     if (!self.queueFilter || self.queueFilter(object)) {
       self.offlineQueue.push({ts: Date.now(), query: object, cb: cb});
       self.emitEvent('offlineQueuePush', {query: object, cb: cb});
     }
+  }
+  else {
+    discardRequest(object, cb);
   }
 
   return self;
@@ -1485,5 +1487,11 @@ Kuzzle.prototype.stopQueuing = function () {
 
   return this;
 };
+
+function discardRequest(object, cb) {
+  if (cb) {
+    cb(new Error('Unable to execute request: not connected to a Kuzzle server.\nDiscarded request: ' + JSON.stringify(object)));
+  }
+}
 
 module.exports = Kuzzle;


### PR DESCRIPTION
Fix #168 

Instead of silently discarding requests during offline mode with no queue option activated, it now explicitly rejects them, allowing clients to catch the error and act accordingly.

Other bugfix: it was also silently discarding requests during offline mode, if queue option is false but the request itself was passed with the `queuable` option set to true