### PR TITLE
Update MemoryStorage.*scan return value format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/MemoryStorage.js
+++ b/src/MemoryStorage.js
@@ -520,19 +520,10 @@ function mapZrangeResults(results) {
  * @return {object}
  */
 function mapScanResults(results) {
-  var mapped = {};
-
-  if (results.length === 0) {
-    return {
-      cursor: 0,
-      values: []
-    };
-  }
-
-  mapped.cursor = results[0];
-  mapped.values = results[1];
-
-  return mapped;
+  return {
+    cursor: results[0],
+    values: results[1]
+  };
 }
 
 module.exports = MemoryStorage;

--- a/src/MemoryStorage.js
+++ b/src/MemoryStorage.js
@@ -4,7 +4,12 @@ var
   getIdField = {getter: true, required: ['_id', 'field']},
   getKeys = {getter: true, required: ['keys']},
   getMember = {getter: true, required: ['_id', 'member']},
-  getxScan = {getter: true, required: ['_id', 'cursor'], opts: ['match', 'count']},
+  getxScan = {
+    getter: true, 
+    required: ['_id', 'cursor'], 
+    opts: ['match', 'count'],
+    mapResults: mapScanResults
+  },
   getZrange = {
     getter: true,
     required: ['_id', 'start', 'stop'],
@@ -112,7 +117,7 @@ var
     rpush: {required: ['_id', 'values']},
     rpushx: setIdValue,
     sadd: {required: ['_id', 'members']},
-    scan: {getter: true, required: ['cursor'], opts: ['match', 'count']},
+    scan: {getter: true, required: ['cursor'], opts: ['match', 'count'], mapResults: mapScanResults},
     scard: getId,
     sdiff: {getter: true, required: ['_id', 'keys']},
     sdiffstore: {required: ['_id', 'keys', 'destination']},
@@ -486,6 +491,46 @@ function mapZrangeResults(results) {
       buffer = null;
     }
   });
+
+  return mapped;
+}
+
+/**
+ * Map *scan calls results, from:
+ * [
+ *   "<cursor>",
+ *   [
+ *     "value1",
+ *     "value2", 
+ *     "..."
+ *   ]
+ * ]
+ *
+ * To:
+ * {
+ *   cursor: <cursor>,
+ *   values: [
+ *     "value1",
+ *     "value2",
+ *     "..."
+ *   ]
+ * }
+ * 
+ * @param  {array.<string|array>} results 
+ * @return {object}
+ */
+function mapScanResults(results) {
+  var mapped = {};
+
+  if (results.length === 0) {
+    return {
+      cursor: 0,
+      values: []
+    };
+  }
+
+  mapped.cursor = results[0];
+  mapped.values = results[1];
 
   return mapped;
 }

--- a/test/MemoryStorage/methods.test.js
+++ b/test/MemoryStorage/methods.test.js
@@ -492,7 +492,7 @@ describe('MemoryStorage methods', function () {
       {_id: 'key', cursor: 0},
       {count: 42, match: 'foo*'},
       [42, ['bar', 'baz', 'qux']],
-      [42, ['bar', 'baz', 'qux']]
+      {cursor: 42, values: ['bar', 'baz', 'qux']}
     );
   });
 
@@ -966,7 +966,7 @@ describe('MemoryStorage methods', function () {
       {cursor: 0},
       {count: 42, match: 'foo*'},
       [42, ['bar', 'baz', 'qux']],
-      [42, ['bar', 'baz', 'qux']]
+      {cursor: 42, values: ['bar', 'baz', 'qux']}
     );
   });
 
@@ -1158,7 +1158,7 @@ describe('MemoryStorage methods', function () {
       {_id: 'key', cursor: 0},
       {count: 42, match: 'foo*'},
       [42, ['bar', 'baz', 'qux']],
-      [42, ['bar', 'baz', 'qux']]
+      {cursor: 42, values: ['bar', 'baz', 'qux']}
     );
   });
 
@@ -1472,7 +1472,7 @@ describe('MemoryStorage methods', function () {
       {_id: 'key', cursor: 0},
       {count: 42, match: 'foo*'},
       [42, ['bar', 'baz', 'qux']],
-      [42, ['bar', 'baz', 'qux']]
+      {cursor: 42, values: ['bar', 'baz', 'qux']}
     );
   });
 


### PR DESCRIPTION
# Description

Following the work done in https://github.com/kuzzleio/documentation/pull/281, the returned values of `MemoryStorage.*scan` methods has been changed.

This PR updates the SDK to make it match the new return value format for these methods.


**Note:** this will trigger a patch version update on this SDK (5.0.2), as the published 5.x version is not usable until Kuzzle RC10 is out