### PR TITLE
Fix ms.hgetall return value interpretation

### DIFF
--- a/src/MemoryStorage.js
+++ b/src/MemoryStorage.js
@@ -65,7 +65,7 @@ var
     hdel: {required: ['_id', 'fields']},
     hexists: getIdField,
     hget: getIdField,
-    hgetall: {getter: true, required: ['_id'], mapResults: mapKeyValueResults},
+    hgetall: {getter: true, required: ['_id']},
     hincrby: setIdFieldValue,
     hincrbyfloat: {required: ['_id', 'field', 'value'], mapResults: parseFloat},
     hkeys: getId,
@@ -451,31 +451,6 @@ function mapArrayStringToArrayInt(results) {
   return results.map(function (value) {
     return parseInt(value);
   });
-}
-
-/**
- * Map results like ['key', 'value', 'key', 'value', ...]
- * to a JSON object {key: 'value', ...}
- *
- * @param {Array.<string>} results
- * @return {Object}
- */
-function mapKeyValueResults(results) {
-  var
-    buffer = null,
-    mapped = {};
-
-  results.forEach(function (value) {
-    if (buffer === null) {
-      buffer = value;
-    }
-    else {
-      mapped[buffer] = value;
-      buffer = null;
-    }
-  });
-
-  return mapped;
 }
 
 /**

--- a/test/MemoryStorage/methods.test.js
+++ b/test/MemoryStorage/methods.test.js
@@ -407,7 +407,7 @@ describe('MemoryStorage methods', function () {
       {},
       {_id: 'key'},
       {},
-      ['foo', 'bar', 'baz', 'qux'],
+      {foo: 'bar', baz: 'qux'},
       {foo: 'bar', baz: 'qux'}
     );
   });


### PR DESCRIPTION
# Description

(this PR should not appear in the changelog: it affects only the changes on the MemoryStorage controller in the `4.x` SDK version)

The `hgetall` result was interpreted as an array of, alternatively, key and its associated value, and a mapper function was plugged into this method to ensure a proper JSON object was returned to the client.
But the result of this redis call is already a POJO, so the mapping is unnecessary and causes a SDK crash.
