### PR TITLE
Allow paginated search using ES's search_after in SearchResult:fetchNext

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 
 ## Basic usage
 
-Follow [Kuzzle Guide](http://docs.kuzzle.io/guide/getting-started/#sdk-play-time)
+Follow [Kuzzle Guide](http://docs.kuzzle.io/guide/#sdk-play-time)
 
 ## SDK Documentation
 
@@ -36,10 +36,10 @@ https://github.com/kuzzleio/kuzzle-sdk/issues
 
 ## Protocols used
 
-The SDK Javascript implements two network protocols: raw WebSocket, and [Socket.IO](http://socket.io/)  
+The Javascript SDK implements two network protocols: raw WebSocket, and [Socket.IO](http://socket.io/)  
 The main reason behind this is that while Socket.IO offers better compatibility with older web browsers, our raw WebSocket implementation is about 20% faster
 
-What protocol is used when you connect to Kuzzle depends on multiple factors:
+Which protocol is used when you connect to Kuzzle depends on multiple factors:
 
 #### NodeJS
 
@@ -71,8 +71,8 @@ Clone this github repository and run ``npm run build``. A ``dist`` directory wil
 If you want to support older browser versions, you may load `socket.io` before Kuzzle, making the SDK compatible with browsers without websocket support:
 
 ```html
-<!-- Don't forget to include socketio before kuzzle SDK -->
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.6.0/socket.io.min.js"></script>
+<!-- Don't forget to include socketio before Kuzzle SDK -->
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.3/socket.io.slim.js"></script>
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 
 ## Basic usage
 
-Follow [Kuzzle Guide](http://docs.kuzzle.io/guide/#sdk-play-time)
+Follow [Kuzzle Guide](http://docs.kuzzle.io/guide/getting-started/#sdk-play-time)
 
 ## SDK Documentation
 

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -649,7 +649,6 @@ Collection.prototype.search = function (filters, options, cb) {
 
   query = self.kuzzle.addHeaders({body: filters}, this.headers);
 
-
   self.kuzzle.query(this.buildQueryArgs('document', 'search'), query, options, function (error, result) {
     var documents = [];
 

--- a/src/SearchResult.js
+++ b/src/SearchResult.js
@@ -71,9 +71,28 @@ function SearchResult (collection, total, documents, aggregations, options, filt
 SearchResult.prototype.fetchNext = function (cb) {
   var
     filters,
-    options = Object.assign({}, this.options);
+    options = Object.assign({}, this.options),
+    self = this;
   
   options.previous = this;
+
+  // retrieve next results using ES's search_after
+  if (options.size && this.filters.sort && options.from === undefined) {
+    if (this.fetchedDocument >= this.getTotal()) {
+      cb(null, null);
+      return;
+    }
+
+    filters = Object.assign(this.filters, {search_after: []});
+
+    filters.sort.forEach(function (sortRule) {
+      filters.search_after.push(self.documents[self.documents.length - 1].content[Object.keys(sortRule)[0]]);
+    });
+
+    this.collection.search(filters, options, cb);
+
+    return;
+  }
 
   // retrieve next results with scroll if original search use it
   if (options.scrollId) {

--- a/test/SearchResult/methods.test.js
+++ b/test/SearchResult/methods.test.js
@@ -29,6 +29,46 @@ describe('SearchResult methods', function () {
       collection.scroll = sinon.stub();
     });
 
+    it('should be able to perform a search-after request', function (done) {
+      var
+        firstSearchResult;
+
+      searchFilters = {sort: [{foo: 'asc'}]};
+
+      this.timeout(50);
+
+      collection.search = function(filters, options, cb) {
+        cb(null, new SearchResult(collection, 2, [secondDocument], {}, {size: 1}, searchFilters));
+      };
+
+      firstSearchResult = new SearchResult(collection, 2, [firstDocument], {}, {size: 1}, searchFilters);
+      firstSearchResult.fetchNext(function(error, result) {
+        should(result).be.an.instanceOf(SearchResult);
+        should(result.getDocuments()).be.an.Array();
+        should(result.getDocuments().length).be.exactly(1);
+        done();
+      });
+    });
+
+    it('should transfer error if not-able to do a search-after request', function (done) {
+      var
+        firstSearchResult;
+
+      searchFilters = {sort: [{foo: 'asc'}]};
+
+      collection.search = function(filters, options, cb) {
+        cb(new Error('foobar search'));
+      };
+
+      firstSearchResult = new SearchResult(collection, 2, [firstDocument], {}, {size: 1}, searchFilters);
+
+      firstSearchResult.fetchNext(function(error) {
+        should(error).be.an.instanceOf(Error);
+        should(error.message).be.exactly('foobar search');
+        done();
+      });
+    });
+
     it('should be able to do a scroll request', function (done) {
       var
         firstSearchResult;


### PR DESCRIPTION
## Introduces
- Way to use ES's search_after if conditions are met when calling SearchResult:fetchNext (better than using scrolls, bypasses the default search limit count)

## Related issue
https://github.com/kuzzleio/kuzzle/issues/856

## Boyscoot
- Updates README.md (typos / various)