### PR TITLE
Remove cleanHistory from event loop upon disconnection

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -42,6 +42,10 @@ function Kuzzle (host, options, cb) {
 
   Object.defineProperties(this, {
     // 'private' properties
+    cleanHistoryTimer: {
+      value: null,
+      writable: true
+    },
     collections: {
       value: {},
       writable: true
@@ -289,7 +293,7 @@ function Kuzzle (host, options, cb) {
     this.state = 'ready';
   }
 
-  cleanHistory(this.requestHistory);
+  this.cleanHistoryTimer = setInterval(function () { cleanHistory(self.requestHistory); }, 1000);
 
   if (this.bluebird) {
     return this.bluebird.promisifyAll(this, {
@@ -847,10 +851,6 @@ function cleanHistory (requestHistory) {
       delete requestHistory[key];
     }
   });
-
-  setTimeout(function () {
-    cleanHistory(requestHistory);
-  }, 1000);
 }
 
 /**
@@ -1162,6 +1162,7 @@ Kuzzle.prototype.listIndexes = function (options, cb) {
 Kuzzle.prototype.disconnect = function () {
   var collection;
 
+  clearInterval(this.cleanHistoryTimer);
   this.state = 'disconnected';
   this.network.close();
   this.network = null;

--- a/test/kuzzle/query.test.js
+++ b/test/kuzzle/query.test.js
@@ -381,19 +381,32 @@ describe('Query management', function () {
 
   describe('#cleanHistory', function () {
     it('should be started by kuzzle constructor', function () {
-      var cleanStub = sinon.stub();
+      var 
+        cleanStub = sinon.stub(),
+        clock = sinon.useFakeTimers(),
+        kuzzle;
 
+      // we need to re-import so that fake timers can take effect
+      Kuzzle = rewire('../../src/Kuzzle');
       Kuzzle.__set__('cleanHistory', cleanStub);
-      new Kuzzle('foo', {connect: 'manual'});
+      kuzzle = new Kuzzle('foo', {connect: 'manual'});
 
+      clock.tick(1000);
+
+      should(kuzzle.cleanHistoryTimer).be.not.null();
       should(cleanStub.calledOnce).be.true();
+
+      clock.restore();
     });
 
     it('should clean oldest entries every 1s', function () {
       var
         i,
         clock = sinon.useFakeTimers(),
-        kuzzle = new Kuzzle('foo', {connect: 'manual'});
+        kuzzle;
+
+      Kuzzle = rewire('../../src/Kuzzle');
+      kuzzle = new Kuzzle('foo', {connect: 'manual'});
 
       for (i = 100000; i >= 0; i -= 10000) {
         kuzzle.requestHistory[i] = -i;


### PR DESCRIPTION
# Description

While invoking `kuzzle.disconnect()` correctly closes the network connection and prepare Kuzzle so that nothing stay on the event loop, the clean history timer still runs indefinitely.

This means that, without using `process.exit`, it is impossible to make a program stop when a Kuzzle instance is created.

This PR adds a property keeping track of the history timer, and makes the disconnect method remove the timer, leaving nothing on the event loop after been called