### PR TITLE
Make all Kuzzle constructor options writable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -95,9 +95,10 @@ function Kuzzle (host, options, cb) {
       },
       writable: true
     },
-    // read-only properties
+    // configuration properties
     autoReconnect: {
       value: (options && typeof options.autoReconnect === 'boolean') ? options.autoReconnect : true,
+      writable: true,
       enumerable: true
     },
     defaultIndex: {
@@ -107,6 +108,7 @@ function Kuzzle (host, options, cb) {
     },
     reconnectionDelay: {
       value: (options && typeof options.reconnectionDelay === 'number') ? options.reconnectionDelay : 1000,
+      writable: true,
       enumerable: true
     },
     host: {
@@ -121,6 +123,7 @@ function Kuzzle (host, options, cb) {
     },
     sslConnection: {
       value: (options && typeof options.sslConnection === 'boolean') ? options.sslConnection : false,
+      writable: true,
       enumerable: true
     },
     autoQueue: {

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -56,7 +56,7 @@ describe('Kuzzle constructor', () => {
       var kuzzle = new Kuzzle('nowhere');
 
       should(kuzzle).have.propertyWithDescriptor('autoQueue', { enumerable: true, writable: true, configurable: false });
-      should(kuzzle).have.propertyWithDescriptor('autoReconnect', { enumerable: true, writable: false, configurable: false });
+      should(kuzzle).have.propertyWithDescriptor('autoReconnect', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('autoReplay', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('autoResubscribe', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('defaultIndex', { enumerable: true, writable: true, configurable: false });
@@ -67,11 +67,11 @@ describe('Kuzzle constructor', () => {
       should(kuzzle).have.propertyWithDescriptor('headers', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('metadata', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('replayInterval', { enumerable: true, writable: true, configurable: false });
-      should(kuzzle).have.propertyWithDescriptor('reconnectionDelay', { enumerable: true, writable: false, configurable: false });
+      should(kuzzle).have.propertyWithDescriptor('reconnectionDelay', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('jwtToken', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('offlineQueueLoader', { enumerable: true, writable: true, configurable: false });
       should(kuzzle).have.propertyWithDescriptor('port', { enumerable: true, writable: true, configurable: false });
-      should(kuzzle).have.propertyWithDescriptor('sslConnection', { enumerable: true, writable: false, configurable: false });
+      should(kuzzle).have.propertyWithDescriptor('sslConnection', { enumerable: true, writable: true, configurable: false });
     });
 
     it('should have properties with the documented default values', () => {


### PR DESCRIPTION
# Description

In some circumstances, we may want to use the same kuzzle object and change its options, for instance to switch to another environment.

This PR allows to update any possible option given to Kuzzle constructor.

Notably, this allows to switch the connection mode back from or to ssl on the current kuzzle instance, without having to create a new object.

# Linked issue

kuzzleio/kuzzle-backoffice#154

# Linked PRs

* #188
* https://github.com/kuzzleio/documentation/pull/113