### PR TITLE
[HOTFIX] Collection.scroll: the scroll parameter is now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 Official Kuzzle Javascript SDK
 ======
 
-
-Please use SDK v1.x for earlier versions of Kuzzle.
+This SDK version is compatible with Kuzzle 1.0.0-RC9.5 and higher
 
 ## About Kuzzle
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -490,7 +490,7 @@ Collection.prototype.search = function (filters, options, cb) {
  */
 Collection.prototype.scroll = function (scrollId, options, filters, cb) {
   var
-    request = {body:{}},
+    request = {},
     self = this;
 
   if (!scrollId) {
@@ -507,17 +507,13 @@ Collection.prototype.scroll = function (scrollId, options, filters, cb) {
     options = {};
   }
 
-  if (!options) {
-    options = {};
-  }
-
-  if (!options.scroll) {
-    throw new Error('Collection.scroll: scroll is required');
-  }
-
-  options.scrollId = scrollId;
-
   this.kuzzle.callbackRequired('Collection.scroll', cb);
+
+  request.scrollId = scrollId;
+
+  if (options && options.scroll) {
+    request.scroll = options.scroll;
+  }
 
   this.kuzzle.query({controller: 'document', action: 'scroll'}, request, options, function (error, result) {
     var documents = [];

--- a/test/Collection/methods.test.js
+++ b/test/Collection/methods.test.js
@@ -149,11 +149,6 @@ describe('Collection methods', function () {
       should(() => { collection.scroll(); }).throw('Collection.scroll: scrollId is required');
     });
 
-    it('should throw an error if no scroll is provided', () => {
-      var collection = kuzzle.collection(expectedQuery.collection);
-      should(() => { collection.scroll('scrollId'); }).throw('Collection.scroll: scroll is required');
-    });
-
     it('should throw an error if no callback is given', () => {
       var collection = kuzzle.collection(expectedQuery.collection);
       should(() => { collection.scroll('scrollId', {scroll: '1m'}); }).throw('Collection.scroll: a callback argument is required for read queries');
@@ -173,8 +168,8 @@ describe('Collection methods', function () {
       queryScrollStub = function (args, query, opts, callback) {
         should(args.controller).be.exactly('document');
         should(args.action).be.exactly('scroll');
-        should(opts.scroll).be.exactly(options.scroll);
-        should(opts.scrollId).be.exactly(scrollId);
+        should(query.scroll).be.exactly(options.scroll);
+        should(query.scrollId).be.exactly(scrollId);
 
         callback(null, {
           result: {


### PR DESCRIPTION
# Description

Following https://github.com/kuzzleio/kuzzle/pull/709, the `scroll` option is now optional (!)
Also fix the way the query is built to make it consistent with the way `kuzzle.query` is meant to be used.
