### PR TITLE
Fix uuid API

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -1,5 +1,5 @@
 var
-  uuid = require('uuid'),
+  uuidv4 = require('uuid/v4'),
   KuzzleEventEmitter = require('./eventEmitter'),
   Collection = require('./Collection.js'),
   Security = require('./security/Security'),
@@ -704,7 +704,7 @@ Kuzzle.prototype.logout = function (cb) {
     request = {
       action: 'logout',
       controller: 'auth',
-      requestId: uuid.v4(),
+      requestId: uuidv4(),
       body: {}
     };
 
@@ -1438,7 +1438,7 @@ Kuzzle.prototype.query = function (queryArgs, query, options, cb) {
   }
 
   if (!object.requestId) {
-    object.requestId = uuid.v4();
+    object.requestId = uuidv4();
   }
 
   object.volatile.sdkVersion = this.sdkVersion;

--- a/src/Room.js
+++ b/src/Room.js
@@ -1,5 +1,5 @@
 var
-  uuid = require('uuid'),
+  uuidv4 = require('uuid/v4'),
   Document = require('./Document');
 
 /**
@@ -36,7 +36,7 @@ function Room(collection, options) {
       writable: true
     },
     id: {
-      value: uuid.v4()
+      value: uuidv4()
     },
     lastRenewal: {
       value: null,


### PR DESCRIPTION
replace deprecated syntax:
```javascript
var
  uuid = require('uuid'),
  generatedUuid = uuid.v4();
```

by new one:
```javascript
var
  uuidv4 = require('uuid/v4'),
  generatedUuid = uuidv4();
```

(see https://www.npmjs.com/package/uuid#deprecated--browser-ready-api)
