### PR TITLE
Fix 178 realtime notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/Room.js
+++ b/src/Room.js
@@ -320,13 +320,12 @@ function notificationCallback (data) {
     return this.kuzzle.emitEvent('jwtTokenExpired');
   }
 
-  if (data.controller === 'document') {
+  if (data.controller === 'document' || (data.controller === 'realtime' && data.action === 'publish')) {
     data.type = 'document';
     data.document = new Document(this.collection, data.result._id, data.result._source);
     delete data.result;
   }
-
-  if (data.controller === 'realtime') {
+  else if (data.controller === 'realtime') {
     data.type = 'user';
     data.user = {count: data.result.count};
     delete data.result;

--- a/test/Room/methods.test.js
+++ b/test/Room/methods.test.js
@@ -429,6 +429,34 @@ describe('Room methods', function () {
         .be.an.instanceOf(Document);
     });
 
+    it('should handle realtime publish notifications', () => {
+      notifCB.call(room, {
+        controller: 'realtime',
+        action: 'publish',
+        result: {
+          _source: {
+            foo: 'bar'
+          }
+        }
+      });
+
+      should(room.callback)
+        .be.calledOnce()
+        .be.calledWithMatch(null, {
+          controller: 'realtime',
+          action: 'publish',
+          type: 'document',
+          document: {
+            id: undefined,
+            content: {
+              foo: 'bar'
+            }
+          }
+        });
+      should(room.callback.firstCall.args[1].document)
+        .be.an.instanceOf(Document);
+    });
+
     it('should handle user notifications', () => {
       notifCB.call(room, {
         controller: 'realtime',


### PR DESCRIPTION
Fix #178 

Notification object for `realtime/publish` action now contains a `document` attribute, containing a `Document`object with the content of the published message.
