### PR TITLE
networkError payload should be an Error object

### DIFF
--- a/src/networkWrapper/wrappers/websocket.js
+++ b/src/networkWrapper/wrappers/websocket.js
@@ -148,7 +148,7 @@ function onClientError(autoReconnect, reconnectionDelay, message) {
     }, reconnectionDelay);
   }
 
-  self.emitEvent('networkError', message);
+  self.emitEvent('networkError', new Error(message));
 }
 
 module.exports = WSNode;


### PR DESCRIPTION
# Description

The `networkError` event has an inconsistent payload: the main `Kuzzle` object may trigger it with an `Error` object (if unable to establish a connection), but the `websocket` wrapper triggers it with a `string` message if the socket gets unexpectedly closed.
