### PR TITLE
Update to new notifications format

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -55,7 +55,7 @@ function Kuzzle (host, options, cb) {
         'networkError',
         'disconnected',
         'reconnected',
-        'jwtTokenExpired',
+        'tokenExpired',
         'loginAttempt',
         'offlineQueuePush',
         'offlineQueuePop',
@@ -273,7 +273,7 @@ function Kuzzle (host, options, cb) {
       error: {timeout: this.eventTimeout},
       disconnected: {timeout: this.eventTimeout},
       reconnected: {timeout: this.eventTimeout},
-      jwtTokenExpired: {timeout: this.eventTimeout},
+      tokenExpired: {timeout: this.eventTimeout},
       loginAttempt: {timeout: this.eventTimeout}
     },
     writeable: false
@@ -414,7 +414,7 @@ Kuzzle.prototype.connect = function () {
         // shouldn't obtain an error but let's invalidate the token anyway
         if (err || !res.valid) {
           self.jwtToken = undefined;
-          self.emitEvent('jwtTokenExpired');
+          self.emitEvent('tokenExpired');
         }
 
         reconnect();
@@ -869,7 +869,7 @@ function emitRequest (request, cb) {
 
       if (request.action !== 'logout' && response.error && response.error.message === 'Token expired') {
         self.jwtToken = undefined;
-        self.emitEvent('jwtTokenExpired', request, cb);
+        self.emitEvent('tokenExpired', request, cb);
       }
 
       if (response.error) {

--- a/src/Room.js
+++ b/src/Room.js
@@ -311,22 +311,16 @@ Room.prototype.setHeaders = function (content, replace) {
  * @returns {*}
  */
 function notificationCallback (data) {
-  if (data.error) {
-    return this.callback(data.error);
-  }
-
-  if (data.action === 'jwtTokenExpired') {
+  if (data.type === 'TokenExpired') {
     this.kuzzle.jwtToken = undefined;
-    return this.kuzzle.emitEvent('jwtTokenExpired');
+    return this.kuzzle.emitEvent('tokenExpired');
   }
 
-  if (data.controller === 'document' || (data.controller === 'realtime' && data.action === 'publish')) {
-    data.type = 'document';
+  if (data.type === 'document') {
     data.document = new Document(this.collection, data.result._id, data.result._source, data.result._meta);
     delete data.result;
   }
-  else if (data.controller === 'realtime') {
-    data.type = 'user';
+  else if (data.type === 'user') {
     data.user = {count: data.result.count};
     delete data.result;
   }

--- a/test/Room/methods.test.js
+++ b/test/Room/methods.test.js
@@ -342,18 +342,10 @@ describe('Room methods', function () {
       room.callback = sinon.stub();
     });
 
-    it('should call back with an error if query returns an error', function () {
-      notifCB.call(room, {error: 'foobar', result: {}});
-      should(room.callback)
-        .be.calledOnce()
-        .be.calledWith('foobar');
-      should(room.callback.firstCall.args)
-        .have.length(1);
-    });
-
     it('should handle document notifications', function () {
       notifCB.call(room, {
         controller: 'document',
+        type: 'document',
         result: {
           _id: 'id',
           _source: {
@@ -382,6 +374,7 @@ describe('Room methods', function () {
       notifCB.call(room, {
         controller: 'realtime',
         action: 'publish',
+        type: 'document',
         result: {
           _source: {
             foo: 'bar'
@@ -409,7 +402,8 @@ describe('Room methods', function () {
     it('should handle user notifications', function () {
       notifCB.call(room, {
         controller: 'realtime',
-        result: { count: 3 }
+        result: { count: 3 },
+        type: 'user'
       });
 
       should(room.callback)
@@ -425,7 +419,7 @@ describe('Room methods', function () {
     it('should delete the result from history if emitted by this instance', function () {
       room.subscribeToSelf = true;
       kuzzle.requestHistory.bar = {};
-      notifCB.call(room, {error: null, result: {}, action: 'foo', requestId: 'bar'});
+      notifCB.call(room, {type: 'document', result: {}, action: 'foo', requestId: 'bar'});
 
       should(room.callback)
         .be.calledOnce();
@@ -435,18 +429,18 @@ describe('Room methods', function () {
     it('should not forward the message if subscribeToSelf is false and the response comes from a query emitted by this instance', function () {
       room.subscribeToSelf = false;
       kuzzle.requestHistory.bar = {};
-      notifCB.call(room, {error: null, result: {}, requestId: 'bar', action: 'foo'});
+      notifCB.call(room, {type: 'document', result: {}, requestId: 'bar', action: 'foo'});
 
       should(room.callback).not.be.called();
       should(kuzzle.requestHistory).be.empty();
     });
 
-    it('should fire a "jwtTokenExpired" event when receiving a jwtTokenExpired notification', function () {
+    it('should fire a "tokenExpired" event when receiving a TokenExpired notification', function () {
       kuzzle.emitEvent = sinon.stub();
 
-      notifCB.call(room, {error: null, result: {}, action: 'jwtTokenExpired'});
+      notifCB.call(room, {type: 'TokenExpired'});
       should(kuzzle.emitEvent).be.calledOnce();
-      should(kuzzle.emitEvent).be.calledWith('jwtTokenExpired');
+      should(kuzzle.emitEvent).be.calledWith('tokenExpired');
     });
   });
 });

--- a/test/kuzzle/connect.test.js
+++ b/test/kuzzle/connect.test.js
@@ -303,7 +303,7 @@ describe('Kuzzle connect', function () {
     it('should empty the JWT Token if it has expired', function (done) {
       var
         kuzzle = new Kuzzle('somewhereagain', {connect: 'manual'}),
-        jwtTokenExpiredStub = sinon.stub();
+        tokenExpiredStub = sinon.stub();
 
       sinon.stub(kuzzle, 'checkToken', function (token, cb) {
         should(token).be.eql(kuzzle.jwtToken);
@@ -311,13 +311,13 @@ describe('Kuzzle connect', function () {
       });
 
       kuzzle.jwtToken = 'foobar';
-      kuzzle.addListener('jwtTokenExpired', jwtTokenExpiredStub);
+      kuzzle.addListener('tokenExpired', tokenExpiredStub);
       kuzzle.connect();
 
       process.nextTick(function () {
         should(kuzzle.state).be.exactly('connected');
         should(kuzzle.jwtToken).be.undefined();
-        should(jwtTokenExpiredStub).be.calledOnce();
+        should(tokenExpiredStub).be.calledOnce();
         done();
       });
     });

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -35,7 +35,7 @@ describe('Kuzzle listeners management', function () {
         'networkError',
         'disconnected',
         'reconnected',
-        'jwtTokenExpired',
+        'tokenExpired',
         'loginAttempt',
         'offlineQueuePush',
         'offlineQueuePop',

--- a/test/kuzzle/query.test.js
+++ b/test/kuzzle/query.test.js
@@ -29,19 +29,19 @@ describe('Query management', function () {
       should(kuzzle.requestHistory.bar).be.within(start, Date.now());
     });
 
-    it('should fire a jwtTokenExpired event if the token has expired', function (done) {
+    it('should trigger a tokenExpired event if the token has expired', function (done) {
       var
-        jwtTokenExpiredStub = sinon.stub(),
+        tokenExpiredStub = sinon.stub(),
         response = {
           error: {
             message: 'Token expired'
           }
         };
 
-      kuzzle.addListener('jwtTokenExpired', jwtTokenExpiredStub);
+      kuzzle.addListener('tokenExpired', tokenExpiredStub);
 
       emitRequest.call(kuzzle, {requestId: 'foobar', response: response}, function(error) {
-        should(jwtTokenExpiredStub).be.calledOnce();
+        should(tokenExpiredStub).be.calledOnce();
         should(error.message).be.exactly('Token expired');
         done();
       });


### PR DESCRIPTION
# Description

Following https://github.com/kuzzleio/kuzzle/pull/882, the SDK JS gets an update to make it able to handle the new notifications format.

Also, the `jwtTokenExpired` event has been renamed `tokenExpired`.
