### PR TITLE
Fix ms.zscore return value type

### DIFF
--- a/src/MemoryStorage.js
+++ b/src/MemoryStorage.js
@@ -155,7 +155,7 @@ var
     zrevrangebyscore: getZrangeBy,
     zrevrank: getMember,
     zscan: getxScan,
-    zscore: getMember,
+    zscore: {getter: true, required: ['_id', 'member'], mapResults: parseFloat},
     zunionstore: {required: ['_id', 'keys'], opts: ['weights', 'aggregate']}
   };
 

--- a/test/MemoryStorage/methods.test.js
+++ b/test/MemoryStorage/methods.test.js
@@ -1488,8 +1488,8 @@ describe('MemoryStorage methods', function () {
       {},
       {_id: 'key', member: 'foo'},
       {},
-      3,
-      3
+      '3.14159',
+      3.14159
     );
   });
 

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -434,7 +434,7 @@ describe('Kuzzle constructor', function () {
             catch (e) {
               done(e);
             }
-          }, 10);
+          }, 100);
         });
 
         it('should enable queuing if autoQueue is set to true', function (done) {


### PR DESCRIPTION
# Description

The `ms.zscore()` method should return a floating point number, but redis sends a string response, so we need to interpret the result to return the right result type.
