### PR TITLE
Fix exposed object properties

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2015 Kaliop SAS
+   Copyright 2015-2017 Kuzzle
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -43,12 +43,6 @@ function Collection(kuzzle, collection, index) {
     kuzzle: {
       value: kuzzle,
       enumerable: true
-    },
-    // writable properties
-    headers: {
-      value: JSON.parse(JSON.stringify(kuzzle.headers)),
-      enumerable: true,
-      writable: true
     }
   });
 
@@ -67,7 +61,7 @@ function Collection(kuzzle, collection, index) {
     return this.kuzzle.bluebird.promisifyAll(this, {
       suffix: 'Promise',
       filter: function (name, func, target, passes) {
-        var blacklist = ['setHeaders', 'subscribe'];
+        var blacklist = ['subscribe'];
 
         return passes && blacklist.indexOf(name) === -1;
       }
@@ -89,8 +83,7 @@ function Collection(kuzzle, collection, index) {
  * @param {responseCallback} cb - Handles the query response
  */
 Collection.prototype.count = function (filters, options, cb) {
-  var
-    query;
+  var query = {body: filters};
 
   if (!cb && typeof options === 'function') {
     cb = options;
@@ -98,8 +91,6 @@ Collection.prototype.count = function (filters, options, cb) {
   }
 
   this.kuzzle.callbackRequired('Collection.count', cb);
-
-  query = this.kuzzle.addHeaders({body: filters}, this.headers);
 
   this.kuzzle.query(this.buildQueryArgs('document', 'count'), query, options, function (err, res) {
     cb(err, err ? undefined : res.result.count);
@@ -124,7 +115,6 @@ Collection.prototype.create = function (options, cb) {
     options = null;
   }
 
-  data = this.kuzzle.addHeaders(data, this.headers);
   this.kuzzle.query(this.buildQueryArgs('collection', 'create'), data, options, function(err) {
     cb(err, err ? undefined : self);
   });
@@ -186,8 +176,6 @@ Collection.prototype.createDocument = function (id, document, options, cb) {
     data._id = id;
   }
 
-  data = self.kuzzle.addHeaders(data, self.headers);
-
   self.kuzzle.query(this.buildQueryArgs('document', action), data, options, cb && function (err, res) {
     var doc;
 
@@ -237,8 +225,6 @@ Collection.prototype.deleteDocument = function (arg, options, cb) {
     options = null;
   }
 
-  data = this.kuzzle.addHeaders(data, this.headers);
-
   this.kuzzle.query(this.buildQueryArgs('document', action), data, options, cb && function (err, res) {
     if (err) {
       cb(err);
@@ -267,8 +253,6 @@ Collection.prototype.deleteSpecifications = function (options, cb) {
     cb = options;
     options = null;
   }
-
-  data = self.kuzzle.addHeaders(data, this.headers);
 
   self.kuzzle.query(this.buildQueryArgs('collection', 'deleteSpecifications'), data, options, function (err, res) {
     cb(err, err ? undefined : res.result);
@@ -319,7 +303,6 @@ Collection.prototype.fetchDocument = function (documentId, options, cb) {
   }
 
   self.kuzzle.callbackRequired('Collection.fetch', cb);
-  data = self.kuzzle.addHeaders(data, this.headers);
 
   self.kuzzle.query(this.buildQueryArgs('document', 'get'), data, options, function (err, res) {
     var document;
@@ -383,8 +366,6 @@ Collection.prototype.mCreateDocument = function (documents, options, cb) {
     return (doc instanceof Document) ? doc.serialize() : doc;
   });
 
-  data = self.kuzzle.addHeaders(data, this.headers);
-
   self.kuzzle.query(this.buildQueryArgs('document', 'mCreate'), data, options, cb && function (err, res) {
     cb(err, err ? undefined : res.result);
   });
@@ -421,8 +402,6 @@ Collection.prototype.mCreateOrReplaceDocument = function (documents, options, cb
     return (doc instanceof Document) ? doc.serialize() : doc;
   });
 
-  data = self.kuzzle.addHeaders(data, this.headers);
-
   self.kuzzle.query(this.buildQueryArgs('document', 'mCreateOrReplace'), data, options, cb && function (err, res) {
     cb(err, err ? undefined : res.result);
   });
@@ -457,8 +436,6 @@ Collection.prototype.mDeleteDocument = function (documentIds, options, cb) {
 
   self.kuzzle.callbackRequired('Collection.mDelete', cb);
 
-  data = self.kuzzle.addHeaders(data, this.headers);
-
   self.kuzzle.query(this.buildQueryArgs('document', 'mDelete'), data, options, cb && function (err, res) {
     cb(err, err ? undefined : res.result);
   });
@@ -491,8 +468,6 @@ Collection.prototype.mGetDocument = function (documentIds, options, cb) {
   }
 
   self.kuzzle.callbackRequired('Collection.mGet', cb);
-
-  data = self.kuzzle.addHeaders(data, this.headers);
 
   self.kuzzle.query(this.buildQueryArgs('document', 'mGet'), data, options, cb && function (err, res) {
     cb(err, err ? undefined : res.result);
@@ -527,8 +502,6 @@ Collection.prototype.mReplaceDocument = function (documents, options, cb) {
   data.body.documents = documents.map(function (doc) {
     return (doc instanceof Document) ? doc.serialize() : doc;
   });
-
-  data = self.kuzzle.addHeaders(data, this.headers);
 
   self.kuzzle.query(this.buildQueryArgs('document', 'mReplace'), data, options, cb && function (err, res) {
     cb(err, err ? undefined : res.result);
@@ -566,8 +539,6 @@ Collection.prototype.mUpdateDocument = function (documents, options, cb) {
     return (doc instanceof Document) ? doc.serialize() : doc;
   });
 
-  data = self.kuzzle.addHeaders(data, this.headers);
-
   self.kuzzle.query(this.buildQueryArgs('document', 'mUpdate'), data, options, cb && function (err, res) {
     cb(err, err ? undefined : res.result);
   });
@@ -592,7 +563,6 @@ Collection.prototype.getSpecifications = function (options, cb) {
   }
 
   self.kuzzle.callbackRequired('Collection.getSpecifications', cb);
-  data = self.kuzzle.addHeaders(data, this.headers);
 
   self.kuzzle.query(this.buildQueryArgs('collection', 'getSpecifications'), data, options, function (err, res) {
     cb(err, err ? undefined : res.result);
@@ -620,7 +590,6 @@ Collection.prototype.publishMessage = function (document, options, cb) {
     data.body = document;
   }
 
-  data = this.kuzzle.addHeaders(data, this.headers);
   this.kuzzle.query(this.buildQueryArgs('realtime', 'publish'), data, options, cb);
 
   return this;
@@ -652,8 +621,6 @@ Collection.prototype.replaceDocument = function (documentId, content, options, c
     options = null;
   }
 
-  data = self.kuzzle.addHeaders(data, this.headers);
-
   self.kuzzle.query(this.buildQueryArgs('document', 'createOrReplace'), data, options, cb && function (err, res) {
     var document;
 
@@ -683,7 +650,7 @@ Collection.prototype.replaceDocument = function (documentId, content, options, c
 
 Collection.prototype.search = function (filters, options, cb) {
   var
-    query,
+    query = {body: filters},
     self = this;
 
   if (!cb && typeof options === 'function') {
@@ -692,8 +659,6 @@ Collection.prototype.search = function (filters, options, cb) {
   }
 
   self.kuzzle.callbackRequired('Collection.search', cb);
-
-  query = self.kuzzle.addHeaders({body: filters}, this.headers);
 
   self.kuzzle.query(this.buildQueryArgs('document', 'search'), query, options, function (error, result) {
     var documents = [];
@@ -817,7 +782,7 @@ Collection.prototype.scrollSpecifications = function (scrollId, options, cb) {
 
   this.kuzzle.query(
     { controller: 'collection', action: 'scrollSpecifications'},
-    this.kuzzle.addHeaders(data, this.headers),
+    data,
     options,
     function (err, res) {
       cb (err, err ? undefined : res.result);
@@ -843,8 +808,6 @@ Collection.prototype.searchSpecifications = function (filters, options, cb) {
   }
 
   self.kuzzle.callbackRequired('Collection.searchSpecifications', cb);
-
-  data = self.kuzzle.addHeaders(data, this.headers);
 
   self.kuzzle.query({ controller: 'collection', action: 'searchSpecifications' }, data, options, function (err, res) {
     cb(err, err ? undefined : res.result);
@@ -907,7 +870,6 @@ Collection.prototype.truncate = function (options, cb) {
     options = null;
   }
 
-  data = this.kuzzle.addHeaders(data, this.headers);
   this.kuzzle.query(this.buildQueryArgs('collection', 'truncate'), data, options, cb);
 
   return this;
@@ -943,8 +905,6 @@ Collection.prototype.updateDocument = function (documentId, content, options, cb
     data.retryOnConflict = options.retryOnConflict;
   }
 
-  data = self.kuzzle.addHeaders(data, this.headers);
-
   self.kuzzle.query(this.buildQueryArgs('document', 'update'), data, options, cb && function (err, res) {
     if (err) {
       return cb(err);
@@ -978,8 +938,6 @@ Collection.prototype.updateSpecifications = function (specifications, options, c
     options = null;
   }
 
-  data = self.kuzzle.addHeaders(data, this.headers);
-
   self.kuzzle.query(this.buildQueryArgs('collection', 'updateSpecifications'), data, options, cb && function (err, res) {
     cb(err, err ? undefined : res.result);
   });
@@ -1009,7 +967,6 @@ Collection.prototype.validateSpecifications = function (specifications, options,
   }
 
   self.kuzzle.callbackRequired('Collection.validateSpecifications', cb);
-  data = self.kuzzle.addHeaders(data, this.headers);
 
   self.kuzzle.query(this.buildQueryArgs('collection', 'validateSpecifications'), data, options, function (err, res) {
     cb(err, err ? undefined : res.result.valid);
@@ -1037,20 +994,6 @@ Collection.prototype.document = function (id, content) {
  */
 Collection.prototype.collectionMapping = function (mapping) {
   return new CollectionMapping(this, mapping);
-};
-
-/**
- * Helper function allowing to set headers while chaining calls.
- *
- * If the replace argument is set to true, replace the current headers with the provided content.
- * Otherwise, it appends the content to the current headers, only replacing already existing values
- *
- * @param content - new headers content
- * @param [replace] - default: false = append the content. If true: replace the current headers with tj
- */
-Collection.prototype.setHeaders = function (content, replace) {
-  this.kuzzle.setHeaders.call(this, content, replace);
-  return this;
 };
 
 module.exports = Collection;

--- a/src/CollectionMapping.js
+++ b/src/CollectionMapping.js
@@ -31,11 +31,6 @@ function CollectionMapping(collection, mapping) {
       enumerable: true
     },
     // writable properties
-    headers: {
-      value: JSON.parse(JSON.stringify(collection.headers)),
-      enumerable: true,
-      writable: true
-    },
     mapping: {
       value: mapping || {},
       enumerable: true,
@@ -47,7 +42,7 @@ function CollectionMapping(collection, mapping) {
     return this.kuzzle.bluebird.promisifyAll(this, {
       suffix: 'Promise',
       filter: function (name, func, target, passes) {
-        var blacklist = ['set', 'setHeaders'];
+        var blacklist = ['set'];
 
         return passes && blacklist.indexOf(name) === -1;
       }
@@ -66,7 +61,11 @@ function CollectionMapping(collection, mapping) {
 CollectionMapping.prototype.apply = function (options, cb) {
   var
     self = this,
-    data = this.kuzzle.addHeaders({body: {properties: this.mapping}}, this.headers);
+    data = {
+      body: {
+        properties: this.mapping
+      }
+    };
 
   if (!cb && typeof options === 'function') {
     cb = options;
@@ -96,7 +95,7 @@ CollectionMapping.prototype.apply = function (options, cb) {
 CollectionMapping.prototype.refresh = function (options, cb) {
   var
     self = this,
-    data = this.kuzzle.addHeaders({}, this.headers);
+    data = {};
 
   if (!cb && typeof options === 'function') {
     cb = options;
@@ -144,20 +143,6 @@ CollectionMapping.prototype.refresh = function (options, cb) {
 CollectionMapping.prototype.set = function (field, mapping) {
   this.mapping[field] = mapping;
 
-  return this;
-};
-
-/**
- * Helper function allowing to set headers while chaining calls.
- *
- * If the replace argument is set to true, replace the current headers with the provided content.
- * Otherwise, it appends the content to the current headers, only replacing already existing values
- *
- * @param content - new headers content
- * @param [replace] - default: false = append the content. If true: replace the current headers with tj
- */
-CollectionMapping.prototype.setHeaders = function (content, replace) {
-  this.kuzzle.setHeaders.call(this, content, replace);
   return this;
 };
 

--- a/src/Document.js
+++ b/src/Document.js
@@ -47,11 +47,6 @@ function Document(collection, documentId, content, meta) {
       writable: true,
       enumerable: true
     },
-    headers: {
-      value: JSON.parse(JSON.stringify(collection.headers)),
-      enumerable: true,
-      writable: true
-    },
     version: {
       value: undefined,
       enumerable: true,
@@ -119,7 +114,6 @@ Document.prototype.serialize = function () {
 
   data.body = this.content;
   data.meta = this.meta;
-  data = this.kuzzle.addHeaders(data, this.headers);
 
   return data;
 };
@@ -326,20 +320,5 @@ Document.prototype.subscribe = function (options, cb) {
 
   return this.dataCollection.subscribe(filters, options, cb);
 };
-
-/**
- * Helper function allowing to set headers while chaining calls.
- *
- * If the replace argument is set to true, replace the current headers with the provided content.
- * Otherwise, it appends the content to the current headers, only replacing already existing values
- *
- * @param content - new headers content
- * @param [replace] - default: false = append the content. If true: replace the current headers with tj
- */
-Document.prototype.setHeaders = function (content, replace) {
-  this.kuzzle.setHeaders.call(this, content, replace);
-  return this;
-};
-
 
 module.exports = Document;

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -233,6 +233,129 @@ function Kuzzle (host, options, cb) {
 
   this.network = networkWrapper(this.protocol, host, options);
 
+  // Properties related to the network layer
+  // Accessing a property irrelevant for a given protocol
+  // (e.g. "autoReconnect" for the HTTP layer) should
+  // throw an exception
+  Object.defineProperties(this, {
+    autoQueue: {
+      enumerable: true,
+      get: function() {
+        return self.network.autoQueue;
+      },
+      set: function(value) {
+        checkPropertyType('autoQueue', 'boolean', value);
+        self.network.autoQueue = value;
+      }
+    },
+    autoReconnect: {
+      enumerable: true,
+      get: function() {
+        return self.network.autoReconnect;
+      }
+    },
+    autoReplay: {
+      enumerable: true,
+      get: function() {
+        return self.network.autoReplay;
+      },
+      set: function(value) {
+        checkPropertyType('autoReplay', 'boolean', value);
+        self.network.autoReplay = value;
+      }
+    },
+    host: {
+      enumerable: true,
+      get: function() {
+        return self.network.host;
+      }
+    },
+    offlineQueue: {
+      enumerable: true,
+      get: function() {
+        return self.network.offlineQueue;
+      },
+      set: function(value) {
+        checkPropertyType('offlineQueue', 'array', value);
+        self.network.offlineQueue = value;
+      }
+    },
+    offlineQueueLoader: {
+      enumerable: true,
+      get: function() {
+        return self.network.offlineQueueLoader;
+      },
+      set: function(value) {
+        if (value !== null) {
+          checkPropertyType('offlineQueueLoader', 'function', value);
+        }
+        self.network.offlineQueueLoader = value;
+      }
+    },
+    port: {
+      enumerable: true,
+      get: function() {
+        return self.network.port;
+      }
+    },
+    queueFilter: {
+      enumerable: true,
+      get: function() {
+        return self.network.queueFilter;
+      },
+      set: function(value) {
+        if (typeof value !== 'function') {
+          throw new Error('Can only assign a function to the "queueFilter" property');
+        }
+        self.network.queueFilter = value;
+      }
+    },
+    queueMaxSize: {
+      enumerable: true,
+      get: function() {
+        return self.network.queueMaxSize;
+      },
+      set: function(value) {
+        checkPropertyType('queueMaxSize', 'number', value);
+        self.network.queueMaxSize = value;
+      }
+    },
+    queueTTL: {
+      enumerable: true,
+      get: function() {
+        return self.network.queueTTL;
+      },
+      set: function(value) {
+        checkPropertyType('queueTTL', 'number', value);
+        self.network.queueTTL = value;
+      }
+    },
+    replayInterval: {
+      enumerable: true,
+      get: function() {
+        return self.network.replayInterval;
+      },
+      set: function(value) {
+        if (!Number.isInteger(value)) {
+          throw new Error('Invalid value "' + value + '" assigned to the "replayInterval" property');
+        }
+        self.network.replayInterval = value;
+      }
+    },
+    reconnectionDelay: {
+      enumerable: true,
+      get: function() {
+        return self.network.reconnectionDelay;
+      }
+    },
+    sslConnection: {
+      eumerable: true,
+      get: function() {
+        return self.network.ssl;
+      }
+    }
+  });
+
   this.network.addListener('offlineQueuePush', function(data) {
     self.emitEvent('offlineQueuePush', data);
   });
@@ -1261,5 +1384,13 @@ Kuzzle.prototype.setHeaders = function (content, replace) {
 
   return self;
 };
+
+function checkPropertyType(prop, typestr, value) {
+  var wrongType = typestr === 'array' ? !Array.isArray(value) : typeof value !== typestr;
+
+  if (wrongType) {
+    throw new Error('Can only assign a ' + typestr + ' value to property "' + prop + '"');
+  }
+}
 
 module.exports = Kuzzle;

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -70,11 +70,6 @@ function Kuzzle (host, options, cb) {
       writable: true,
       enumerable: true
     },
-    headers: {
-      value: {},
-      enumerable: true,
-      writable: true
-    },
     jwt: {
       value: undefined,
       enumerable: true,
@@ -102,19 +97,6 @@ function Kuzzle (host, options, cb) {
     });
   }
 
-  // Helper function copying headers to the query data
-  Object.defineProperty(this, 'addHeaders', {
-    value: function (query, headers) {
-      Object.keys(headers).forEach(function (header) {
-        if (!query[header]) {
-          query[header] = headers[header];
-        }
-      });
-
-      return query;
-    }
-  });
-
   // Forward the subscribe query to the network wrapper
   Object.defineProperty(this, 'subscribe', {
     value: function(room, opts, subscribeCB) {
@@ -125,7 +107,6 @@ function Kuzzle (host, options, cb) {
           action: 'subscribe',
           index: room.collection.index,
           collection: room.collection.collection,
-          headers: room.headers,
           volatile: this.volatile,
           body: room.filters,
           scope: room.scope,
@@ -149,8 +130,6 @@ function Kuzzle (host, options, cb) {
 
       Object.assign(object.volatile, room.volatile, {sdkVersion: this.sdkVersion});
 
-      object = this.addHeaders(object, this.headers);
-
       this.network.subscribe(object, opts, notificationCB, subscribeCB);
     }
   });
@@ -164,7 +143,6 @@ function Kuzzle (host, options, cb) {
           controller: 'realtime',
           action: 'unsubscribe',
           volatile: this.volatile,
-          headers: room.headers,
           body: {roomId: room.roomId}
         };
 
@@ -179,8 +157,6 @@ function Kuzzle (host, options, cb) {
         });
       }
       object.volatile.sdkVersion = this.sdkVersion;
-
-      object = this.addHeaders(object, this.headers);
 
       this.network.unsubscribe(object, opts, room.channel, unsubscribeCB);
     }
@@ -1279,8 +1255,6 @@ Kuzzle.prototype.query = function (queryArgs, query, options, cb) {
     }
   }
 
-  object = this.addHeaders(object, this.headers);
-
   /*
    * Do not add the token for the checkToken route, to avoid getting a token error when
    * a developer simply wish to verify his token
@@ -1356,33 +1330,6 @@ Kuzzle.prototype.setDefaultIndex = function (index) {
   this.defaultIndex = index;
 
   return this;
-};
-
-/**
- * Helper function allowing to set headers while chaining calls.
- *
- * If the replace argument is set to true, replace the current headers with the provided content.
- * Otherwise, it appends the content to the current headers, only replacing already existing values
- *
- * @param content - new headers content
- * @param [replace] - default: false = append the content. If true: replace the current headers with tj
- */
-Kuzzle.prototype.setHeaders = function (content, replace) {
-  var self = this;
-
-  if (typeof content !== 'object' || Array.isArray(content)) {
-    throw new Error('Expected a content object, received a ' + typeof content);
-  }
-
-  if (replace) {
-    self.headers = content;
-  } else {
-    Object.keys(content).forEach(function (key) {
-      self.headers[key] = content[key];
-    });
-  }
-
-  return self;
 };
 
 function checkPropertyType(prop, typestr, value) {

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -250,10 +250,6 @@ function Kuzzle (host, options, cb) {
       enumerable: true,
       get: function() {
         return self.network.offlineQueue;
-      },
-      set: function(value) {
-        checkPropertyType('offlineQueue', 'array', value);
-        self.network.offlineQueue = value;
       }
     },
     offlineQueueLoader: {
@@ -312,9 +308,7 @@ function Kuzzle (host, options, cb) {
         return self.network.replayInterval;
       },
       set: function(value) {
-        if (!Number.isInteger(value)) {
-          throw new Error('Invalid value "' + value + '" assigned to the "replayInterval" property');
-        }
+        checkPropertyType('replayInterval', 'number', value);
         self.network.replayInterval = value;
       }
     },

--- a/src/MemoryStorage.js
+++ b/src/MemoryStorage.js
@@ -196,22 +196,14 @@ function MemoryStorage(kuzzle) {
     kuzzle: {
       value: kuzzle,
       enumerable: true
-    },
-    // writable properties
-    headers: {
-      value: JSON.parse(JSON.stringify(kuzzle.headers)),
-      enumerable: true,
-      writable: true
     }
   });
-
-  this.setHeaders = kuzzle.setHeaders.bind(this);
 
   if (this.kuzzle.bluebird) {
     return this.kuzzle.bluebird.promisifyAll(this, {
       suffix: 'Promise',
       filter: function (name, func, target, passes) {
-        var blacklist = ['setHeaders'];
+        var blacklist = [];
 
         return passes && blacklist.indexOf(name) === -1;
       }

--- a/src/Room.js
+++ b/src/Room.js
@@ -77,12 +77,6 @@ class Room extends KuzzleEventEmitter {
         value: filters ? filters : {},
         enumerable: true,
       },
-      // writable properties
-      headers: {
-        value: JSON.parse(JSON.stringify(collection.headers)),
-        enumerable: true,
-        writable: true
-      },
       roomId: {
         enumerable: true,
         get: () => _roomId,
@@ -92,6 +86,7 @@ class Room extends KuzzleEventEmitter {
           }
         }
       },
+      // writable properties
       volatile: {
         value: (options && options.volatile) ? options.volatile : {},
         enumerable: true,
@@ -128,7 +123,7 @@ class Room extends KuzzleEventEmitter {
   count(cb) {
     this.kuzzle.callbackRequired('Room.count', cb);
 
-    const data = this.kuzzle.addHeaders({body: {roomId: this.roomId}}, this.headers);
+    const data = {body: {roomId: this.roomId}};
 
     if (this.subscribing) {
       this.queue.push({action: 'count', args: [cb]});
@@ -295,20 +290,6 @@ class Room extends KuzzleEventEmitter {
     if (!data.fromSelf || this.subscribeToSelf) {
       this.emit(data.type, data);
     }
-    return this;
-  }
-
-  /**
-   * Helper function allowing to set headers while chaining calls.
-   *
-   * If the replace argument is set to true, replace the current headers with the provided content.
-   * Otherwise, it appends the content to the current headers, only replacing already existing values
-   *
-   * @param content - new headers content
-   * @param [replace] - default: false = append the content. If true: replace the current headers with tj
-   */
-  setHeaders(content, replace) {
-    this.kuzzle.setHeaders.call(this, content, replace);
     return this;
   }
 

--- a/src/networkWrapper/protocols/abstract/realtime.js
+++ b/src/networkWrapper/protocols/abstract/realtime.js
@@ -15,32 +15,27 @@ class RTWrapper extends KuzzleEventEmitter {
       },
       host: {
         value: host,
-        writable: false,
         enumerable: true
       },
       port: {
         value: (options && typeof options.port === 'number') ? options.port : 7512,
-        enumerable: true,
-        writable: false
+        enumerable: true
       },
       ssl: {
         value: (options && typeof options.sslConnection === 'boolean') ? options.sslConnection : false,
-        writable: true,
-        enumerable: false
+        enumerable: true
       },
       queuing: {
         value: false,
         writable: true
       },
+      reconnectionDelay: {
+        value: (options && typeof options.reconnectionDelay === 'number') ? options.reconnectionDelay : 1000,
+        enumerable: true
+      },
       // configuration properties
       autoReconnect: {
         value: (options && typeof options.autoReconnect === 'boolean') ? options.autoReconnect : true,
-        writable: true,
-        enumerable: true
-      },
-      reconnectionDelay: {
-        value: (options && typeof options.reconnectionDelay === 'number') ? options.reconnectionDelay : 1000,
-        writable: true,
         enumerable: true
       },
       autoQueue: {

--- a/test/Collection/constructor.test.js
+++ b/test/Collection/constructor.test.js
@@ -12,22 +12,15 @@ describe('Collection constructor', function () {
       collectionName = 'foobar',
       c;
 
-    kuzzle.headers.some = 'headers';
     c = new Collection(kuzzle, collectionName, index);
-
-    // the collection "headers" should be a hard copy of the kuzzle ones
-    kuzzle.headers = { someother: 'headers' };
 
     should(c).be.instanceof(Collection);
     should(c).have.propertyWithDescriptor('index', { enumerable: true, writable: false, configurable: false });
     should(c).have.propertyWithDescriptor('collection', { enumerable: true, writable: false, configurable: false });
     should(c).have.propertyWithDescriptor('kuzzle', { enumerable: true, writable: false, configurable: false });
-    should(c).have.propertyWithDescriptor('headers', { enumerable: true, writable: true, configurable: false });
     should(c.index).be.exactly(index);
     should(c.collection).be.exactly(collectionName);
     should(c.kuzzle).be.exactly(kuzzle);
-    should(c.headers.some).be.exactly('headers');
-    should(c.headers.someother).be.undefined();
   });
 
   it('should promisify the right functions', function () {
@@ -58,24 +51,11 @@ describe('Collection constructor', function () {
     should.exist(collection.replaceDocumentPromise);
     should.exist(collection.scrollSpecificationsPromise);
     should.exist(collection.searchSpecificationsPromise);
-    should.not.exist(collection.setHeadersPromise);
     should.not.exist(collection.subscribePromise);
     should.exist(collection.truncatePromise);
     should.exist(collection.updateDocumentPromise);
     should.exist(collection.updateSpecificationsPromise);
     should.exist(collection.validateSpecificationsPromise);
-  });
-
-  it('should set headers using setHeaders', function () {
-    var
-      kuzzle = new Kuzzle('foo', {connect: 'manual'}),
-      collection = new Collection(kuzzle, 'foo', 'bar');
-
-    collection.setHeaders({foo: 'bar'}, true);
-    should(collection.headers).match({foo: 'bar'});
-
-    collection.setHeaders({bar: 'foobar'}, false);
-    should(collection.headers).match({foo: 'bar', bar: 'foobar'});
   });
 
   it('should throw an error if no collection or no index is provided', function () {

--- a/test/CollectionMapping/constructor.test.js
+++ b/test/CollectionMapping/constructor.test.js
@@ -30,18 +30,7 @@ describe('CollectionMapping constructor', function () {
   it('should expose documented properties with the right permissions', function () {
     var mapping = new CollectionMapping(collection);
 
-    should(mapping).have.propertyWithDescriptor('headers', { enumerable: true, writable: true, configurable: false });
     should(mapping).have.propertyWithDescriptor('mapping', { enumerable: true, writable: true, configurable: false });
-  });
-
-  it('should initialize headers coming from the provided data collection object', function () {
-    var
-      headers = {foo: 'bar'},
-      mapping;
-
-    collection.headers = headers;
-    mapping = new CollectionMapping(collection);
-    should(mapping.headers).match(headers);
   });
 
   it('should promisify the right functions', function () {
@@ -54,6 +43,5 @@ describe('CollectionMapping constructor', function () {
     should.exist(mapping.applyPromise);
     should.exist(mapping.refreshPromise);
     should.not.exist(mapping.setPromise);
-    should.not.exist(mapping.setHeadersPromise);
   });
 });

--- a/test/CollectionMapping/methods.test.js
+++ b/test/CollectionMapping/methods.test.js
@@ -43,13 +43,6 @@ describe('CollectionMapping methods', function () {
 
       should(kuzzle.query).be.calledOnce();
       should(kuzzle.query).calledWith(expectedQuery, {body: content}, options, sinon.match.func);
-
-      kuzzle.query.reset();
-      mapping.headers = {foohead: 'barhead'};
-      mapping.apply(options, sinon.stub());
-
-      should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).calledWith(expectedQuery, {body: content, foohead: 'barhead'}, options, sinon.match.func);
     });
 
     it('should call refresh() method when invoked', function (done) {
@@ -222,17 +215,6 @@ describe('CollectionMapping methods', function () {
 
       mapping.set('foo', {type: 'string'});
       should(mapping.mapping.bar).match({type: 'string'});
-    });
-  });
-
-  describe('#setHeaders', function () {
-    it('should allow setting headers', function () {
-      var
-        mapping = new CollectionMapping(collection),
-        header = {foohead: 'barhead'};
-
-      should(mapping.setHeaders(header)).be.exactly(mapping);
-      should(mapping.headers).match(header);
     });
   });
 });

--- a/test/Document/constructor.test.js
+++ b/test/Document/constructor.test.js
@@ -60,7 +60,6 @@ describe('Document constructor', function () {
 
     should(document).have.propertyWithDescriptor('collection', { enumerable: true, writable: false, configurable: false });
     should(document).have.propertyWithDescriptor('content', { enumerable: true, writable: true, configurable: false });
-    should(document).have.propertyWithDescriptor('headers', { enumerable: true, writable: true, configurable: false });
     should(document).have.propertyWithDescriptor('id', { enumerable: true, writable: true, configurable: false });
     should(document).have.propertyWithDescriptor('version', { enumerable: true, writable: true, configurable: false });
     should(document).have.propertyWithDescriptor('meta', { enumerable: true, writable: false, configurable: false });
@@ -75,7 +74,6 @@ describe('Document constructor', function () {
     should.exist(document.refreshPromise);
     should.exist(document.savePromise);
     should.not.exist(document.setContentPromise);
-    should.not.exist(document.setHeadersPromise);
     should.not.exist(document.subscribePromise);
   });
 });

--- a/test/Document/methods.test.js
+++ b/test/Document/methods.test.js
@@ -453,15 +453,4 @@ describe('Document methods', function () {
       should(collection.subscribe).not.be.called();
     });
   });
-
-  describe('#setHeaders', function () {
-    it('should properly set headers', function () {
-      var
-        document = new Document(collection),
-        header = {_id: 'foobar'};
-
-      should(document.setHeaders(header)).be.exactly(document);
-      should(document.headers).match(header);
-    });
-  });
 });

--- a/test/MemoryStorage/constructor.test.js
+++ b/test/MemoryStorage/constructor.test.js
@@ -10,17 +10,10 @@ describe('MemoryStorage constructor', function () {
       kuzzle = new Kuzzle('foo', {connect: 'manual'}),
       ms;
 
-    kuzzle.headers.some = 'headers';
     ms = new MemoryStorage(kuzzle);
-
-    // the collection "headers" should be a hard copy of the kuzzle ones
-    kuzzle.headers = { someother: 'headers' };
 
     should(ms).be.an.instanceOf(MemoryStorage);
     should(ms).have.propertyWithDescriptor('kuzzle', {enumerable: true, writable: false, configurable: false});
-    should(ms).have.propertyWithDescriptor('headers', {enumerable: true, writable: true, configurable: false});
-    should(ms.headers.some).be.exactly('headers');
-    should(ms.headers.someother).be.undefined();
   });
 
   it('should promisify all methods', function () {
@@ -35,7 +28,7 @@ describe('MemoryStorage constructor', function () {
     ms = new MemoryStorage(kuzzle);
 
     functions = Object.getOwnPropertyNames(Object.getPrototypeOf(ms)).filter(function (p) {
-      return (typeof ms[p] === 'function' && ['constructor', 'setHeaders'].indexOf(p) === -1);
+      return typeof ms[p] === 'function' && p !== 'constructor';
     });
 
     should(functions.length).be.eql(117);
@@ -45,18 +38,6 @@ describe('MemoryStorage constructor', function () {
     });
 
     delete Kuzzle.prototype.bluebird;
-  });
-
-  it('should set headers using setHeaders', function () {
-    var
-      kuzzle = new Kuzzle('foo', {connect: 'manual'}),
-      ms = new MemoryStorage(kuzzle);
-
-    ms.setHeaders({foo: 'bar'}, true);
-    should(ms.headers).match({foo: 'bar'});
-
-    ms.setHeaders({bar: 'foobar'}, false);
-    should(ms.headers).match({foo: 'bar', bar: 'foobar'});
   });
 
   it('auto-generated functions should throw if the wrong number of parameters is provided', function () {

--- a/test/Room/constructor.test.js
+++ b/test/Room/constructor.test.js
@@ -12,7 +12,6 @@ describe('Room constructor', function () {
 
   beforeEach(function () {
     kuzzle = new KuzzleMock();
-    kuzzle.headers = {foo: 'bar'};
     kuzzle.autoResubscribe = true;
     collection = new CollectionMock(kuzzle);
   });
@@ -28,7 +27,6 @@ describe('Room constructor', function () {
     should(room.users).be.exactly('none');
     should(room.collection).be.exactly(collection);
     should(room.filters).match({equals: {foo: 'bar'}});
-    should(room.headers).match({foo: 'bar'});
     should(room.roomId).be.null();
 
 
@@ -60,7 +58,6 @@ describe('Room constructor', function () {
     should(room).have.propertyWithDescriptor('autoResubscribe', {enumerable: true});
     should(room).have.propertyWithDescriptor('collection', {enumerable: true});
     should(room).have.propertyWithDescriptor('filters', {enumerable: true, writable: false});
-    should(room).have.propertyWithDescriptor('headers', {enumerable: true, writable: true});
     should(room).have.propertyWithDescriptor('scope', {enumerable: true});
     should(room).have.propertyWithDescriptor('state', {enumerable: true});
     should(room).have.propertyWithDescriptor('users', {enumerable: true});
@@ -79,7 +76,6 @@ describe('Room constructor', function () {
     should.exist(room.onDonePromise);
     should.not.exist(room.notifyPromise);
     should.exist(room.renewPromise);
-    should.not.exist(room.setHeadersPromise);
     should.exist(room.subscribePromise);
     should.exist(room.unsubscribePromise);
   });

--- a/test/Room/constructor.test.js
+++ b/test/Room/constructor.test.js
@@ -57,19 +57,16 @@ describe('Room constructor', function () {
   it('should expose documented properties with the right permissions', function () {
     var room = new Room(collection, {equals: {foo: 'bar'}});
 
-    should(room).have.propertyWithDescriptor('collection', {enumerable: true, writable: false, configurable: false});
-    should(room).have.propertyWithDescriptor('filters', {enumerable: true, writable: false, configurable: false});
-    should(room).have.propertyWithDescriptor('headers', {enumerable: true, writable: true, configurable: false});
-    should(room).have.propertyWithDescriptor('scope', {enumerable: false, writable: false, configurable: false});
-    should(room).have.propertyWithDescriptor('state', {enumerable: false, writable: false, configurable: false});
-    should(room).have.propertyWithDescriptor('users', {enumerable: false, writable: false, configurable: false});
-    should(room).have.propertyWithDescriptor('volatile', {enumerable: true, writable: true, configurable: false});
-    should(room).have.propertyWithDescriptor('subscribeToSelf', {
-      enumerable: true,
-      writable: true,
-      configurable: false
-    });
-    should(room).have.propertyWithDescriptor('roomId', {enumerable: true, writable: true, configurable: false});
+    should(room).have.propertyWithDescriptor('autoResubscribe', {enumerable: true});
+    should(room).have.propertyWithDescriptor('collection', {enumerable: true});
+    should(room).have.propertyWithDescriptor('filters', {enumerable: true, writable: false});
+    should(room).have.propertyWithDescriptor('headers', {enumerable: true, writable: true});
+    should(room).have.propertyWithDescriptor('scope', {enumerable: true});
+    should(room).have.propertyWithDescriptor('state', {enumerable: true});
+    should(room).have.propertyWithDescriptor('users', {enumerable: true});
+    should(room).have.propertyWithDescriptor('volatile', {enumerable: true, writable: true});
+    should(room).have.propertyWithDescriptor('subscribeToSelf', {enumerable: true, writable: true});
+    should(room).have.propertyWithDescriptor('roomId', {enumerable: true});
   });
 
   it('should promisify the right functions', function () {

--- a/test/Room/methods.test.js
+++ b/test/Room/methods.test.js
@@ -293,13 +293,6 @@ describe('Room methods', function () {
     });
   });
 
-  describe('#setHeaders', function () {
-    it('should set headers properly', function () {
-      should(room.setHeaders({foo: 'bar'})).be.exactly(room);
-      should(room.headers).match({foo: 'bar'});
-    });
-  });
-
   describe('#subscribe', function() {
     var
       revert,

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -94,12 +94,6 @@ describe('Kuzzle constructor', function () {
     should(kuzzle).have.propertyWithDescriptor('defaultIndex', { enumerable: true, writable: true, configurable: false });
     should(kuzzle).have.propertyWithDescriptor('jwt', { enumerable: true, writable: true, configurable: false });
 
-    should(kuzzle).have.propertyWithDescriptor('offlineQueue', { enumerable: true});
-    should(kuzzle.offlineQueue).be.an.Array().and.be.empty();
-    kuzzle.offlineQueue = ['foo', 'bar'];
-    should(kuzzle.offlineQueue).be.eql(['foo', 'bar']);
-    should(function() {kuzzle.offlineQueue = {};}).throw();
-
     should(kuzzle).have.propertyWithDescriptor('offlineQueueLoader', { enumerable: true});
     should(kuzzle.offlineQueueLoader).be.null();
     kuzzle.offlineQueueLoader = fn;
@@ -165,6 +159,12 @@ describe('Kuzzle constructor', function () {
     kuzzle.reconnectionDelay = 123;
     should(kuzzle.reconnectionDelay).be.eql(1000);
 
+
+    should(kuzzle).have.propertyWithDescriptor('offlineQueue', { enumerable: true});
+    should(kuzzle.offlineQueue).be.an.Array().and.be.empty();
+    kuzzle.offlineQueue = ['foo', 'bar'];
+    should(kuzzle.offlineQueue).be.an.Array().and.be.empty();
+    
     should(kuzzle).have.propertyWithDescriptor('sdkVersion', { enumerable: false, writable: false, configurable: false });
   });
 

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -62,7 +62,6 @@ describe('Kuzzle constructor', function () {
     should(kuzzle.removeListener).be.a.Function();
     should(kuzzle.setAutoRefresh).be.a.Function();
     should(kuzzle.setDefaultIndex).be.a.Function();
-    should(kuzzle.setHeaders).be.a.Function();
     should(kuzzle.setJwt).be.a.Function();
     should(kuzzle.startQueuing).be.a.Function();
     should(kuzzle.stopQueuing).be.a.Function();
@@ -93,7 +92,6 @@ describe('Kuzzle constructor', function () {
     should(function() {kuzzle.autoReplay = 123;}).throw();
 
     should(kuzzle).have.propertyWithDescriptor('defaultIndex', { enumerable: true, writable: true, configurable: false });
-    should(kuzzle).have.propertyWithDescriptor('headers', { enumerable: true, writable: true, configurable: false });
     should(kuzzle).have.propertyWithDescriptor('jwt', { enumerable: true, writable: true, configurable: false });
 
     should(kuzzle).have.propertyWithDescriptor('offlineQueue', { enumerable: true});
@@ -173,7 +171,6 @@ describe('Kuzzle constructor', function () {
   it('should have right internal properties and methods', function () {
     var kuzzle = new Kuzzle('somewhere');
 
-    should(kuzzle.addHeaders).be.a.Function();
     should(kuzzle.callbackRequired).be.a.Function();
     should(kuzzle.subscribe).be.a.Function();
     should(kuzzle.unsubscribe).be.a.Function();
@@ -192,7 +189,6 @@ describe('Kuzzle constructor', function () {
 
     should(kuzzle.autoResubscribe).be.true();
     should(kuzzle.defaultIndex).be.undefined();
-    should(kuzzle.headers).be.an.Object().and.be.empty();
     should(kuzzle.jwt).be.undefined();
     should(kuzzle.protocol).be.exactly('websocket');
     should(kuzzle.sdkVersion).be.exactly(sdkVersion);
@@ -239,7 +235,6 @@ describe('Kuzzle constructor', function () {
         options = {
           autoResubscribe: false,
           protocol: 'fakeproto',
-          headers: {foo: 'bar'},
           volatile: {foo: ['bar', 'baz', 'qux'], bar: 'foo'},
           defaultIndex: 'foobar',
           jwt: 'fakejwt',
@@ -249,7 +244,6 @@ describe('Kuzzle constructor', function () {
 
       should(kuzzle.autoResubscribe).be.false();
       should(kuzzle.defaultIndex).be.exactly('foobar');
-      should(kuzzle.headers).be.an.Object().and.match(options.headers);
       should(kuzzle.jwt).be.exactly('fakejwt');
       should(kuzzle.protocol).be.exactly('fakeproto');
       should(kuzzle.sdkVersion).be.exactly(sdkVersion);
@@ -326,7 +320,6 @@ describe('Kuzzle constructor', function () {
     should(kuzzle.removeListenerPromise).be.undefined();
     should(kuzzle.setAutoRefreshPromise).be.a.Function();
     should(kuzzle.setDefaultIndexPromise).be.undefined();
-    should(kuzzle.setHeadersPromise).be.undefined();
     should(kuzzle.setJwtPromise).be.undefined();
     should(kuzzle.startQueuingPromise).be.undefined();
     should(kuzzle.stopQueuingPromise).be.undefined();

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -73,16 +73,101 @@ describe('Kuzzle constructor', function () {
     should(kuzzle.whoAmI).be.a.Function();
   });
 
-  it('should expose the documented properties', function () {
-    var kuzzle = new Kuzzle('somewhere');
+  it('should expose the documented writable properties', function () {
+    var 
+      kuzzle = new Kuzzle('somewhere'),
+      fn = function() {};
 
-    should(kuzzle).have.propertyWithDescriptor('autoResubscribe', { enumerable: true, writable: false, configurable: false });
+    // there is no way to simply test the presence of a getter or a setter
+    // we have to manually make sure that the value can be changed
+    should(kuzzle).have.propertyWithDescriptor('autoQueue', { enumerable: true});
+    should(kuzzle.autoQueue).be.eql(false);
+    kuzzle.autoQueue = true;
+    should(kuzzle.autoQueue).be.true();
+    should(function() {kuzzle.autoQueue = 123;}).throw();
+
+    should(kuzzle).have.propertyWithDescriptor('autoReplay', { enumerable: true});
+    should(kuzzle.autoReplay).be.eql(false);
+    kuzzle.autoReplay = true;
+    should(kuzzle.autoReplay).be.true();
+    should(function() {kuzzle.autoReplay = 123;}).throw();
+
     should(kuzzle).have.propertyWithDescriptor('defaultIndex', { enumerable: true, writable: true, configurable: false });
     should(kuzzle).have.propertyWithDescriptor('headers', { enumerable: true, writable: true, configurable: false });
     should(kuzzle).have.propertyWithDescriptor('jwt', { enumerable: true, writable: true, configurable: false });
-    should(kuzzle).have.propertyWithDescriptor('protocol', { enumerable: true, writable: false, configurable: false });
-    should(kuzzle).have.propertyWithDescriptor('sdkVersion', { enumerable: false, writable: false, configurable: false });
+
+    should(kuzzle).have.propertyWithDescriptor('offlineQueue', { enumerable: true});
+    should(kuzzle.offlineQueue).be.an.Array().and.be.empty();
+    kuzzle.offlineQueue = ['foo', 'bar'];
+    should(kuzzle.offlineQueue).be.eql(['foo', 'bar']);
+    should(function() {kuzzle.offlineQueue = {};}).throw();
+
+    should(kuzzle).have.propertyWithDescriptor('offlineQueueLoader', { enumerable: true});
+    should(kuzzle.offlineQueueLoader).be.null();
+    kuzzle.offlineQueueLoader = fn;
+    should(kuzzle.offlineQueueLoader).be.eql(fn);
+    // special case: should be able to unset this property by providing a null value
+    kuzzle.offlineQueueLoader = null;
+    should(kuzzle.offlineQueueLoader).be.null();
+    should(function() {kuzzle.offlineQueueLoader = 123;}).throw();
+
+    should(kuzzle).have.propertyWithDescriptor('queueMaxSize', { enumerable: true });
+    should(kuzzle.queueMaxSize).be.eql(500);
+    kuzzle.queueMaxSize = 123;
+    should(kuzzle.queueMaxSize).be.eql(123);
+    should(function() {kuzzle.queueMaxSize = 'foobar';}).throw();
+
+    should(kuzzle).have.propertyWithDescriptor('queueTTL', { enumerable: true });
+    should(kuzzle.queueTTL).be.eql(120000);
+    kuzzle.queueTTL = 123;
+    should(kuzzle.queueTTL).be.eql(123);
+    should(function() {kuzzle.queueTTL = 'foobar';}).throw();
+    
+    should(kuzzle).have.propertyWithDescriptor('replayInterval', { enumerable: true });
+    should(kuzzle.replayInterval).be.eql(10);
+    kuzzle.replayInterval = 123;
+    should(kuzzle.replayInterval).be.eql(123);
+    should(function() {kuzzle.replayInterval = 'foobar';}).throw();
+
     should(kuzzle).have.propertyWithDescriptor('volatile', { enumerable: true, writable: true, configurable: false });
+  });
+
+  it('should expose the documented read-only properties', function () {
+    var kuzzle = new Kuzzle('somewhere');
+
+    // there is no way to simply test the presence of a getter or a setter
+    // we have to manually make sure that the value cannot be changed
+    should(kuzzle).have.propertyWithDescriptor('autoReconnect', { enumerable: true });
+    should(kuzzle.autoReconnect).be.true();
+    kuzzle.autoReconnect = false;
+    should(kuzzle.autoReconnect).be.true();
+
+    should(kuzzle).have.propertyWithDescriptor('autoResubscribe', { enumerable: true });
+    should(kuzzle.autoResubscribe).be.true();
+    kuzzle.autoResubscribe = false;
+    should(kuzzle.autoResubscribe).be.true();
+
+    should(kuzzle).have.propertyWithDescriptor('host', { enumerable: true });
+    should(kuzzle.host).be.eql('somewhere');
+    kuzzle.host = 'foobar';
+    should(kuzzle.host).be.eql('somewhere');
+
+    should(kuzzle).have.propertyWithDescriptor('port', { enumerable: true });
+    should(kuzzle.port).be.eql(7512);
+    kuzzle.port = 123;
+    should(kuzzle.port).be.eql(7512);
+
+    should(kuzzle).have.propertyWithDescriptor('protocol', { enumerable: true });
+    should(kuzzle.protocol).be.eql('websocket');
+    kuzzle.protocol = 'foobar';
+    should(kuzzle.protocol).be.eql('websocket');
+
+    should(kuzzle).have.propertyWithDescriptor('reconnectionDelay', { enumerable: true });
+    should(kuzzle.reconnectionDelay).be.eql(1000);
+    kuzzle.reconnectionDelay = 123;
+    should(kuzzle.reconnectionDelay).be.eql(1000);
+
+    should(kuzzle).have.propertyWithDescriptor('sdkVersion', { enumerable: false, writable: false, configurable: false });
   });
 
   it('should have right internal properties and methods', function () {

--- a/test/kuzzle/methods.test.js
+++ b/test/kuzzle/methods.test.js
@@ -936,34 +936,6 @@ describe('Kuzzle methods', function () {
     });
   });
 
-  describe('#setHeaders', function () {
-    it('should throw an error if an invalid content object is provided', function () {
-      should(function () { kuzzle.setHeaders(); }).throw(Error);
-      should(function () { kuzzle.setHeaders(123); }).throw(Error);
-      should(function () { kuzzle.setHeaders('foo'); }).throw(Error);
-      should(function () { kuzzle.setHeaders(['mama', 'mia']); }).throw(Error);
-    });
-
-    it('should set headers properly', function () {
-      should(kuzzle.setHeaders({foo: 'bar'})).be.exactly(kuzzle);
-      kuzzle.setHeaders({bar: 'baz', baz: ['bar, baz, qux', 'foo']});
-      kuzzle.setHeaders({foo: { bar: 'baz'}});
-
-      should(kuzzle.headers).match({bar: 'baz', baz: ['bar, baz, qux', 'foo'], foo: { bar: 'baz'}});
-    });
-
-    it('should replace existing headers if asked to', function () {
-      kuzzle.setHeaders({foo: 'bar'});
-
-      kuzzle.setHeaders({bar: 'foo'}, true);
-      should(kuzzle.headers).match({bar: 'foo'});
-      should(kuzzle.headers).not.match({foo: 'bar'});
-
-      kuzzle.setHeaders({}, true);
-      should(kuzzle.headers).be.empty();
-    });
-  });
-
   describe('#setJwt', function () {
     var loginAttemptStub = sinon.stub();
 

--- a/test/kuzzle/query.test.js
+++ b/test/kuzzle/query.test.js
@@ -157,13 +157,6 @@ describe('Kuzzle query management', function () {
       should(kuzzle.network.query).be.calledWithMatch({scrollId: 'foo'});
     });
 
-    it('should add global headers without overwriting any existing query headers', function () {
-      kuzzle.headers = { foo: 'bar', bar: 'foo' };
-      kuzzle.query(queryArgs, { foo: 'foo', body: {some: 'query'}});
-      should(kuzzle.network.query).be.calledOnce();
-      should(kuzzle.network.query).be.calledWithMatch({foo: 'foo', bar: 'foo'});
-    });
-
     it('should not generate a new request ID if one is already defined', function () {
       kuzzle.query(queryArgs, { body: { some: 'query'}, requestId: 'foobar'});
       should(kuzzle.network.query).be.calledOnce();

--- a/test/kuzzle/subscribe.test.js
+++ b/test/kuzzle/subscribe.test.js
@@ -62,14 +62,6 @@ describe('Kuzzle subscription management', function () {
       should(kuzzle.network.subscribe).be.calledWithMatch({volatile: room.volatile});
     });
 
-    it('should add global headers without overwriting any existing query headers', function () {
-      kuzzle.headers = {scope: 'none', foo: 'bar'};
-      kuzzle.subscribe(room, {}, cb);
-
-      should(kuzzle.network.subscribe).be.calledOnce();
-      should(kuzzle.network.subscribe).be.calledWithMatch({scope: 'all', foo: 'bar'});
-    });
-
     it('should set jwt if present', function () {
       kuzzle.jwt = 'fake-token';
       kuzzle.subscribe(room, {}, cb);
@@ -110,14 +102,6 @@ describe('Kuzzle subscription management', function () {
 
       should(kuzzle.network.unsubscribe).be.calledOnce();
       should(kuzzle.network.unsubscribe).be.calledWithMatch({volatile: room.volatile});
-    });
-
-    it('should add global headers without overwriting any existing query headers', function () {
-      kuzzle.headers = {body: {roomId: 'none'}, foo: 'bar'};
-      kuzzle.unsubscribe(room, {}, cb);
-
-      should(kuzzle.network.unsubscribe).be.calledOnce();
-      should(kuzzle.network.unsubscribe).be.calledWithMatch({body: {roomId: 'roomId'}, foo: 'bar'});
     });
 
     it('should set jwt if present', function () {

--- a/test/mocks/collection.mock.js
+++ b/test/mocks/collection.mock.js
@@ -6,7 +6,6 @@ function CollectionMock (kuzzle) {
   this.kuzzle = kuzzle;
   this.collection = 'foo';
   this.index = 'bar';
-  this.headers = kuzzle.headers || {};
 
   Object.defineProperty(this, 'buildQueryArgs', {
     value: function (controller, action) {

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -7,21 +7,11 @@ var
  * @constructor
  */
 function KuzzleMock () {
-  this.headers = {};
   this.network = new NetworkWrapperMock();
 
   this.query = sinon.stub();
   this.subscribe = sinon.stub();
   this.unsubscribe = sinon.stub();
-
-  this.addHeaders = function(query, headers) {
-    Object.keys(headers).forEach(function (header) {
-      if (!query[header]) {
-        query[header] = headers[header];
-      }
-    });
-    return query;
-  };
 
   this.callbackRequired = function (errorMessagePrefix, callback) {
     if (!callback || typeof callback !== 'function') {
@@ -33,19 +23,4 @@ function KuzzleMock () {
 KuzzleMock.prototype = new (require('events'))();
 KuzzleMock.prototype.constructor = KuzzleMock;
 
-KuzzleMock.prototype.setHeaders = function (content, replace) {
-  var self = this;
-
-  if (replace) {
-    self.headers = content;
-  } else {
-    Object.keys(content).forEach(function (key) {
-      self.headers[key] = content[key];
-    });
-  }
-
-  return self;
-};
-
 module.exports = KuzzleMock;
-

--- a/test/network/socketio.test.js
+++ b/test/network/socketio.test.js
@@ -70,8 +70,8 @@ describe('SocketIO network wrapper', function () {
 
       socketIO = new SocketIO('address', {
         port: 1234,
-        autoReconnect: 'autoReconnectValue',
-        reconnectionDelay: 'reconnectionDelayValue'
+        autoReconnect: false,
+        reconnectionDelay: 1234
       });
       socketIO.socket = socketStub;
 
@@ -98,20 +98,27 @@ describe('SocketIO network wrapper', function () {
       socketIO.connect();
       should(window.io).be.calledOnce();
       should(window.io).be.calledWithMatch('http://address:1234', {
-        reconnection: 'autoReconnectValue',
-        reconnectionDelay: 'reconnectionDelayValue',
+        reconnection: false,
+        reconnectionDelay: 1234,
         forceNew: true
       });
     });
 
     it('should connect with the secure connection', function () {
-      socketIO.ssl = true;
+      socketIO = new SocketIO('address', {
+        port: 1234,
+        autoReconnect: false,
+        reconnectionDelay: 1234,
+        sslConnection: true
+      });
+      socketIO.socket = socketStub;
+
       socketIO.connect();
-      should(window.io.calledWithMatch('https://address:1234', {
-        reconnection: 'autoReconnectValue',
-        reconnectionDelay: 'reconnectionDelayValue',
+      should(window.io).be.calledWithMatch('https://address:1234', {
+        reconnection: false,
+        reconnectionDelay: 1234,
         forceNew: true
-      })).be.true();
+      });
     });
 
     it('should call listeners on connect event', function () {

--- a/test/network/websocket.test.js
+++ b/test/network/websocket.test.js
@@ -25,8 +25,8 @@ describe('WebSocket networking module', function () {
 
     websocket = new WS('address', {
       port: 1234,
-      autoReconnect: 'autoReconnectValue',
-      reconnectionDelay: 'reconnectionDelayValue'
+      autoReconnect: true,
+      reconnectionDelay: 10
     });
   });
 
@@ -60,7 +60,12 @@ describe('WebSocket networking module', function () {
 
   it('should initialize a WS secure connection', function () {
     clientStub.on = sinon.stub();
-    websocket.ssl = true;
+    websocket = new WS('address', {
+      port: 1234,
+      autoReconnect: false,
+      reconnectionDelay: 1234,
+      sslConnection: true
+    });
     websocket.connect();
     should(wsargs).match(['wss://address:1234']);
   });
@@ -152,7 +157,7 @@ describe('WebSocket networking module', function () {
     websocket.addListener('networkError', cb);
     should(websocket.listeners('networkError').length).be.eql(1);
 
-    websocket.connect(true, 10);
+    websocket.connect();
     websocket.connect = sinon.stub();
     clientStub.onerror();
     should(websocket.retrying).be.true();
@@ -166,8 +171,12 @@ describe('WebSocket networking module', function () {
   it('should not try to reconnect on a connection error with autoReconnect = false', function () {
     var cb = sinon.stub();
 
-    websocket.autoReconnect = false;
-    websocket.reconnectionDelay = 10;
+    websocket = new WS('address', {
+      port: 1234,
+      autoReconnect: false,
+      reconnectionDelay: 10
+    });
+
     websocket.retrying = false;
     websocket.addListener('networkError', cb);
     should(websocket.listeners('networkError').length).be.eql(1);


### PR DESCRIPTION
# Description

- expose the missing object properties expected by the current SDK specifications, with the right read/write attributes
  - kuzzle object:
    - autoQueue (writable)
    - autoReconnect (changed to read-only)
    - autoReplay (writable)
    - host (read-only)
    - offlineQueue (changed to read-only)
    - offlineQueueLoader (writable)
    - port (read-only)
    - queueFilter (writable)
    - queueMaxSize (writable)
    - queueTTL (writable)
    - replayInterval (writable)
    - reconnectionDelay (changed to read-only)
    - sslConnection (read-only)
  - `Room` object: 
    - `roomId` is now a read-only property, and is not used as an internal flag to check if a subscription is active. Instead, a new private `active` boolean property has been added for that purpose
    - `scope`, `state` and `users` are now enumerable
    - `autoResubscribe` is now read-only, as is the same property from the Kuzzle main object
- remove the now obsolete `headers` property from all objects
