### PR TITLE
Add support for the new retryOnConflict option

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -634,6 +634,10 @@ Collection.prototype.updateDocument = function (documentId, content, options, cb
     options = null;
   }
 
+  if (options && options.retryOnConflict) {
+    data.retryOnConflict = options.retryOnConflict;
+  }
+
   data = self.kuzzle.addHeaders(data, this.headers);
 
   self.kuzzle.query(this.buildQueryArgs('document', 'update'), data, options, cb && function (err, res) {

--- a/test/Collection/methods.test.js
+++ b/test/Collection/methods.test.js
@@ -965,8 +965,9 @@ describe('Collection methods', function () {
     it('should send the right updateDocument query to Kuzzle', function (done) {
       var
         collection = new Collection(kuzzle, expectedQuery.collection, expectedQuery.index),
-        options = { queuable: false };
+        options = { queuable: false, retryOnConflict: 42 };
       expectedQuery.options = options;
+      expectedQuery.retryOnConflict = 42;
 
       should(collection.updateDocument(result.result._id, result.result._source, options, function (err, res) {
         should(err).be.null();


### PR DESCRIPTION
# Description

Add support for the new `retryOnConflict` option on the `collection.updateDocument` route

# Related issue

https://github.com/kuzzleio/kuzzle/issues/730
