### PR TITLE
Add SDK version into volatile

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -62,7 +62,7 @@ function Kuzzle (host, options, cb) {
         'queryError',
         'discarded'
       ],
-      writeable: false
+      writable: false
     },
     queuing: {
       value: false,
@@ -198,6 +198,10 @@ function Kuzzle (host, options, cb) {
       value: undefined,
       enumerable: true,
       writable: true
+    },
+    sdkVersion: {
+      value: (typeof SDKVERSION === 'undefined') ? require('../package.json').version : SDKVERSION,
+      writable: false
     }
   });
 
@@ -1436,6 +1440,8 @@ Kuzzle.prototype.query = function (queryArgs, query, options, cb) {
   if (!object.requestId) {
     object.requestId = uuid.v4();
   }
+
+  object.volatile.sdkVersion = this.sdkVersion;
 
   if (self.state === 'connected' || (options && options.queuable === false)) {
     if (self.state === 'connected') {

--- a/test/kuzzle/query.test.js
+++ b/test/kuzzle/query.test.js
@@ -5,13 +5,11 @@ var
   NetworkWrapperMock = require('../mocks/networkWrapper.mock'),
   Kuzzle = rewire('../../src/Kuzzle');
 
-
 describe('Query management', function () {
   describe('#emitRequest', function () {
     var
       emitRequest = Kuzzle.__get__('emitRequest'),
       kuzzle;
-
 
     beforeEach(function () {
       kuzzle = new Kuzzle('somewhere', {connect: 'manual'});
@@ -125,7 +123,7 @@ describe('Query management', function () {
         collection: 'collection',
         controller: 'controller',
         index: 'index',
-        volatile: {},
+        volatile: { sdkVersion: kuzzle.sdkVersion },
         requestId: sinon.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
       });
     });
@@ -141,7 +139,7 @@ describe('Query management', function () {
         collection: 'collection',
         controller: 'controller',
         index: 'index',
-        volatile: {},
+        volatile: { sdkVersion: kuzzle.sdkVersion },
         requestId: sinon.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
       }, sinon.match(function(f) {return f === cb;}));
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,8 @@ module.exports = {
     new webpack.IgnorePlugin(/ws/),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.DefinePlugin({
-      global: 'window'
+      global: 'window',
+      SDKVERSION: JSON.stringify(version)
     }),
     new webpack.BannerPlugin('Kuzzle javascript SDK version ' + version),
     new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
- Adds the current version of the SDK into volatile for every Kuzzle query.
- Modified webpack config to integrate the version at build time.