### PR TITLE
use 7512 port by default for both websocket and socketio

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ The complete SDK documentation is available [here](http://kuzzleio.github.io/sdk
 The SDK Javascript implements two network protocols: raw WebSocket, and [Socket.IO](http://socket.io/)  
 The main reason behind this is that while Socket.IO offers better compatibility with older web browsers, our raw WebSocket implementation is about 20% faster
 
-For this reason, there is a slight difference with the [generic SDK documentation](http://kuzzleio.github.io/sdk-documentation): instead of 1 available `port` option, there are actually a `wsPort` and a `ioPort` options.  
-These options are defaulted to Kuzzle default protocol plugins.
-
 What protocol is used when you connect to Kuzzle depends on multiple factors:
 
 #### NodeJS
@@ -141,7 +138,7 @@ kuzzle
 
 ## Migrating from SDK v1.x
 
-* Kuzzle constructor has been changed. Instead of an URL, you have to provide a resolvable server name, or an IP address. If you need to specify a port different than the provided default values, you can do so using these two new options: `wsPort` (WebSocket port) and `ioPort` (Socket.IO port)
+* Kuzzle constructor has been changed. Instead of an URL, you have to provide a resolvable server name, or an IP address. If you need to specify a port different than the provided default value, you can do so using the `port` option.
 
 ## License
 

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -113,13 +113,8 @@ function Kuzzle (host, options, cb) {
       writable: true,
       enumerable: true
     },
-    wsPort: {
-      value: (options && typeof options.wsPort === 'number') ? options.wsPort : 7513,
-      enumerable: true,
-      writable: true
-    },
-    ioPort: {
-      value: (options && typeof options.ioPort === 'number') ? options.ioPort : 7512,
+    port: {
+      value: (options && typeof options.port === 'number') ? options.port : 7512,
       enumerable: true,
       writable: true
     },
@@ -322,7 +317,7 @@ Kuzzle.prototype.connect = function () {
     self.disconnect();
   }
 
-  self.network = networkWrapper(self.host, self.wsPort, self.ioPort, self.sslConnection);
+  self.network = networkWrapper(self.host, self.port, self.sslConnection);
 
   if (['initializing', 'ready', 'disconnected', 'error', 'offline'].indexOf(this.state) === -1) {
     if (self.connectCB) {

--- a/src/networkWrapper/index.js
+++ b/src/networkWrapper/index.js
@@ -1,28 +1,27 @@
 /**
  *
  * @param host
- * @param wsPort
- * @param ioPort
+ * @param port
  * @param sslConnection
  * @returns {Object} tnstantiated WebSocket/Socket.IO object
  */
 
-function network(host, wsPort, ioPort, sslConnection) {
+function network(host, port, sslConnection) {
   // Web browser / NodeJS websocket handling
   if (typeof window !== 'undefined') {
     // use native websockets if the browser supports it
     if (typeof WebSocket !== 'undefined') {
-      return new (require('./wrappers/websocket'))(host, wsPort, sslConnection);
+      return new (require('./wrappers/websocket'))(host, port, sslConnection);
     }
     // otherwise fallback to socket.io, if available
     else if (window.io) {
-      return new (require('./wrappers/socketio'))(host, ioPort, sslConnection);
+      return new (require('./wrappers/socketio'))(host, port, sslConnection);
     }
 
     throw new Error('Aborting: no websocket support detected and no socket.io library loaded either.');
   }
 
-  return new (require('./wrappers/websocket'))(host, wsPort, sslConnection);
+  return new (require('./wrappers/websocket'))(host, port, sslConnection);
 }
 
 module.exports = network;

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -70,8 +70,7 @@ describe('Kuzzle constructor', () => {
       should(kuzzle).have.propertyWithDescriptor('reconnectionDelay', { enumerable: true, writable: false, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('jwtToken', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('offlineQueueLoader', { enumerable: true, writable: true, configurable: false });
-      should(kuzzle).have.propertyWithDescriptor('wsPort', { enumerable: true, writable: true, configurable: false });
-      should(kuzzle).have.propertyWithDescriptor('ioPort', { enumerable: true, writable: true, configurable: false });
+      should(kuzzle).have.propertyWithDescriptor('port', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('sslConnection', { enumerable: true, writable: false, configurable: false });
     });
 
@@ -89,8 +88,7 @@ describe('Kuzzle constructor', () => {
       should(kuzzle.replayInterval).be.exactly(10);
       should(kuzzle.reconnectionDelay).be.exactly(1000);
       should(kuzzle.defaultIndex).be.undefined();
-      should(kuzzle.wsPort).be.exactly(7513);
-      should(kuzzle.ioPort).be.exactly(7512);
+      should(kuzzle.port).be.exactly(7512);
       should(kuzzle.sslConnection).be.false();
     });
 
@@ -108,8 +106,7 @@ describe('Kuzzle constructor', () => {
           replayInterval: 99999,
           reconnectionDelay: 666,
           defaultIndex: 'foobar',
-          wsPort: 1234,
-          ioPort: 4567,
+          port: 1234,
           sslConnection: true
         },
         kuzzle = new Kuzzle('nowhere', options);
@@ -125,8 +122,7 @@ describe('Kuzzle constructor', () => {
       should(kuzzle.metadata).be.an.Object().and.match(options.metadata);
       should(kuzzle.replayInterval).be.exactly(options.replayInterval);
       should(kuzzle.reconnectionDelay).be.exactly(options.reconnectionDelay);
-      should(kuzzle.wsPort).be.exactly(options.wsPort);
-      should(kuzzle.ioPort).be.exactly(options.ioPort);
+      should(kuzzle.port).be.exactly(options.port);
       should(kuzzle.sslConnection).be.exactly(options.sslConnection);
     });
 


### PR DESCRIPTION
 Following https://github.com/kuzzleio/kuzzle-proxy/pull/48

Now, Kuzzle will listen to the same port for both protocols.
This fixes the default config as well as the documentation.

TODO after merging this PR: "un-wip" the related PR on Backoffice: https://github.com/kuzzleio/kuzzle-backoffice/pull/213 (+ update the sdk version dependency into it)