### PR TITLE
add `stopTime` as optional argument for `getStatistics()`

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -858,29 +858,42 @@ Kuzzle.prototype.getAllStatistics = function (options, cb) {
  * Kuzzle monitors active connections, and ongoing/completed/failed requests.
  * This method allows getting either the last statistics frame, or a set of frames starting from a provided timestamp.
  *
- * @param {number} timestamp -  Epoch time. Starting time from which the frames are to be retrieved
+ * @param {number} startTime -  Epoch time. Starting time from which the frames are to be retrieved
+ * @param {number} stopTime -  Epoch time. End time from which the frames are to be retrieved
  * @param {object} [options] - Optional parameters
  * @param {responseCallback} cb - Handles the query response
  */
-Kuzzle.prototype.getStatistics = function (timestamp, options, cb) {
+Kuzzle.prototype.getStatistics = function (startTime, stopTime, options, cb) {
   var
     queryCB,
     body;
 
   if (!cb) {
-    if (arguments.length === 1) {
-      cb = arguments[0];
-      options = null;
-      timestamp = null;
-    } else {
-      cb = arguments[1];
-      if (typeof arguments[0] === 'object') {
-        options = arguments[0];
-        timestamp = null;
-      } else {
-        timestamp = arguments[0];
+    switch (arguments.length) {
+      case 1:
+        cb = arguments[0];
+        startTime = null;
+        stopTime = null;
         options = null;
-      }
+        break;
+      case 2:
+        cb = arguments[1];
+        stopTime = null;
+        if (typeof arguments[0] === 'object') {
+          options = arguments[0];
+          startTime = null;
+        }
+        break;
+      case 3:
+        cb = arguments[2];
+        options = null;
+        if (typeof arguments[1] === 'object') {
+          options = arguments[1];
+          stopTime = null;
+        }
+        break;
+      default:
+        throw new Error('Bad arguments list. Usage: kuzzle.getStatistics([startTime,] [stopTime,] [options,] callback)');
     }
   }
 
@@ -889,13 +902,16 @@ Kuzzle.prototype.getStatistics = function (timestamp, options, cb) {
       return cb(err);
     }
 
-    cb(null, timestamp ? res.result.hits : [res.result]);
+    cb(null, startTime ? res.result.hits : [res.result]);
   };
 
   this.callbackRequired('Kuzzle.getStatistics', cb);
 
-  body = timestamp ? {body: {startTime: timestamp}} : {};
-  this.query({controller: 'server', action: timestamp ? 'getStats' : 'getLastStats'}, body, options, queryCB);
+  if (startTime) {
+    body = stopTime ? {startTime, stopTime} : {startTime};
+  }
+
+  this.query({controller: 'server', action: startTime ? 'getStats' : 'getLastStats'}, body, options, queryCB);
 };
 
 /**

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -866,7 +866,7 @@ Kuzzle.prototype.getAllStatistics = function (options, cb) {
 Kuzzle.prototype.getStatistics = function (startTime, stopTime, options, cb) {
   var
     queryCB,
-    body;
+    query = {};
 
   if (!cb) {
     switch (arguments.length) {
@@ -908,10 +908,10 @@ Kuzzle.prototype.getStatistics = function (startTime, stopTime, options, cb) {
   this.callbackRequired('Kuzzle.getStatistics', cb);
 
   if (startTime) {
-    body = stopTime ? {startTime, stopTime} : {startTime};
+    query = stopTime ? {startTime, stopTime} : {startTime};
   }
 
-  this.query({controller: 'server', action: startTime ? 'getStats' : 'getLastStats'}, body, options, queryCB);
+  this.query({controller: 'server', action: startTime ? 'getStats' : 'getLastStats'}, query, options, queryCB);
 };
 
 /**

--- a/test/kuzzle/methods.test.js
+++ b/test/kuzzle/methods.test.js
@@ -598,7 +598,7 @@ describe('Kuzzle methods', function () {
 
       kuzzle.getStatistics(123, options, cb);
       should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).be.calledWith(expectedQuery, {body: {startTime: 123 }}, options);
+      should(kuzzle.query).be.calledWith(expectedQuery, {startTime: 123 }, options);
       should(cb).be.calledOnce();
       should(cb).be.calledWithExactly(null, hits);
     });
@@ -620,7 +620,7 @@ describe('Kuzzle methods', function () {
 
       kuzzle.getStatistics(123, 456, options, cb);
       should(kuzzle.query).be.calledOnce();
-      should(kuzzle.query).be.calledWith(expectedQuery, {body: {startTime: 123, stopTime: 456 }}, options);
+      should(kuzzle.query).be.calledWith(expectedQuery, {startTime: 123, stopTime: 456 }, options);
       should(cb).be.calledOnce();
       should(cb).be.calledWithExactly(null, hits);
     });

--- a/test/kuzzle/methods.test.js
+++ b/test/kuzzle/methods.test.js
@@ -603,6 +603,28 @@ describe('Kuzzle methods', function () {
       should(cb).be.calledWithExactly(null, hits);
     });
 
+    it('should return statistics frames starting from the given start timestamp to the given stop timestamp', function () {
+      var hits = [
+          {123: {}},
+          {456: {}},
+          {789: {}}
+        ],
+        cb = sinon.stub(),
+        options = {queuable: true, volatile: {foo: 'bar'}},
+        expectedQuery = {
+          controller: 'server',
+          action: 'getStats'
+        };
+
+      result = {result: {hits: hits}};
+
+      kuzzle.getStatistics(123, 456, options, cb);
+      should(kuzzle.query).be.calledOnce();
+      should(kuzzle.query).be.calledWith(expectedQuery, {body: {startTime: 123, stopTime: 456 }}, options);
+      should(cb).be.calledOnce();
+      should(cb).be.calledWithExactly(null, hits);
+    });
+
     it('should execute the provided callback with an error argument if one occurs', function () {
       var cb = sinon.stub();
 


### PR DESCRIPTION
As [getStats](http://docs.kuzzle.io/api-documentation/controller-server/get-stats/) API method accept both a `startTime` and a `stopTime` arguments, we should also accept a `stopTime` parameter in the SDK

Fix https://github.com/kuzzleio/kuzzle-sdk/issues/63
