### PR TITLE
add the addOnceListener event emitter method

### DIFF
--- a/src/eventEmitter/index.js
+++ b/src/eventEmitter/index.js
@@ -55,7 +55,7 @@ if (typeof window === 'undefined') {
     return this;
   };
 
-  KuzzleEventEmitter.prototype.once = function(eventName, listener) {
+  KuzzleEventEmitter.prototype.addOnceListener = function(eventName, listener) {
     var onceListeners;
 
     if (!eventName || !listener) {
@@ -69,6 +69,7 @@ if (typeof window === 'undefined') {
 
     return this;
   };
+  KuzzleEventEmitter.prototype.once = KuzzleEventEmitter.prototype.addOnceListener;
 
   KuzzleEventEmitter.prototype.prependOnceListener = function(eventName, listener) {
     var onceListeners;


### PR DESCRIPTION
After thinking about the event emitter specifications and what we are planning for our SDK in other languages, I took the following decision (checked with @ballinette and @jenow ):

* a new `addOnceListener` (not part of nodejs event emitter class) method has been added. This allows `once` to have a counterpart following the standard `xxxListener` naming convention of the rest of the emitter API
* the `on` and `once` methods in Javascript are now aliases to `addListener` and `addOnceListener`, respectively
* `on` and `once` are only proposed in the Javascript SDK because it is commonplace to offer these methods for event listeners, but they aren't part of our official SDK specifications. Only `addListener` and `addOnceListener` are required to be implemented, and other languages won't offer aliases
