### PR TITLE
Rename getProfiles to getProfileIds and add a proper getProfiles method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 Official Kuzzle Javascript SDK
 ======
 
-This SDK version is compatible with Kuzzle 1.0.0-RC9.5 and higher
-
 ## About Kuzzle
 
-For UI and linked objects developers, Kuzzle is an open-source solution that handles all the data management (CRUD, real-time storage, search, high-level features, etc).
+A backend software, self-hostable and ready to use to power modern apps.
 
 You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuzzle)
 
@@ -24,11 +22,11 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 
 ## Basic usage
 
-Follow [Kuzzle Guide](http://docs.kuzzle.io/guide/#sdk-play-time)
+Follow [Kuzzle Guide](http://docs.kuzzle.io/guide/getting-started/#sdk-play-time)
 
 ## SDK Documentation
 
-The complete SDK documentation is available [here](http://docs.kuzzle.io/sdk-reference/?javascript#kuzzle)
+The complete SDK documentation is available [here](http://docs.kuzzle.io/sdk-reference/)
 
 ## Report an issue
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/security/User.js
+++ b/src/security/User.js
@@ -222,14 +222,19 @@ User.prototype.getProfiles = function (options, cb) {
     fetchedProfiles = [],
     errored = false;
 
-  if (!self.content.profileIds) {
-    return fetchedProfiles;
+  if (options && !cb && typeof options === 'function') {
+    cb = options;
+    options = null;
   }
 
   self.Security.kuzzle.callbackRequired('User.getProfiles', cb);
 
+  if (!self.content.profileIds) {
+    return cb(null, fetchedProfiles);
+  }
+
   self.content.profileIds.forEach(function (profileId) {
-    self.Security.fetchprofile(profileId, option, function (error, profile) {
+    self.Security.fetchProfile(profileId, options, function (error, profile) {
       if (error) {
         if (errored) {
           return;
@@ -241,8 +246,8 @@ User.prototype.getProfiles = function (options, cb) {
 
       fetchedProfiles.push(profile);
 
-      if (fetchedProfiled.length === self.content.profileIds.length) {
-        cb(null, fetchProfiles);
+      if (fetchedProfiles.length === self.content.profileIds.length) {
+        cb(null, fetchedProfiles);
       }
     });
   });

--- a/test/security/kuzzleUser/methods.test.js
+++ b/test/security/kuzzleUser/methods.test.js
@@ -3,6 +3,7 @@ var
   sinon = require('sinon'),
   Kuzzle = require('../../../src/Kuzzle'),
   User = require('../../../src/security/User'),
+  Profile = require('../../../src/security/Profile'),
   sandbox = sinon.sandbox.create();
 
 describe('User methods', function () {
@@ -326,6 +327,57 @@ describe('User methods', function () {
   });
 
   describe('#getProfiles', function () {
-    
+    it('should return an empty array if no profile is attached', function (done) {
+      kuzzleUser = new User(kuzzle.security, 'foo', {});
+
+      kuzzleUser.getProfiles(function (error, profiles) {
+        should(error).be.null();
+        should(profiles).be.an.Array().and.be.empty();
+        done();
+      });
+    });
+
+    it('should fetch the attached profiles using the API to build Profile objects', function (done) {
+      kuzzleUser = new User(kuzzle.security, 'foo', {profileIds: ['foo', 'bar', 'baz']});
+      kuzzle.query.yields(null, {
+        result: {
+          _id: 'foobar',
+          _source: {}
+        }
+      });
+
+      kuzzleUser.getProfiles(function (error, profiles) {
+        should(error).be.null();
+        should(profiles).be.an.Array().and.have.lengthOf(3);
+
+        profiles.forEach(function (profile) {
+          should(profile).be.instanceof(Profile);
+        });
+
+        done();
+      });
+    });
+
+    it('should not invoke the callback more than once even if multiple errors occur', function (done) {
+      var callCount = 0;
+
+      kuzzleUser = new User(kuzzle.security, 'foo', {profileIds: ['foo', 'bar', 'baz']});
+      kuzzle.query.yields(new Error('errored'));
+
+      kuzzleUser.getProfiles(function (error, profiles) {
+        callCount++;
+        should(profiles).be.undefined();
+        should(error).be.an.Error().and.have.value('message', 'errored');
+        should(callCount).be.eql(1);
+        done();
+      });
+    });
+
+    it('should throw if no callback is provided', function () {
+      kuzzleUser = new User(kuzzle.security, 'foo', {});
+
+      should(function () { kuzzleUser.getProfiles(); }).throw('User.getProfiles: a callback argument is required for read queries');
+      should(function () { kuzzleUser.getProfiles({}); }).throw('User.getProfiles: a callback argument is required for read queries');
+    });
   });
 });

--- a/test/security/kuzzleUser/methods.test.js
+++ b/test/security/kuzzleUser/methods.test.js
@@ -312,11 +312,20 @@ describe('User methods', function () {
     });
   });
 
-  describe('#getProfiles', function () {
+  describe('#getProfileIds', function () {
     it('should return the associated profiles', function () {
       var profileIds = ['profile'];
       kuzzleUser = new User(kuzzle.security, 'user', {some: 'content', profileIds: profileIds});
-      should(kuzzleUser.getProfiles()).be.eql(profileIds);
+      should(kuzzleUser.getProfileIds()).be.eql(profileIds);
     });
+
+    it('should return an empty array if no profile ID is attached', function () {
+      kuzzleUser = new User(kuzzle.security, 'foo', {});
+      should(kuzzleUser.getProfileIds()).be.an.Array().and.be.empty();
+    });
+  });
+
+  describe('#getProfiles', function () {
+    
   });
 });


### PR DESCRIPTION
# Description

* `User.getProfiles` is renamed to `User.getProfileIds`
* `User.getProfileIds` now returns an empty array instead of `undefined` if no profile is attached to the user object
* add a new `User.getProfiles` method fetching profiles from Kuzzle API and returning an array of `Profile` objects

# Boyscout

Update README file

# Related issue

https://github.com/kuzzleio/kuzzle-sdk/issues/33
