### PR TITLE
 Harmonize event emitters implementation

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -295,8 +295,7 @@ function Kuzzle (host, options, cb) {
     });
   }
 }
-
-Kuzzle.prototype = new KuzzleEventEmitter();
+Kuzzle.prototype = Object.create(KuzzleEventEmitter.prototype);
 
 /**
 * Emit an event to all registered listeners

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -1,6 +1,6 @@
 var
   uuid = require('uuid'),
-  EventEmitter = require('./eventEmitter'),
+  KuzzleEventEmitter = require('./eventEmitter'),
   Collection = require('./Collection.js'),
   Security = require('./security/Security'),
   MemoryStorage = require('./MemoryStorage'),
@@ -30,7 +30,7 @@ function Kuzzle (host, options, cb) {
   if (!(this instanceof Kuzzle)) {
     return new Kuzzle(host, options, cb);
   }
-  EventEmitter.call(this);
+  KuzzleEventEmitter.call(this);
 
   if (!cb && typeof options === 'function') {
     cb = options;
@@ -296,7 +296,7 @@ function Kuzzle (host, options, cb) {
   }
 }
 
-Kuzzle.prototype = new EventEmitter();
+Kuzzle.prototype = new KuzzleEventEmitter();
 
 /**
 * Emit an event to all registered listeners
@@ -313,7 +313,7 @@ Kuzzle.prototype.emit = function(eventName) {
     }
     protectedEvent.lastEmitted = now;
   }
-  EventEmitter.prototype.emit.apply(this, arguments);
+  KuzzleEventEmitter.prototype.emit.apply(this, arguments);
 };
 Kuzzle.prototype.emitEvent = Kuzzle.prototype.emit;
 Kuzzle.prototype.off = Kuzzle.prototype.removeListener;
@@ -861,7 +861,7 @@ Kuzzle.prototype.addListener = function(event, listener) {
     throw new Error('[' + event + '] is not a known event. Known events: ' + knownEvents.toString());
   }
 
-  return EventEmitter.prototype.addListener.call(this, event, listener);
+  return KuzzleEventEmitter.prototype.addListener.call(this, event, listener);
 };
 
 /**

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -304,7 +304,7 @@ Kuzzle.prototype = Object.create(KuzzleEventEmitter.prototype);
 Kuzzle.prototype.emit = function(eventName) {
   var
     now = Date.now(),
-    protectedEvent = this.protectedEvents && this.protectedEvents[eventName];
+    protectedEvent = this.protectedEvents[eventName];
 
   if (protectedEvent) {
     if (protectedEvent.lastEmitted && protectedEvent.lastEmitted > now - protectedEvent.timeout) {

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -53,7 +53,7 @@ function Kuzzle (host, options, cb) {
     eventActions: {
       value: [
         'connected',
-        'kerror',
+        'networkError',
         'disconnected',
         'reconnected',
         'jwtTokenExpired',
@@ -361,7 +361,7 @@ Kuzzle.prototype.connect = function () {
 
     connectionError.internal = error;
     self.state = 'error';
-    self.emitEvent('kerror', connectionError);
+    self.emitEvent('networkError', connectionError);
 
     if (self.connectCB) {
       self.connectCB(connectionError);

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -848,11 +848,8 @@ function removeAllSubscriptions() {
  * Adds a listener to a Kuzzle global event. When an event is fired, listeners are called in the order of their
  * insertion.
  *
- * The ID returned by this function is required to remove this listener at a later time.
- *
  * @param {string} event - name of the global event to subscribe to
  * @param {function} listener - callback to invoke each time an event is fired
- * @returns {string} Unique listener ID
  */
 Kuzzle.prototype.addListener = function(event, listener) {
   this.isValid();

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -296,6 +296,7 @@ function Kuzzle (host, options, cb) {
   }
 }
 Kuzzle.prototype = Object.create(KuzzleEventEmitter.prototype);
+Kuzzle.prototype.constructor = Kuzzle;
 
 /**
 * Emit an event to all registered listeners

--- a/src/Room.js
+++ b/src/Room.js
@@ -317,7 +317,7 @@ function notificationCallback (data) {
 
   if (data.action === 'jwtTokenExpired') {
     this.kuzzle.jwtToken = undefined;
-    return this.kuzzle.emitEvent('jwtTokenExpired');
+    return this.kuzzle.eventEmitter.emitEvent('jwtTokenExpired');
   }
 
   if (data.controller === 'document' || (data.controller === 'realtime' && data.action === 'publish')) {

--- a/src/Room.js
+++ b/src/Room.js
@@ -317,7 +317,7 @@ function notificationCallback (data) {
 
   if (data.action === 'jwtTokenExpired') {
     this.kuzzle.jwtToken = undefined;
-    return this.kuzzle.eventEmitter.emitEvent('jwtTokenExpired');
+    return this.kuzzle.emitEvent('jwtTokenExpired');
   }
 
   if (data.controller === 'document' || (data.controller === 'realtime' && data.action === 'publish')) {

--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -1,5 +1,3 @@
-var EventEmitter;
-
 function KuzzleEventEmitter(eventTimeout) {
   Object.defineProperties(this, {
     eventTimeout: {
@@ -16,8 +14,7 @@ function KuzzleEventEmitter(eventTimeout) {
 }
 
 if (typeof window === 'undefined') {
-  EventEmitter = require('events');
-  KuzzleEventEmitter.prototype = new EventEmitter();
+  KuzzleEventEmitter.prototype = new (require('events'))();
 } else {
 
   KuzzleEventEmitter.prototype.on = function(eventName, listener) {

--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -1,6 +1,6 @@
-var NodeEmitter;
+var EventEmitter;
 
-function EventEmitter(eventTimeout) {
+function KuzzleEventEmitter(eventTimeout) {
   Object.defineProperties(this, {
     eventTimeout: {
       value: eventTimeout || 200,
@@ -16,11 +16,11 @@ function EventEmitter(eventTimeout) {
 }
 
 if (typeof window === 'undefined') {
-  NodeEmitter = require('events');
-  EventEmitter.prototype = new NodeEmitter();
+  EventEmitter = require('events');
+  KuzzleEventEmitter.prototype = new EventEmitter();
 } else {
 
-  EventEmitter.prototype.on = function(eventName, listener) {
+  KuzzleEventEmitter.prototype.on = function(eventName, listener) {
     var
       listenerType = typeof listener,
       listeners;
@@ -44,9 +44,9 @@ if (typeof window === 'undefined') {
 
     return this;
   };
-  EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+  KuzzleEventEmitter.prototype.addListener = KuzzleEventEmitter.prototype.on;
 
-  EventEmitter.prototype.prependListener = function(eventName, listener) {
+  KuzzleEventEmitter.prototype.prependListener = function(eventName, listener) {
     var listeners;
 
     if (!eventName || !listener) {
@@ -65,7 +65,7 @@ if (typeof window === 'undefined') {
     return this;
   };
 
-  EventEmitter.prototype.once = function(eventName, listener) {
+  KuzzleEventEmitter.prototype.once = function(eventName, listener) {
     var onceListeners;
 
     if (!eventName || !listener) {
@@ -80,7 +80,7 @@ if (typeof window === 'undefined') {
     return this;
   };
 
-  EventEmitter.prototype.prependOnceListener = function(eventName, listener) {
+  KuzzleEventEmitter.prototype.prependOnceListener = function(eventName, listener) {
     var onceListeners;
 
     if (!eventName || !listener) {
@@ -93,7 +93,7 @@ if (typeof window === 'undefined') {
     return this;
   };
 
-  EventEmitter.prototype.removeListener = function(eventName, listener) {
+  KuzzleEventEmitter.prototype.removeListener = function(eventName, listener) {
     var
       index,
       listeners = this._events[eventName];
@@ -116,7 +116,7 @@ if (typeof window === 'undefined') {
     return this;
   };
 
-  EventEmitter.prototype.removeAllListeners = function(eventName) {
+  KuzzleEventEmitter.prototype.removeAllListeners = function(eventName) {
     if (eventName) {
       delete this._events[eventName];
       delete this._onceEvents[eventName];
@@ -128,7 +128,7 @@ if (typeof window === 'undefined') {
     return this;
   };
 
-  EventEmitter.prototype.emit = function(eventName) {
+  KuzzleEventEmitter.prototype.emit = function(eventName) {
     var
       i = 0,
       listeners,
@@ -173,15 +173,15 @@ if (typeof window === 'undefined') {
     return this;
   };
 
-  EventEmitter.prototype.eventNames = function () {
+  KuzzleEventEmitter.prototype.eventNames = function () {
     return Object.keys(this._events);
   };
 
-  EventEmitter.prototype.listenerCount = function (eventName) {
+  KuzzleEventEmitter.prototype.listenerCount = function (eventName) {
     return this._events[eventName] && this._events[eventName].length || 0;
   };
 
-  EventEmitter.prototype.listeners = function (eventName) {
+  KuzzleEventEmitter.prototype.listeners = function (eventName) {
     if (this._events[eventName] === undefined) {
       this._events[eventName] = [];
     }
@@ -190,7 +190,7 @@ if (typeof window === 'undefined') {
 
 }
 // Aliases:
-EventEmitter.prototype.emitEvent = EventEmitter.prototype.emit;
-EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+KuzzleEventEmitter.prototype.emitEvent = KuzzleEventEmitter.prototype.emit;
+KuzzleEventEmitter.prototype.off = KuzzleEventEmitter.prototype.removeListener;
 
-module.exports = EventEmitter;
+module.exports = KuzzleEventEmitter;

--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -10,11 +10,10 @@ function KuzzleEventEmitter(eventTimeout) {
     this._events = {};
     this._onceEvents = {};
   }
-  this.removeAllListeners();
 }
 
 if (typeof window === 'undefined') {
-  KuzzleEventEmitter.prototype = new (require('events'))();
+  KuzzleEventEmitter.prototype = require('events').prototype;
   KuzzleEventEmitter.prototype.constructor = KuzzleEventEmitter;
 } else {
 

--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -1,10 +1,10 @@
 var
   uuid = require('uuid');
 
-function EventEmitter(eventTimeout) {
+function EventEmitter(listeners, eventTimeout) {
   Object.defineProperties(this, {
     eventListeners: {
-      value: {}
+      value: listeners || {}
     },
     eventTimeout: {
       value: eventTimeout || 200,
@@ -125,7 +125,7 @@ EventEmitter.prototype.removeListener = function (event, listenerId) {
 
   this.eventListeners[event].listeners.forEach(function (listener, index) {
     if (listener.id === listenerId) {
-      if (self.eventListeners[event].listeners.length === 1) {
+      if (self.eventListeners[event].listeners.length === 1 && self.eventListeners[event].lastEmitted === undefined) {
         delete self.eventListeners[event];
       } else {
         self.eventListeners[event].listeners.splice(index, 1);
@@ -151,11 +151,18 @@ EventEmitter.prototype.removeAllListeners = function (event) {
     if (knownEvents.indexOf(event) === -1) {
       throw new Error('[' + event + '] is not a known event. Known events: ' + knownEvents.toString());
     }
-
-    delete this.eventListeners[event];
+    if (self.eventListeners[event].lastEmitted === undefined) {
+      delete self.eventListeners[event];
+    } else {
+      self.eventListeners[event].listeners = [];
+    }
   } else {
     knownEvents.forEach(function (eventName) {
-      delete self.eventListeners[eventName];
+      if (self.eventListeners[eventName].lastEmitted === undefined) {
+        delete self.eventListeners[eventName];
+      } else {
+        self.eventListeners[eventName].listeners = [];
+      }
     });
   }
 

--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -125,7 +125,11 @@ EventEmitter.prototype.removeListener = function (event, listenerId) {
 
   this.eventListeners[event].listeners.forEach(function (listener, index) {
     if (listener.id === listenerId) {
-      self.eventListeners[event].listeners.splice(index, 1);
+      if (self.eventListeners[event].listeners.length === 1) {
+        delete self.eventListeners[event];
+      } else {
+        self.eventListeners[event].listeners.splice(index, 1);
+      }
     }
   });
 
@@ -148,10 +152,10 @@ EventEmitter.prototype.removeAllListeners = function (event) {
       throw new Error('[' + event + '] is not a known event. Known events: ' + knownEvents.toString());
     }
 
-    this.eventListeners[event].listeners = [];
+    delete this.eventListeners[event];
   } else {
     knownEvents.forEach(function (eventName) {
-      self.eventListeners[eventName].listeners = [];
+      delete self.eventListeners[eventName];
     });
   }
 

--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -1,10 +1,10 @@
 var
   uuid = require('uuid');
 
-function EventEmitter(listeners, eventTimeout) {
+function EventEmitter(eventTimeout) {
   Object.defineProperties(this, {
     eventListeners: {
-      value: listeners || {}
+      value: {}
     },
     eventTimeout: {
       value: eventTimeout || 200,
@@ -135,6 +135,21 @@ EventEmitter.prototype.removeListener = function (event, listenerId) {
 
   return self;
 };
+
+/**
+ * Unregisters a callback from a room.
+ *
+ * @param {string} roomId
+ * @param {function} callback
+*/
+EventEmitter.prototype.off = function (event, callback) {
+  var listenerId = this.getListener(event, callback);
+
+  if (listenerId) {
+    this.removeListener(event, listenerId);
+  }
+};
+
 
 /**
  * Removes all listeners, either from a specific event or from all events

--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -15,6 +15,7 @@ function KuzzleEventEmitter(eventTimeout) {
 
 if (typeof window === 'undefined') {
   KuzzleEventEmitter.prototype = new (require('events'))();
+  KuzzleEventEmitter.prototype.constructor = KuzzleEventEmitter;
 } else {
 
   KuzzleEventEmitter.prototype.on = function(eventName, listener) {

--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -1,0 +1,161 @@
+var
+  uuid = require('uuid');
+
+function EventEmitter(eventTimeout) {
+  Object.defineProperties(this, {
+    eventListeners: {
+      value: {}
+    },
+    eventTimeout: {
+      value: eventTimeout || 200,
+      writeable: false
+    }
+  });
+}
+
+/**
+ * Emit an event to all registered listeners
+ * An event cannot be emitted multiple times before a timeout has been reached.
+ */
+EventEmitter.prototype.emitEvent = function emitEvent(event) {
+  var
+    self = this,
+    now = Date.now(),
+    args = Array.prototype.slice.call(arguments, 1),
+    eventProperties = this.eventListeners[event];
+
+  if (!eventProperties) {
+    return false;
+  }
+
+  if (eventProperties.lastEmitted && eventProperties.lastEmitted >= now - this.eventTimeout) {
+    return false;
+  }
+
+  eventProperties.listeners.forEach(function (listener) {
+    setTimeout(function () {
+      if (listener.once) {
+        self.removeListener(event, listener.id);
+      }
+      listener.fn.apply(undefined, args);
+    }, 0);
+  });
+
+  // Events without the 'lastEmitted' property can be emitted without minimum time between emissions
+  if (eventProperties.lastEmitted !== undefined) {
+    eventProperties.lastEmitted = now;
+  }
+};
+
+
+/**
+ * Adds a listener to a Kuzzle global event. When an event is fired, listeners are called in the order of their
+ * insertion.
+ *
+ * The ID returned by this function is required to remove this listener at a later time.
+ *
+ * @param {string} event - name of the global event to subscribe to (see the 'eventListeners' object property)
+ * @param {function} listener - callback to invoke each time an event is fired
+ * @param {boolean} once - true if the listener should be triggered only once and then removed.
+ * @returns {string} Unique listener ID
+ */
+EventEmitter.prototype.addListener = function(event, listener, once) {
+  var
+    listenerType = typeof listener,
+    listenerId;
+
+  if (listenerType !== 'function') {
+    throw new Error('Invalid listener type: expected a function, got a ' + listenerType);
+  }
+
+  if (!this.eventListeners[event]) {
+    this.eventListeners[event] = {listeners: []};
+  }
+
+  listenerId = uuid.v4();
+
+  this.eventListeners[event].listeners.push({id: listenerId, fn: listener, once: (once === true)});
+  return listenerId;
+};
+
+/**
+ * Removes a listener from an event.
+ *
+ * @param {string} event - One of the event described in the Event Handling section of this documentation
+ * @param {function} fn - callback to match the listener
+ * @returns {string} the listener ID
+ */
+EventEmitter.prototype.getListener = function (event, fn) {
+  var
+    listenerType = typeof fn,
+    listenerId = false;
+
+  if (!this.eventListeners[event || fn === undefined]) {
+    return false;
+  }
+
+  if (listenerType !== 'function') {
+    throw new Error('Invalid listener type: expected a function, got a ' + listenerType);
+  }
+
+  this.eventListeners[event].listeners.forEach(function (listener) {
+    if (listener.fn === fn) {
+      listenerId = listener.id;
+    }
+  });
+
+  return listenerId;
+};
+
+/**
+ * Removes a listener from an event.
+ *
+ * @param {string} event - One of the event described in the Event Handling section of this documentation
+ * @param {string} listenerId - The ID returned by addListener
+ * @returns {EventEmitter} this object
+ */
+EventEmitter.prototype.removeListener = function (event, listenerId) {
+  var
+    self = this,
+    knownEvents = Object.keys(this.eventListeners);
+
+  if (knownEvents.indexOf(event) === -1) {
+    throw new Error('[' + event + '] is not a known event. Known events: ' + knownEvents.toString());
+  }
+
+  this.eventListeners[event].listeners.forEach(function (listener, index) {
+    if (listener.id === listenerId) {
+      self.eventListeners[event].listeners.splice(index, 1);
+    }
+  });
+
+  return self;
+};
+
+/**
+ * Removes all listeners, either from a specific event or from all events
+ *
+ * @param {string} event - One of the event described in the Event Handling section of this documentation
+ * @returns {EventEmitter} this object
+ */
+EventEmitter.prototype.removeAllListeners = function (event) {
+  var
+    self = this,
+    knownEvents = Object.keys(this.eventListeners);
+
+  if (event) {
+    if (knownEvents.indexOf(event) === -1) {
+      throw new Error('[' + event + '] is not a known event. Known events: ' + knownEvents.toString());
+    }
+
+    this.eventListeners[event].listeners = [];
+  } else {
+    knownEvents.forEach(function (eventName) {
+      self.eventListeners[eventName].listeners = [];
+    });
+  }
+
+  return self;
+};
+
+module.exports = EventEmitter;

--- a/src/networkWrapper/wrappers/websocket.js
+++ b/src/networkWrapper/wrappers/websocket.js
@@ -126,7 +126,8 @@ function WSNode(host, port, ssl) {
     self.stopRetryingToConnect = true;
   };
 }
-WSNode.prototype = new KuzzleEventEmitter();
+WSNode.prototype = Object.create(KuzzleEventEmitter.prototype);
+
 
 /**
  * Called when the connection closes with an error state

--- a/src/networkWrapper/wrappers/websocket.js
+++ b/src/networkWrapper/wrappers/websocket.js
@@ -127,6 +127,7 @@ function WSNode(host, port, ssl) {
   };
 }
 WSNode.prototype = Object.create(KuzzleEventEmitter.prototype);
+WSNode.prototype.constructor = WSNode;
 
 
 /**

--- a/src/networkWrapper/wrappers/websocket.js
+++ b/src/networkWrapper/wrappers/websocket.js
@@ -85,7 +85,7 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.onConnectError = function (callback) {
-    this.addListener('wserror', callback);
+    this.addListener('networkError', callback);
   };
 
   /**
@@ -146,7 +146,7 @@ function onClientError(autoReconnect, reconnectionDelay, message) {
     }, reconnectionDelay);
   }
 
-  self.emitEvent('wserror', message);
+  self.emitEvent('networkError', message);
 }
 
 module.exports = WSNode;

--- a/src/networkWrapper/wrappers/websocket.js
+++ b/src/networkWrapper/wrappers/websocket.js
@@ -1,9 +1,9 @@
 var
-  EventEmitter = require('../../eventEmitter');
+  KuzzleEventEmitter = require('../../eventEmitter');
 
 function WSNode(host, port, ssl) {
   var self = this;
-  EventEmitter.call(this);
+  KuzzleEventEmitter.call(this);
 
   this.WebSocket = typeof WebSocket !== 'undefined' ? WebSocket : require('ws');
   this.host = host;
@@ -126,7 +126,7 @@ function WSNode(host, port, ssl) {
     self.stopRetryingToConnect = true;
   };
 }
-WSNode.prototype = new EventEmitter();
+WSNode.prototype = new KuzzleEventEmitter();
 
 /**
  * Called when the connection closes with an error state

--- a/src/networkWrapper/wrappers/websocket.js
+++ b/src/networkWrapper/wrappers/websocket.js
@@ -15,10 +15,6 @@ function WSNode(host, port, ssl) {
   this.lasturl = null;
   this.stopRetryingToConnect = false;
 
-  Object.defineProperty(this, 'eventListeners', {
-    value: {}
-  });
-
   /**
    * Creates a new socket from the provided arguments
    *
@@ -89,7 +85,7 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.onConnectError = function (callback) {
-    this.addListener('error', callback);
+    this.addListener('wserror', callback);
   };
 
   /**
@@ -106,27 +102,6 @@ function WSNode(host, port, ssl) {
    */
   this.onReconnect = function (callback) {
     this.addListener('reconnect', callback);
-  };
-
-  /**
-   * Registers a callback on a room. Once 1 message is received, fires the
-   * callback and unregister it afterward.
-   *
-   * @param {string} roomId
-   * @param {function} callback
-   */
-  this.once = function (roomId, callback) {
-    this.addListener(roomId, callback, true);
-  };
-
-  /**
-   * Registers a callback on a room.
-   *
-   * @param {string} roomId
-   * @param {function} callback
-   */
-  this.on = function (roomId, callback) {
-    this.addListener(roomId, callback);
   };
 
   /**
@@ -171,7 +146,7 @@ function onClientError(autoReconnect, reconnectionDelay, message) {
     }, reconnectionDelay);
   }
 
-  self.emitEvent('error', message);
+  self.emitEvent('wserror', message);
 }
 
 module.exports = WSNode;

--- a/src/networkWrapper/wrappers/websocket.js
+++ b/src/networkWrapper/wrappers/websocket.js
@@ -1,3 +1,6 @@
+var
+  EventEmitter = require('../../eventEmitter');
+
 function WSNode(host, port, ssl) {
   var self = this;
   this.WebSocket = typeof WebSocket !== 'undefined' ? WebSocket : require('ws');
@@ -10,19 +13,7 @@ function WSNode(host, port, ssl) {
   this.lasturl = null;
   this.stopRetryingToConnect = false;
 
-  /*
-   Listeners are stored using the following format:
-   roomId: {
-   fn: callback_function,
-   once: boolean
-   }
-   */
-  this.listeners = {
-    error: [],
-    connect: [],
-    disconnect: [],
-    reconnect: []
-  };
+  this.eventEmitter = new EventEmitter();
 
   /**
    * Creates a new socket from the provided arguments
@@ -46,10 +37,10 @@ function WSNode(host, port, ssl) {
 
     this.client.onopen = function () {
       if (self.wasConnected) {
-        poke(self.listeners, 'reconnect');
+        self.eventEmitter.emitEvent('reconnect');
       }
       else {
-        poke(self.listeners, 'connect');
+        self.eventEmitter.emitEvent('connect');
       }
       self.wasConnected = true;
       self.stopRetryingToConnect = false;
@@ -57,7 +48,7 @@ function WSNode(host, port, ssl) {
 
     this.client.onclose = function (code, message) {
       if (code === 1000) {
-        poke(self.listeners, 'disconnect');
+        self.eventEmitter.emitEvent('disconnect');
       }
       else {
         onClientError.call(self, autoReconnect, reconnectionDelay, message);
@@ -71,11 +62,11 @@ function WSNode(host, port, ssl) {
     this.client.onmessage = function (payload) {
       var data = JSON.parse(payload.data || payload);
 
-      if (data.room && self.listeners[data.room]) {
-        poke(self.listeners, data.room, data);
+      if (data.room) {
+        self.eventEmitter.emitEvent(data.room, data);
       }
-      else if (self.listeners.discarded) {
-        poke(self.listeners, 'discarded', data);
+      else {
+        self.eventEmitter.emitEvent('discarded', data);
       }
     };
   };
@@ -86,10 +77,7 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.onConnect = function (callback) {
-    this.listeners.connect.push({
-      fn: callback,
-      keep: true
-    });
+    this.eventEmitter.addListener('connect', callback);
   };
 
   /**
@@ -97,10 +85,7 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.onConnectError = function (callback) {
-    this.listeners.error.push({
-      fn: callback,
-      keep: true
-    });
+    this.eventEmitter.addListener('error', callback);
   };
 
   /**
@@ -108,10 +93,7 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.onDisconnect = function (callback) {
-    this.listeners.disconnect.push({
-      fn: callback,
-      keep: true
-    });
+    this.eventEmitter.addListener('disconnect', callback);
   };
 
   /**
@@ -119,10 +101,7 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.onReconnect = function (callback) {
-    this.listeners.reconnect.push({
-      fn: callback,
-      keep: true
-    });
+    this.eventEmitter.addListener('reconnect', callback);
   };
 
   /**
@@ -133,14 +112,7 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.once = function (roomId, callback) {
-    if (!this.listeners[roomId]) {
-      this.listeners[roomId] = [];
-    }
-
-    this.listeners[roomId].push({
-      fn: callback,
-      keep: false
-    });
+    this.eventEmitter.addListener(roomId, callback, true);
   };
 
   /**
@@ -150,14 +122,7 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.on = function (roomId, callback) {
-    if (!this.listeners[roomId]) {
-      this.listeners[roomId] = [];
-    }
-
-    this.listeners[roomId].push({
-      fn: callback,
-      keep: true
-    });
+    this.eventEmitter.addListener(roomId, callback);
   };
 
   /**
@@ -167,27 +132,10 @@ function WSNode(host, port, ssl) {
    * @param {function} callback
    */
   this.off = function (roomId, callback) {
-    var index = -1;
+    var listenerId = this.eventEmitter.getListener(roomId, callback);
 
-    if (this.listeners[roomId]) {
-      // Array.findIndex is not supported by internet explorer
-      this.listeners[roomId].some(function (listener, i) {
-        if (listener.fn === callback) {
-          index = i;
-          return true;
-        }
-
-        return false;
-      });
-
-      if (index !== -1) {
-        if (this.listeners[roomId].length === 1 && ['error', 'connect', 'disconnect', 'reconnect'].indexOf(roomId) === -1) {
-          delete this.listeners[roomId];
-        }
-        else {
-          this.listeners[roomId].splice(index, 1);
-        }
-      }
+    if (listenerId) {
+      this.eventEmitter.removeListener(roomId, listenerId);
     }
   };
 
@@ -207,54 +155,12 @@ function WSNode(host, port, ssl) {
    * Closes the connection
    */
   this.close = function () {
-    this.listeners = {
-      error: [],
-      connect: [],
-      disconnect: [],
-      reconnect: []
-    };
-
+    this.eventEmitter.removeAllListeners();
     this.wasConnected = false;
     this.client.close();
     this.client = null;
     self.stopRetryingToConnect = true;
   };
-}
-
-/**
- * Executes all registered listeners in the provided
- * "listeners" structure.
- *
- * Listeners are of the following format:
- * [
- *    { fn: callback, once: boolean },
- *    ...
- * ]
- *
- * @private
- * @param {Object} listeners
- * @param {string} roomId
- * @param {Object} [payload]
- */
-function poke (listeners, roomId, payload) {
-  var
-    i,
-    length = listeners[roomId].length;
-
-  for (i = 0; i < length; ++i) {
-    listeners[roomId][i].fn(payload);
-
-    if (!listeners[roomId][i].keep) {
-      if (listeners[roomId].length > 1) {
-        listeners[roomId].splice(i, 1);
-        --i;
-        --length;
-      }
-      else {
-        delete listeners[roomId];
-      }
-    }
-  }
 }
 
 /**
@@ -275,7 +181,7 @@ function onClientError(autoReconnect, reconnectionDelay, message) {
     }, reconnectionDelay);
   }
 
-  poke(self.listeners, 'error', message);
+  self.eventEmitter.emitEvent('error', message);
 }
 
 module.exports = WSNode;

--- a/test/Room/methods.test.js
+++ b/test/Room/methods.test.js
@@ -291,6 +291,8 @@ describe('Room methods', function () {
       collection = kuzzle.collection('foo');
       room = new Room(collection);
       room.roomId = 'foobar';
+      room.channel = 'barfoo';
+      room.notifier = sinon.stub();
       kuzzle.subscriptions.foobar = {};
       kuzzle.subscriptions.foobar[room.id] = room;
     });

--- a/test/Room/methods.test.js
+++ b/test/Room/methods.test.js
@@ -496,8 +496,10 @@ describe('Room methods', function () {
         eventEmitted = null,
         context = {
           kuzzle: {
-            emitEvent: function (event) {
-              eventEmitted = event;
+            eventEmitter: {
+              emitEvent: function (event) {
+                eventEmitted = event;
+              }
             }
           }
         };

--- a/test/Room/methods.test.js
+++ b/test/Room/methods.test.js
@@ -496,10 +496,8 @@ describe('Room methods', function () {
         eventEmitted = null,
         context = {
           kuzzle: {
-            eventEmitter: {
-              emitEvent: function (event) {
-                eventEmitted = event;
-              }
+            emitEvent: function (event) {
+              eventEmitted = event;
             }
           }
         };

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -323,7 +323,7 @@ describe('Kuzzle constructor', function () {
             listenerCalled,
             kuzzle = new Kuzzle('nowhere');
 
-          kuzzle.addListener('kerror', function () { listenerCalled = true; });
+          kuzzle.addListener('networkError', function () { listenerCalled = true; });
 
           setTimeout(function () {
             try {

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -323,7 +323,7 @@ describe('Kuzzle constructor', function () {
             listenerCalled,
             kuzzle = new Kuzzle('nowhere');
 
-          kuzzle.addListener('error', function () { listenerCalled = true; });
+          kuzzle.addListener('kerror', function () { listenerCalled = true; });
 
           setTimeout(function () {
             try {

--- a/test/kuzzle/emitEvent.test.js
+++ b/test/kuzzle/emitEvent.test.js
@@ -20,6 +20,7 @@ describe('Event emitter', function () {
         listenersCalled++;
       },
       context = {
+        protectedEvents: {},
         _events: {
           foo: [
             listener,
@@ -44,6 +45,7 @@ describe('Event emitter', function () {
         argsCount = arguments.length;
       },
       context = {
+        protectedEvents: {},
         eventTimeout: -100,
         _events: {
           foo: [

--- a/test/kuzzle/emitEvent.test.js
+++ b/test/kuzzle/emitEvent.test.js
@@ -10,7 +10,7 @@ describe('Event emitter', function () {
 
   before(function () {
     kuzzle = new Kuzzle('foo', {connect: 'manual'});
-    emitEvent = kuzzle.emitEvent;
+    emitEvent = kuzzle.eventEmitter.emitEvent;
   });
 
   it('should call all added listeners for a given event', function (done) {

--- a/test/kuzzle/emitEvent.test.js
+++ b/test/kuzzle/emitEvent.test.js
@@ -10,7 +10,7 @@ describe('Event emitter', function () {
 
   before(function () {
     kuzzle = new Kuzzle('foo', {connect: 'manual'});
-    emitEvent = kuzzle.eventEmitter.emitEvent;
+    emitEvent = kuzzle.emitEvent;
   });
 
   it('should call all added listeners for a given event', function (done) {

--- a/test/kuzzle/emitEvent.test.js
+++ b/test/kuzzle/emitEvent.test.js
@@ -20,15 +20,12 @@ describe('Event emitter', function () {
         listenersCalled++;
       },
       context = {
-        eventListeners: {
-          foo: {
-            lastEmitted: null,
-            listeners: [
-              {fn: listener},
-              {fn: listener},
-              {fn: listener}
-            ]
-          }
+        _events: {
+          foo: [
+            listener,
+            listener,
+            listener
+          ]
         }
       };
 
@@ -48,13 +45,10 @@ describe('Event emitter', function () {
       },
       context = {
         eventTimeout: -100,
-        eventListeners: {
-          foo: {
-            lastEmitted: null,
-            listeners: [
-              {fn: listener}
-            ]
-          }
+        _events: {
+          foo: [
+            listener
+          ]
         }
       };
 
@@ -90,14 +84,13 @@ describe('Event emitter', function () {
         listenerCalled++;
       },
       context = {
-        eventTimeout: 20,
-        eventListeners: {
-          foo: {
-            lastEmitted: null,
-            listeners: [
-              {fn: listener}
-            ]
-          }
+        protectedEvents: {
+          foo: {timeout: 20}
+        },
+        _events: {
+          foo: [
+            listener
+          ]
         }
       };
 

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -28,10 +28,10 @@ describe('Listeners management', function () {
 
   describe('#addListener', function () {
     it('should properly add new listeners to events', function () {
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
+      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
+      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
+      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
 
     it('should throw an error if trying to adding a listener to an unknown event', function () {
@@ -51,19 +51,19 @@ describe('Listeners management', function () {
     it('should remove all registered listeners on a given event when asked to', function () {
       kuzzle.removeAllListeners('disconnected');
 
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(0);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
+      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
+      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
 
     it('should remove all registered listeners on all events when providing no event argument', function () {
       kuzzle.removeAllListeners();
 
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(0);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(0);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(0);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(0);
     });
 
     it('should throw an error when an unknown event is provided', function () {
@@ -72,30 +72,30 @@ describe('Listeners management', function () {
         should.fail('success', 'failure', 'Should have failed removing listeners with an unknown event', '');
       }
       catch (e) {
-        should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-        should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-        should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-        should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+        should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
+        should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
+        should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
+        should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
       }
     });
   });
 
   describe('#removeListener', function () {
     it('should remove any one listener from the listener list', function () {
-      var listener = kuzzle.eventListeners.connected.listeners.filter(function (l) {
+      var listener = kuzzle.eventEmitter.eventListeners.connected.listeners.filter(function (l) {
         return l.id === listenerIds[2];
       });
 
       should(listener.length).be.exactly(1);
       kuzzle.removeListener('connected', listenerIds[2]);
-      listener = kuzzle.eventListeners.connected.listeners.filter(function (l) {
+      listener = kuzzle.eventEmitter.eventListeners.connected.listeners.filter(function (l) {
         return l.id === listenerIds[2];
       });
       should(listener.length).be.exactly(0);
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(3);
+      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
+      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
+      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
 
     it('should throw an error when trying to remove a listener from an unknown event', function () {
@@ -104,19 +104,19 @@ describe('Listeners management', function () {
         should.fail('success', 'failure', 'Should have failed removing listeners with an unknown event', '');
       }
       catch (e) {
-        should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-        should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-        should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-        should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+        should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
+        should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
+        should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
+        should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
       }
     });
 
     it('should do nothing if the provided listener id does not exist', function () {
       kuzzle.removeListener('connected', 'foo');
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
+      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
+      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
+      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
   });
 });

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -53,17 +53,17 @@ describe('Listeners management', function () {
 
       should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
       should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventEmitter.eventListeners.disconnected).be.undefined();
+      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(0);
       should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
 
     it('should remove all registered listeners on all events when providing no event argument', function () {
       kuzzle.removeAllListeners();
 
-      should(kuzzle.eventEmitter.eventListeners.connected).be.undefined();
-      should(kuzzle.eventEmitter.eventListeners.error).be.undefined();
-      should(kuzzle.eventEmitter.eventListeners.disconnected).be.undefined();
-      should(kuzzle.eventEmitter.eventListeners.reconnected).be.undefined();
+      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(0);
     });
 
     it('should throw an error when an unknown event is provided', function () {

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -28,10 +28,10 @@ describe('Listeners management', function () {
 
   describe('#addListener', function () {
     it('should properly add new listeners to events', function () {
-      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
+      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
+      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
+      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
 
     it('should throw an error if trying to adding a listener to an unknown event', function () {
@@ -51,19 +51,19 @@ describe('Listeners management', function () {
     it('should remove all registered listeners on a given event when asked to', function () {
       kuzzle.removeAllListeners('disconnected');
 
-      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(0);
-      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
+      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
+      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
 
     it('should remove all registered listeners on all events when providing no event argument', function () {
       kuzzle.removeAllListeners();
 
-      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(0);
-      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(0);
-      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(0);
-      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(0);
+      should(kuzzle.eventListeners.error.listeners.length).be.exactly(0);
+      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(0);
     });
 
     it('should throw an error when an unknown event is provided', function () {
@@ -72,30 +72,30 @@ describe('Listeners management', function () {
         should.fail('success', 'failure', 'Should have failed removing listeners with an unknown event', '');
       }
       catch (e) {
-        should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
-        should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
-        should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
-        should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
+        should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
+        should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
+        should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
+        should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
       }
     });
   });
 
   describe('#removeListener', function () {
     it('should remove any one listener from the listener list', function () {
-      var listener = kuzzle.eventEmitter.eventListeners.connected.listeners.filter(function (l) {
+      var listener = kuzzle.eventListeners.connected.listeners.filter(function (l) {
         return l.id === listenerIds[2];
       });
 
       should(listener.length).be.exactly(1);
       kuzzle.removeListener('connected', listenerIds[2]);
-      listener = kuzzle.eventEmitter.eventListeners.connected.listeners.filter(function (l) {
+      listener = kuzzle.eventListeners.connected.listeners.filter(function (l) {
         return l.id === listenerIds[2];
       });
       should(listener.length).be.exactly(0);
-      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(3);
-      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(3);
+      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
+      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
+      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
 
     it('should throw an error when trying to remove a listener from an unknown event', function () {
@@ -104,19 +104,19 @@ describe('Listeners management', function () {
         should.fail('success', 'failure', 'Should have failed removing listeners with an unknown event', '');
       }
       catch (e) {
-        should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
-        should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
-        should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
-        should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
+        should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
+        should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
+        should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
+        should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
       }
     });
 
     it('should do nothing if the provided listener id does not exist', function () {
       kuzzle.removeListener('connected', 'foo');
-      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
+      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
+      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
+      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
   });
 });

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -25,9 +25,9 @@ describe('Listeners management', function () {
     listenerIds.push(kuzzle.addListener('connected', stublistener2));
     listenerIds.push(kuzzle.addListener('connected', stublistener3));
     listenerIds.push(kuzzle.addListener('connected', stublistener4));
-    kuzzle.addListener('kerror', stublistener1);
-    kuzzle.addListener('kerror', stublistener2);
-    kuzzle.addListener('kerror', stublistener3);
+    kuzzle.addListener('networkError', stublistener1);
+    kuzzle.addListener('networkError', stublistener2);
+    kuzzle.addListener('networkError', stublistener3);
     kuzzle.addListener('disconnected', stublistener1);
     kuzzle.addListener('disconnected', stublistener2);
     kuzzle.addListener('reconnected', stublistener3);
@@ -36,7 +36,7 @@ describe('Listeners management', function () {
   describe('#addListener', function () {
     it('should properly add new listeners to events', function () {
       should(kuzzle.listeners('connected').length).be.exactly(4);
-      should(kuzzle.listeners('kerror').length).be.exactly(3);
+      should(kuzzle.listeners('networkError').length).be.exactly(3);
       should(kuzzle.listeners('disconnected').length).be.exactly(2);
       should(kuzzle.listeners('reconnected').length).be.exactly(1);
     });
@@ -59,7 +59,7 @@ describe('Listeners management', function () {
       kuzzle.removeAllListeners('disconnected');
 
       should(kuzzle.listeners('connected').length).be.exactly(4);
-      should(kuzzle.listeners('kerror').length).be.exactly(3);
+      should(kuzzle.listeners('networkError').length).be.exactly(3);
       should(kuzzle.listeners('disconnected').length).be.exactly(0);
       should(kuzzle.listeners('reconnected').length).be.exactly(1);
     });
@@ -68,7 +68,7 @@ describe('Listeners management', function () {
       kuzzle.removeAllListeners();
 
       should(kuzzle.listeners('connected').length).be.exactly(0);
-      should(kuzzle.listeners('kerror').length).be.exactly(0);
+      should(kuzzle.listeners('networkError').length).be.exactly(0);
       should(kuzzle.listeners('disconnected').length).be.exactly(0);
       should(kuzzle.listeners('reconnected').length).be.exactly(0);
     });
@@ -80,7 +80,7 @@ describe('Listeners management', function () {
       }
       catch (e) {
         should(kuzzle.listeners('connected').length).be.exactly(4);
-        should(kuzzle.listeners('kerror').length).be.exactly(3);
+        should(kuzzle.listeners('networkError').length).be.exactly(3);
         should(kuzzle.listeners('disconnected').length).be.exactly(2);
         should(kuzzle.listeners('reconnected').length).be.exactly(1);
       }
@@ -91,7 +91,7 @@ describe('Listeners management', function () {
     it('should remove any one listener from the listener list', function () {
       kuzzle.removeListener('connected', stublistener2);
       should(kuzzle.listeners('connected').length).be.exactly(3);
-      should(kuzzle.listeners('kerror').length).be.exactly(3);
+      should(kuzzle.listeners('networkError').length).be.exactly(3);
       should(kuzzle.listeners('disconnected').length).be.exactly(2);
       should(kuzzle.listeners('reconnected').length).be.exactly(1);
     });
@@ -103,7 +103,7 @@ describe('Listeners management', function () {
       }
       catch (e) {
         should(kuzzle.listeners('connected').length).be.exactly(4);
-        should(kuzzle.listeners('kerror').length).be.exactly(3);
+        should(kuzzle.listeners('networkError').length).be.exactly(3);
         should(kuzzle.listeners('disconnected').length).be.exactly(2);
         should(kuzzle.listeners('reconnected').length).be.exactly(1);
       }
@@ -112,7 +112,7 @@ describe('Listeners management', function () {
     it('should do nothing if the provided listener id does not exist', function () {
       kuzzle.removeListener('connected', function() {});
       should(kuzzle.listeners('connected').length).be.exactly(4);
-      should(kuzzle.listeners('kerror').length).be.exactly(3);
+      should(kuzzle.listeners('networkError').length).be.exactly(3);
       should(kuzzle.listeners('disconnected').length).be.exactly(2);
       should(kuzzle.listeners('reconnected').length).be.exactly(1);
     });

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -53,17 +53,17 @@ describe('Listeners management', function () {
 
       should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(4);
       should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.disconnected).be.undefined();
       should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(1);
     });
 
     it('should remove all registered listeners on all events when providing no event argument', function () {
       kuzzle.removeAllListeners();
 
-      should(kuzzle.eventEmitter.eventListeners.connected.listeners.length).be.exactly(0);
-      should(kuzzle.eventEmitter.eventListeners.error.listeners.length).be.exactly(0);
-      should(kuzzle.eventEmitter.eventListeners.disconnected.listeners.length).be.exactly(0);
-      should(kuzzle.eventEmitter.eventListeners.reconnected.listeners.length).be.exactly(0);
+      should(kuzzle.eventEmitter.eventListeners.connected).be.undefined();
+      should(kuzzle.eventEmitter.eventListeners.error).be.undefined();
+      should(kuzzle.eventEmitter.eventListeners.disconnected).be.undefined();
+      should(kuzzle.eventEmitter.eventListeners.reconnected).be.undefined();
     });
 
     it('should throw an error when an unknown event is provided', function () {

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -6,32 +6,39 @@ var
 describe('Listeners management', function () {
   var
     kuzzle,
+    stublistener1,
+    stublistener2,
+    stublistener3,
+    stublistener4,
     listenerIds;
 
   beforeEach(function () {
-    var stublistener = function () {};
+    stublistener1 = function () {};
+    stublistener2 = function () {};
+    stublistener3 = function () {};
+    stublistener4 = function () {};
 
     kuzzle = new Kuzzle('foo', 'this is not an index');
     listenerIds = [];
 
-    listenerIds.push(kuzzle.addListener('connected', stublistener));
-    listenerIds.push(kuzzle.addListener('connected', stublistener));
-    listenerIds.push(kuzzle.addListener('connected', stublistener));
-    listenerIds.push(kuzzle.addListener('connected', stublistener));
-    kuzzle.addListener('error', stublistener);
-    kuzzle.addListener('error', stublistener);
-    kuzzle.addListener('error', stublistener);
-    kuzzle.addListener('disconnected', stublistener);
-    kuzzle.addListener('disconnected', stublistener);
-    kuzzle.addListener('reconnected', stublistener);
+    listenerIds.push(kuzzle.addListener('connected', stublistener1));
+    listenerIds.push(kuzzle.addListener('connected', stublistener2));
+    listenerIds.push(kuzzle.addListener('connected', stublistener3));
+    listenerIds.push(kuzzle.addListener('connected', stublistener4));
+    kuzzle.addListener('kerror', stublistener1);
+    kuzzle.addListener('kerror', stublistener2);
+    kuzzle.addListener('kerror', stublistener3);
+    kuzzle.addListener('disconnected', stublistener1);
+    kuzzle.addListener('disconnected', stublistener2);
+    kuzzle.addListener('reconnected', stublistener3);
   });
 
   describe('#addListener', function () {
     it('should properly add new listeners to events', function () {
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.listeners('connected').length).be.exactly(4);
+      should(kuzzle.listeners('kerror').length).be.exactly(3);
+      should(kuzzle.listeners('disconnected').length).be.exactly(2);
+      should(kuzzle.listeners('reconnected').length).be.exactly(1);
     });
 
     it('should throw an error if trying to adding a listener to an unknown event', function () {
@@ -51,19 +58,19 @@ describe('Listeners management', function () {
     it('should remove all registered listeners on a given event when asked to', function () {
       kuzzle.removeAllListeners('disconnected');
 
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(0);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+      should(kuzzle.listeners('connected').length).be.exactly(4);
+      should(kuzzle.listeners('kerror').length).be.exactly(3);
+      should(kuzzle.listeners('disconnected').length).be.exactly(0);
+      should(kuzzle.listeners('reconnected').length).be.exactly(1);
     });
 
     it('should remove all registered listeners on all events when providing no event argument', function () {
       kuzzle.removeAllListeners();
 
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(0);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(0);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(0);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(0);
+      should(kuzzle.listeners('connected').length).be.exactly(0);
+      should(kuzzle.listeners('kerror').length).be.exactly(0);
+      should(kuzzle.listeners('disconnected').length).be.exactly(0);
+      should(kuzzle.listeners('reconnected').length).be.exactly(0);
     });
 
     it('should throw an error when an unknown event is provided', function () {
@@ -72,51 +79,42 @@ describe('Listeners management', function () {
         should.fail('success', 'failure', 'Should have failed removing listeners with an unknown event', '');
       }
       catch (e) {
-        should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-        should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-        should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-        should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+        should(kuzzle.listeners('connected').length).be.exactly(4);
+        should(kuzzle.listeners('kerror').length).be.exactly(3);
+        should(kuzzle.listeners('disconnected').length).be.exactly(2);
+        should(kuzzle.listeners('reconnected').length).be.exactly(1);
       }
     });
   });
 
   describe('#removeListener', function () {
     it('should remove any one listener from the listener list', function () {
-      var listener = kuzzle.eventListeners.connected.listeners.filter(function (l) {
-        return l.id === listenerIds[2];
-      });
-
-      should(listener.length).be.exactly(1);
-      kuzzle.removeListener('connected', listenerIds[2]);
-      listener = kuzzle.eventListeners.connected.listeners.filter(function (l) {
-        return l.id === listenerIds[2];
-      });
-      should(listener.length).be.exactly(0);
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+      kuzzle.removeListener('connected', stublistener2);
+      should(kuzzle.listeners('connected').length).be.exactly(3);
+      should(kuzzle.listeners('kerror').length).be.exactly(3);
+      should(kuzzle.listeners('disconnected').length).be.exactly(2);
+      should(kuzzle.listeners('reconnected').length).be.exactly(1);
     });
 
     it('should throw an error when trying to remove a listener from an unknown event', function () {
       try {
-        kuzzle.removeListener('foo', 'bar');
+        kuzzle.removeListener('foo', function() {});
         should.fail('success', 'failure', 'Should have failed removing listeners with an unknown event', '');
       }
       catch (e) {
-        should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-        should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-        should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-        should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+        should(kuzzle.listeners('connected').length).be.exactly(4);
+        should(kuzzle.listeners('kerror').length).be.exactly(3);
+        should(kuzzle.listeners('disconnected').length).be.exactly(2);
+        should(kuzzle.listeners('reconnected').length).be.exactly(1);
       }
     });
 
     it('should do nothing if the provided listener id does not exist', function () {
-      kuzzle.removeListener('connected', 'foo');
-      should(kuzzle.eventListeners.connected.listeners.length).be.exactly(4);
-      should(kuzzle.eventListeners.error.listeners.length).be.exactly(3);
-      should(kuzzle.eventListeners.disconnected.listeners.length).be.exactly(2);
-      should(kuzzle.eventListeners.reconnected.listeners.length).be.exactly(1);
+      kuzzle.removeListener('connected', function() {});
+      should(kuzzle.listeners('connected').length).be.exactly(4);
+      should(kuzzle.listeners('kerror').length).be.exactly(3);
+      should(kuzzle.listeners('disconnected').length).be.exactly(2);
+      should(kuzzle.listeners('reconnected').length).be.exactly(1);
     });
   });
 });

--- a/test/network/websocket.test.js
+++ b/test/network/websocket.test.js
@@ -25,6 +25,7 @@ describe('WebSocket networking module', function () {
   });
 
   afterEach(function () {
+    websocket.removeAllListeners();
     WebSocket = undefined; // eslint-disable-line
     window = undefined; // eslint-disable-line
   });
@@ -51,14 +52,14 @@ describe('WebSocket networking module', function () {
 
     websocket.retrying = false;
     websocket.onConnect(cb);
-    should(websocket.eventEmitter.eventListeners.connect.listeners.length).be.eql(1);
-    should(websocket.eventEmitter.eventListeners.reconnect).be.undefined();
+    should(websocket.eventListeners.connect.listeners.length).be.eql(1);
+    should(websocket.eventListeners.reconnect).be.undefined();
 
     websocket.connect();
     clientStub.onopen();
     setTimeout(function () {
       should(cb.calledOnce).be.true();
-      should(websocket.eventEmitter.eventListeners.connect.listeners.length).be.eql(1);
+      should(websocket.eventListeners.connect.listeners.length).be.eql(1);
       done();
     }, 0);
   });
@@ -69,15 +70,15 @@ describe('WebSocket networking module', function () {
     websocket.wasConnected = true;
     websocket.lasturl = 'ws://address:port';
     websocket.onReconnect(cb);
-    should(websocket.eventEmitter.eventListeners.connect).be.undefined();
-    should(websocket.eventEmitter.eventListeners.reconnect.listeners.length).be.eql(1);
+    should(websocket.eventListeners.connect).be.undefined();
+    should(websocket.eventListeners.reconnect.listeners.length).be.eql(1);
 
     websocket.connect();
     clientStub.onopen();
 
     setTimeout(function () {
       should(cb.calledOnce).be.true();
-      should(websocket.eventEmitter.eventListeners.reconnect.listeners.length).be.eql(1);
+      should(websocket.eventListeners.reconnect.listeners.length).be.eql(1);
       done();
     }, 0);
   });
@@ -89,7 +90,7 @@ describe('WebSocket networking module', function () {
 
     websocket.retrying = false;
     websocket.onConnectError(cb);
-    should(websocket.eventEmitter.eventListeners.error.listeners.length).be.eql(1);
+    should(websocket.eventListeners.error.listeners.length).be.eql(1);
 
     websocket.connect(true, 10);
     websocket.connect = sinon.stub();
@@ -98,7 +99,7 @@ describe('WebSocket networking module', function () {
     clock.tick(10);
 
     should(cb.calledOnce).be.true();
-    should(websocket.eventEmitter.eventListeners.error.listeners.length).be.eql(1);
+    should(websocket.eventListeners.error.listeners.length).be.eql(1);
     should(websocket.retrying).be.false();
     should(websocket.connect.calledOnce).be.true();
     clock.restore();
@@ -111,7 +112,7 @@ describe('WebSocket networking module', function () {
 
     websocket.retrying = false;
     websocket.onConnectError(cb);
-    should(websocket.eventEmitter.eventListeners.error.listeners.length).be.eql(1);
+    should(websocket.eventListeners.error.listeners.length).be.eql(1);
 
     websocket.connect(false, 10);
     websocket.connect = sinon.stub();
@@ -119,7 +120,7 @@ describe('WebSocket networking module', function () {
     clock.tick(10);
 
     should(cb.calledOnce).be.true();
-    should(websocket.eventEmitter.eventListeners.error.listeners.length).be.eql(1);
+    should(websocket.eventListeners.error.listeners.length).be.eql(1);
     should(websocket.retrying).be.false();
     should(websocket.connect.calledOnce).be.false();
     clock.restore();
@@ -130,14 +131,14 @@ describe('WebSocket networking module', function () {
 
     websocket.retrying = false;
     websocket.onDisconnect(cb);
-    should(websocket.eventEmitter.eventListeners.disconnect.listeners.length).be.eql(1);
+    should(websocket.eventListeners.disconnect.listeners.length).be.eql(1);
 
     websocket.connect();
     clientStub.onclose(1000);
 
     setTimeout(function () {
       should(cb.calledOnce).be.true();
-      should(websocket.eventEmitter.eventListeners.disconnect.listeners.length).be.eql(1);
+      should(websocket.eventListeners.disconnect.listeners.length).be.eql(1);
       done();
     }, 0);
   });
@@ -147,7 +148,7 @@ describe('WebSocket networking module', function () {
 
     websocket.retrying = false;
     websocket.onConnectError(cb);
-    should(websocket.eventEmitter.eventListeners.error.listeners.length).be.eql(1);
+    should(websocket.eventListeners.error.listeners.length).be.eql(1);
 
     websocket.connect();
     clientStub.onclose(4666, 'foobar');
@@ -155,7 +156,7 @@ describe('WebSocket networking module', function () {
     setTimeout(function () {
       should(cb.calledOnce).be.true();
       should(cb.calledWith('foobar'));
-      should(websocket.eventEmitter.eventListeners.error.listeners.length).be.eql(1);
+      should(websocket.eventListeners.error.listeners.length).be.eql(1);
       done();
     }, 0);
   });
@@ -170,14 +171,14 @@ describe('WebSocket networking module', function () {
     websocket.once('barfoo', cb);
     websocket.connect();
 
-    should(websocket.eventEmitter.eventListeners.foobar.listeners.length).be.equal(2);
-    should(websocket.eventEmitter.eventListeners.barfoo.listeners.length).be.equal(1);
+    should(websocket.eventListeners.foobar.listeners.length).be.equal(2);
+    should(websocket.eventListeners.barfoo.listeners.length).be.equal(1);
 
     clientStub.onmessage({data: JSON.stringify(payload)});
 
     setTimeout(function () {
-      should(websocket.eventEmitter.eventListeners.foobar).be.undefined();
-      should(websocket.eventEmitter.eventListeners.barfoo.listeners.length).be.equal(1);
+      should(websocket.eventListeners.foobar).be.undefined();
+      should(websocket.eventListeners.barfoo.listeners.length).be.equal(1);
       should(cb.calledTwice).be.true();
       should(cb.alwaysCalledWithMatch(payload)).be.true();
       done();
@@ -193,12 +194,12 @@ describe('WebSocket networking module', function () {
     websocket.on('foobar', cb);
     websocket.connect();
 
-    should(websocket.eventEmitter.eventListeners.foobar.listeners.length).be.equal(2);
+    should(websocket.eventListeners.foobar.listeners.length).be.equal(2);
 
     clientStub.onmessage({data: JSON.stringify(payload)});
 
     setTimeout(function () {
-      should(websocket.eventEmitter.eventListeners.foobar.listeners.length).be.equal(2);
+      should(websocket.eventListeners.foobar.listeners.length).be.equal(2);
       should(cb.calledTwice).be.true();
       should(cb.alwaysCalledWithMatch(payload)).be.true();
       done();
@@ -230,13 +231,13 @@ describe('WebSocket networking module', function () {
     websocket.on('foobar', cb);
     websocket.connect();
 
-    should(websocket.eventEmitter.eventListeners.foobar.listeners).match([{fn: cb}, {fn: cb}]);
+    should(websocket.eventListeners.foobar.listeners).match([{fn: cb}, {fn: cb}]);
 
     websocket.off('foobar', cb);
-    should(websocket.eventEmitter.eventListeners.foobar.listeners).match([{fn: cb}]);
+    should(websocket.eventListeners.foobar.listeners).match([{fn: cb}]);
 
     websocket.off('foobar', cb);
-    should(websocket.eventEmitter.eventListeners.foobar).be.undefined();
+    should(websocket.eventListeners.foobar).be.undefined();
   });
 
   it('should do nothing if trying to unregister an non-existent event/callback', function () {
@@ -247,13 +248,13 @@ describe('WebSocket networking module', function () {
     websocket.on('foobar', cb);
     websocket.connect();
 
-    should(websocket.eventEmitter.eventListeners.foobar.listeners).match([{fn: cb}, {fn: cb}]);
+    should(websocket.eventListeners.foobar.listeners).match([{fn: cb}, {fn: cb}]);
 
-//    websocket.off('foo', cb);
-//    should(websocket.eventEmitter.eventListeners.foobar.listeners).match([{fn: cb}, {fn: cb}]);
+    websocket.off('foo', cb);
+    should(websocket.eventListeners.foobar.listeners).match([{fn: cb}, {fn: cb}]);
 
     websocket.off('foobar', sinon.stub());
-    should(websocket.eventEmitter.eventListeners.foobar.listeners).match([{fn: cb}, {fn: cb}]);
+    should(websocket.eventListeners.foobar.listeners).match([{fn: cb}, {fn: cb}]);
   });
 
   it('should send data payload through websocket', function () {
@@ -292,11 +293,11 @@ describe('WebSocket networking module', function () {
     websocket.connect();
     websocket.close();
 
-    should(websocket.eventEmitter.eventListeners.foobar).be.undefined();
-    should(websocket.eventEmitter.eventListeners.error).be.undefined();
-    should(websocket.eventEmitter.eventListeners.connect).be.undefined();
-    should(websocket.eventEmitter.eventListeners.reconnect).be.undefined();
-    should(websocket.eventEmitter.eventListeners.disconnect).be.undefined();
+    should(websocket.eventListeners.foobar).be.undefined();
+    should(websocket.eventListeners.error).be.undefined();
+    should(websocket.eventListeners.connect).be.undefined();
+    should(websocket.eventListeners.reconnect).be.undefined();
+    should(websocket.eventListeners.disconnect).be.undefined();
     should(websocket.client).be.null();
     should(clientStub.close.called).be.true();
     should(websocket.wasConnected).be.false();

--- a/test/network/websocket.test.js
+++ b/test/network/websocket.test.js
@@ -89,7 +89,7 @@ describe('WebSocket networking module', function () {
 
     websocket.retrying = false;
     websocket.onConnectError(cb);
-    should(websocket.listeners('wserror').length).be.eql(1);
+    should(websocket.listeners('networkError').length).be.eql(1);
 
     websocket.connect(true, 10);
     websocket.connect = sinon.stub();
@@ -98,7 +98,7 @@ describe('WebSocket networking module', function () {
     clock.tick(10);
 
     should(cb.calledOnce).be.true();
-    should(websocket.listeners('wserror').length).be.eql(1);
+    should(websocket.listeners('networkError').length).be.eql(1);
     should(websocket.retrying).be.false();
     should(websocket.connect.calledOnce).be.true();
     clock.restore();
@@ -111,7 +111,7 @@ describe('WebSocket networking module', function () {
 
     websocket.retrying = false;
     websocket.onConnectError(cb);
-    should(websocket.listeners('wserror').length).be.eql(1);
+    should(websocket.listeners('networkError').length).be.eql(1);
 
     websocket.connect(false, 10);
     websocket.connect = sinon.stub();
@@ -119,7 +119,7 @@ describe('WebSocket networking module', function () {
     clock.tick(10);
 
     should(cb.calledOnce).be.true();
-    should(websocket.listeners('wserror').length).be.eql(1);
+    should(websocket.listeners('networkError').length).be.eql(1);
     should(websocket.retrying).be.false();
     should(websocket.connect.calledOnce).be.false();
     clock.restore();
@@ -147,7 +147,7 @@ describe('WebSocket networking module', function () {
 
     websocket.retrying = false;
     websocket.onConnectError(cb);
-    should(websocket.listeners('wserror').length).be.eql(1);
+    should(websocket.listeners('networkError').length).be.eql(1);
 
     websocket.connect();
     clientStub.onclose(4666, 'foobar');
@@ -155,7 +155,7 @@ describe('WebSocket networking module', function () {
     setTimeout(function () {
       should(cb.calledOnce).be.true();
       should(cb.calledWith('foobar'));
-      should(websocket.listeners('wserror').length).be.eql(1);
+      should(websocket.listeners('networkError').length).be.eql(1);
       done();
     }, 0);
   });
@@ -299,7 +299,7 @@ describe('WebSocket networking module', function () {
     websocket.close();
 
     should(websocket.listeners('foobar').length).be.exactly(0);
-    should(websocket.listeners('wserror').length).be.exactly(0);
+    should(websocket.listeners('networkError').length).be.exactly(0);
     should(websocket.listeners('connect').length).be.exactly(0);
     should(websocket.listeners('reconnect').length).be.exactly(0);
     should(websocket.listeners('disconnect').length).be.exactly(0);

--- a/test/network/websocket.test.js
+++ b/test/network/websocket.test.js
@@ -176,7 +176,7 @@ describe('WebSocket networking module', function () {
     clientStub.onmessage({data: JSON.stringify(payload)});
 
     setTimeout(function () {
-      should(websocket.eventEmitter.eventListeners.foobar.listeners.length).be.equal(0);
+      should(websocket.eventEmitter.eventListeners.foobar).be.undefined();
       should(websocket.eventEmitter.eventListeners.barfoo.listeners.length).be.equal(1);
       should(cb.calledTwice).be.true();
       should(cb.alwaysCalledWithMatch(payload)).be.true();
@@ -236,7 +236,7 @@ describe('WebSocket networking module', function () {
     should(websocket.eventEmitter.eventListeners.foobar.listeners).match([{fn: cb}]);
 
     websocket.off('foobar', cb);
-    should(websocket.eventEmitter.eventListeners.foobar.listeners.length).be.equal(0);
+    should(websocket.eventEmitter.eventListeners.foobar).be.undefined();
   });
 
   it('should do nothing if trying to unregister an non-existent event/callback', function () {
@@ -292,11 +292,11 @@ describe('WebSocket networking module', function () {
     websocket.connect();
     websocket.close();
 
-    should(websocket.eventEmitter.eventListeners.foobar.listeners).be.empty();
-    should(websocket.eventEmitter.eventListeners.error.listeners).be.empty();
-    should(websocket.eventEmitter.eventListeners.connect.listeners).be.empty();
-    should(websocket.eventEmitter.eventListeners.reconnect.listeners).be.empty();
-    should(websocket.eventEmitter.eventListeners.disconnect.listeners).be.empty();
+    should(websocket.eventEmitter.eventListeners.foobar).be.undefined();
+    should(websocket.eventEmitter.eventListeners.error).be.undefined();
+    should(websocket.eventEmitter.eventListeners.connect).be.undefined();
+    should(websocket.eventEmitter.eventListeners.reconnect).be.undefined();
+    should(websocket.eventEmitter.eventListeners.disconnect).be.undefined();
     should(websocket.client).be.null();
     should(clientStub.close.called).be.true();
     should(websocket.wasConnected).be.false();


### PR DESCRIPTION
main `Kuzzle` SDK prototype and websocket wrapper implementation both used their own event listeners.

Now, both Kuzzle and websocket wrapper inherits from Node build-in `EventEmitter` class (https://nodejs.org/api/events.html), with a polyfilled implementation for browser.

## Breaking Changes
method `addListener` no longer returns an ID, to be compliant with NodeJS implementation ( https://nodejs.org/api/events.html#events_emitter_on_eventname_listener )
It now returns the Emitter object itself, so that it can be chained.

For each event, the listener callback function is used as the key in listeners list

## Documentation
https://github.com/kuzzleio/documentation/pull/172
