### PR TITLE
Throw when using Nodejs version in browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,4 +5,12 @@ var
 // Adds on the fly methods promisification
 Kuzzle.prototype.bluebird = bluebird;
 
+if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
+  /* eslint-disable no-console */
+  console.warn('It looks like you are using the Nodejs version of Kuzzle SDK ' +
+               'in a browser. ' +
+               'It is strongly recommended to use the browser-specific build instead. ' +
+               'Learn more at https://github.com/kuzzleio/sdk-javascript/tree/master#javascript');
+}
+
 module.exports = Kuzzle;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
   console.warn('It looks like you are using the Nodejs version of Kuzzle SDK ' +
                'in a browser. ' +
                'It is strongly recommended to use the browser-specific build instead. ' +
-               'Learn more at https://github.com/kuzzleio/sdk-javascript/tree/master#javascript');
+               'Learn more at https://github.com/kuzzleio/sdk-javascript/tree/master#browser');
 }
 
 module.exports = Kuzzle;

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ var
 Kuzzle.prototype.bluebird = bluebird;
 
 if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
-  /* eslint-disable no-console */
-  console.warn('It looks like you are using the Nodejs version of Kuzzle SDK ' +
+  throw new Error('It looks like you are using the Nodejs version of Kuzzle SDK ' +
                'in a browser. ' +
                'It is strongly recommended to use the browser-specific build instead. ' +
                'Learn more at https://github.com/kuzzleio/sdk-javascript/tree/master#browser');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,8 @@ module.exports = {
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.DefinePlugin({
       global: 'window',
-      SDKVERSION: JSON.stringify(version)
+      SDKVERSION: JSON.stringify(version),
+      BUILT: true
     }),
     new webpack.BannerPlugin('Kuzzle javascript SDK version ' + version),
     new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
By injecting a `BUILT` constant via Webpack, and by checking the `window` global, we are able to detect if the user is using the Nodejs version in the browser. 