### PR TITLE
Fix createProfile and updateProfile method signatures

### DIFF
--- a/src/security/Security.js
+++ b/src/security/Security.js
@@ -306,11 +306,11 @@ Security.prototype.searchProfiles = function (filters, options, cb) {
  *        Replace the existing profile otherwise
  *
  * @param {string} id - profile identifier
- * @param {object} content - attribute `roles` in `content` must only contains an array of role id
+ * @param {array} policies - list of policies to attach to the new profile
  * @param {object|responseCallback} [options] - (optional) arguments
  * @param {responseCallback} [cb] - (optional) Handles the query response
  */
-Security.prototype.createProfile = function (id, content, options, cb) {
+Security.prototype.createProfile = function (id, policies, options, cb) {
   var
     self = this,
     data = {},
@@ -326,7 +326,10 @@ Security.prototype.createProfile = function (id, content, options, cb) {
   }
 
   data._id = id;
-  data.body = content;
+
+  if (policies) {
+    data.body = { policies: policies };
+  }
 
   if (options) {
     action = options.replaceIfExist ? 'createOrReplaceProfile' : 'createProfile';
@@ -342,12 +345,12 @@ Security.prototype.createProfile = function (id, content, options, cb) {
  * Update a profile in Kuzzle.
  *
  * @param {string} id - profile identifier
- * @param {object} content - a plain javascript object representing the profile's modification
+ * @param {array} policies - the list of policies to apply to this profile
  * @param {object|responseCallback} [options] - (optional) arguments
  * @param {responseCallback} [cb] - (optional) Handles the query response
  * @returns {Security} this object
  */
-Security.prototype.updateProfile = function (id, content, options, cb) {
+Security.prototype.updateProfile = function (id, policies, options, cb) {
   var
     self = this,
     data = {},
@@ -363,7 +366,10 @@ Security.prototype.updateProfile = function (id, content, options, cb) {
   }
 
   data._id = id;
-  data.body = content;
+
+  if (policies) {
+    data.body = {policies: policies};
+  }
 
   self.kuzzle.query(this.buildQueryArgs(action), data, options, cb && function (err, res) {
     var updatedContent = {};

--- a/test/security/kuzzleSecurity/profilesMethods.test.js
+++ b/test/security/kuzzleSecurity/profilesMethods.test.js
@@ -151,9 +151,9 @@ describe('Security profiles methods', function () {
 
 
   describe('#createProfile', function () {
-    var content = {policies: [{roleId: 'myRole'}]};
+    var policies = [{roleId: 'myRole'}];
     beforeEach(function () {
-      result = { result: {_id: 'foobar', _source: content} };
+      result = { result: {_id: 'foobar', _source: {policies: policies}} };
       expectedQuery = {
         action: 'createProfile',
         controller: 'security'
@@ -163,38 +163,38 @@ describe('Security profiles methods', function () {
     it('should send the right query to Kuzzle', function (done) {
       this.timeout(50);
 
-      should(kuzzle.security.createProfile('foobar', content, function (err, res) {
+      should(kuzzle.security.createProfile('foobar', policies, function (err, res) {
         should(err).be.null();
         should(res).be.instanceof(Profile);
         done();
       }));
 
       should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: content}, null, sinon.match.func);
+      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: {policies: policies}}, null, sinon.match.func);
 
       kuzzle.query.yield(null, result);
     });
 
     it('should send the right query to Kuzzle even without callback', function () {
-      kuzzle.security.createProfile('foobar', content);
+      kuzzle.security.createProfile('foobar', policies);
       should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: content}, undefined, undefined);
+      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: {policies: policies}}, undefined, undefined);
     });
 
     it('should construct a createOrReplaceProfile action if option replaceIfExist is set to true', function () {
       expectedQuery.action = 'createOrReplaceProfile';
 
-      should(kuzzle.security.createProfile('foobar', content, {replaceIfExist: true}));
+      should(kuzzle.security.createProfile('foobar', policies, {replaceIfExist: true}));
       should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: content});
+      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: {policies: policies}});
     });
 
     it('should construct a createProfile action if option replaceIfExist is set to false', function () {
       expectedQuery.action = 'createProfile';
 
-      should(kuzzle.security.createProfile('foobar', content, {replaceIfExist: false}));
+      should(kuzzle.security.createProfile('foobar', policies, {replaceIfExist: false}));
       should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: content});
+      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: {policies: policies}});
     });
 
     it('should throw an error if no id provided', function () {
@@ -216,10 +216,7 @@ describe('Security profiles methods', function () {
   });
 
   describe('#updateProfile', function () {
-    var content = {
-      policies: [{roleId: 'foo'}],
-      foo: 'bar'
-    };
+    var policies = [{roleId: 'foo'}];
 
     beforeEach(function () {
       result = {
@@ -227,7 +224,7 @@ describe('Security profiles methods', function () {
           _id: 'foobar',
           _index: '%kuzzle',
           _type: 'profiles',
-          _source: content
+          _source: {policies: policies}
         }
       };
       expectedQuery = {
@@ -239,21 +236,21 @@ describe('Security profiles methods', function () {
     it('should send the right query to Kuzzle', function (done) {
       this.timeout(50);
 
-      kuzzle.security.updateProfile('foobar', content, function (err, res) {
+      kuzzle.security.updateProfile('foobar', policies, function (err, res) {
         should(err).be.null();
         should(res).be.instanceOf(Profile);
         done();
       });
 
       should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: content}, null, sinon.match.func);
+      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: {policies: policies}}, null, sinon.match.func);
       kuzzle.query.yield(null, result);
     });
 
     it('should send the right query to Kuzzle even without callback', function () {
-      kuzzle.security.updateProfile('foobar', content);
+      kuzzle.security.updateProfile('foobar', policies);
       should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: content}, undefined, undefined);
+      should(kuzzle.query).calledWith(expectedQuery, {_id: 'foobar', body: {policies: policies}}, undefined, undefined);
     });
 
     it('should throw an error if no id provided', function () {
@@ -264,7 +261,7 @@ describe('Security profiles methods', function () {
     it('should call the callback with an error if one occurs', function (done) {
       this.timeout(50);
 
-      kuzzle.security.updateProfile(result.result._id, {'foo': 'bar'}, function (err, res) {
+      kuzzle.security.updateProfile(result.result._id, policies, function (err, res) {
         should(err).be.exactly('foobar');
         should(res).be.undefined();
         done();


### PR DESCRIPTION
# Description

Following https://github.com/kuzzleio/sdk-android/pull/133#pullrequestreview-42261560, the `Security.createProfile` and `Security.updateProfile` methods now take a `policies` argument, which is an array of policies to apply to the corresponding profile, instead of a `content` argument, an object containing a `policies` key containing the list of policies to apply.
