### PR TITLE
Allow passing a custom network object to Kuzzle SDK constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
-var
-  bluebird = require('bluebird'),
-  Kuzzle = require('./src/Kuzzle');
-
-// Adds on the fly methods promisification
-Kuzzle.prototype.bluebird = bluebird;
+const
+  Kuzzle = require('./src/Kuzzle'),
+  KuzzleAbstractNetwork = require('./src/networkWrapper/protocols/abstract/common');
 
 if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
   throw new Error('It looks like you are using the Nodejs version of Kuzzle SDK ' +
@@ -12,4 +9,4 @@ if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
                'Learn more at https://github.com/kuzzleio/sdk-javascript/tree/master#browser');
 }
 
-module.exports = Kuzzle;
+module.exports = {Kuzzle, KuzzleAbstractNetwork};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const
   Kuzzle = require('./src/Kuzzle'),
-  KuzzleAbstractNetwork = require('./src/networkWrapper/protocols/abstract/common');
+  KuzzleAbstractNetwork = require('./src/networkWrapper/protocols/abstract/common'),
+  KuzzleEventEmitter = require('./src/eventEmitter');
 
 if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
   throw new Error('It looks like you are using the Nodejs version of Kuzzle SDK ' +
@@ -9,4 +10,4 @@ if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
                'Learn more at https://github.com/kuzzleio/sdk-javascript/tree/master#browser');
 }
 
-module.exports = {Kuzzle, KuzzleAbstractNetwork};
+module.exports = {Kuzzle, KuzzleAbstractNetwork, KuzzleEventEmitter};

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -29,15 +29,25 @@ const
 class Kuzzle extends KuzzleEventEmitter {
 
   /**
-   * @param host - Server name or IP Address to the Kuzzle instance
+   * @param network - the network wrapper to use. if the argument is a string, creates an embeed network wrapper if a
    * @param [options] - Connection options
    */
-  constructor(host, options = {}) {
+  constructor(network, options = {}) {
     super();
 
-    if (!host || host === '') {
-      throw new Error('host argument missing');
+    /* Verify if `network` param exists and implements required methods */
+    if (network === undefined || network === null) {
+      throw new Error('"network" argument missing');
     }
+    if (typeof network === 'string') {
+      return new Kuzzle(networkWrapper(network, options), options);
+    }
+    for (const method of ['addListener', 'isReady', 'query']) {
+      if (typeof network[method] !== 'function') {
+        throw new Error(`Network instance must implement a "${method}" method`);
+      }
+    }
+    this.network = network;
 
     this._protectedEvents = {
       connected: {},
@@ -50,9 +60,7 @@ class Kuzzle extends KuzzleEventEmitter {
 
     this.autoResubscribe = typeof options.autoResubscribe === 'boolean' ? options.autoResubscribe : true;
     this.eventTimeout = typeof options.eventTimeout === 'number' ? options.eventTimeout : 200;
-    this.protocol = typeof options.protocol === 'string' ? options.protocol : 'websocket';
-    this.version = typeof SDKVERSION === 'undefined' ? require('../package').version : SDKVERSION;
-    this.network = networkWrapper(this.protocol, host, options);
+    this.sdkVersion = typeof SDKVERSION === 'undefined' ? require('../package').version : SDKVERSION;
     this.volatile = typeof options.volatile === 'object' ? options.volatile : {};
 
     // controllers
@@ -223,10 +231,7 @@ class Kuzzle extends KuzzleEventEmitter {
     });
 
     this.network.addListener('networkError', error => {
-      const connectionError = new Error(`Unable to connect to kuzzle server at ${this.network.host}:${this.network.port}`);
-
-      connectionError.internal = error;
-      this.emit('networkError', connectionError);
+      this.emit('networkError', error);
     });
 
     this.network.addListener('disconnect', () => {
@@ -248,7 +253,7 @@ class Kuzzle extends KuzzleEventEmitter {
       }
     });
 
-    this.network.on('discarded', data => this.emit('discarded', data));
+    this.network.addListener('discarded', data => this.emit('discarded', data));
 
     return this.network.connect();
   }

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -35,13 +35,16 @@ class Kuzzle extends KuzzleEventEmitter {
   constructor(network, options = {}) {
     super();
 
-    /* Verify if `network` param exists and implements required methods */
     if (network === undefined || network === null) {
       throw new Error('"network" argument missing');
     }
+
+    // embedded network protocol (http/websocket/socketio):
     if (typeof network === 'string') {
       return new Kuzzle(networkWrapper(network, options), options);
     }
+
+    // custom protocol: check the existence of required methods
     for (const method of ['addListener', 'isReady', 'query']) {
       if (typeof network[method] !== 'function') {
         throw new Error(`Network instance must implement a "${method}" method`);

--- a/src/networkWrapper/index.js
+++ b/src/networkWrapper/index.js
@@ -6,22 +6,22 @@
  * @returns {AbstractWrapper} Instantiated WebSocket/Socket.IO object
  */
 
-function network (protocol, host, options) {
+function network (protocol, options) {
   switch (protocol) {
     case 'http':
-      return new (require('./protocols/http'))(host, options);
+      return new (require('./protocols/http'))(options);
     case 'websocket':
       if (typeof window !== 'undefined' && typeof WebSocket === 'undefined') {
         throw new Error('Aborting: no websocket support detected.');
       }
-      return new (require('./protocols/websocket'))(host, options);
+      return new (require('./protocols/websocket'))(options);
     case 'socketio':
       if (!window.io) {
         throw new Error('Aborting: no socket.io library loaded.');
       }
-      return new (require('./protocols/socketio'))(host, options);
+      return new (require('./protocols/socketio'))(options);
     default:
-      throw new Error('Aborting: unknown protocol "' + protocol + '" (only "websocket" and "socketio" are available).');
+      throw new Error('Aborting: unknown protocol "' + protocol + '" (only "http", "websocket" and "socketio" are available).');
   }
 }
 

--- a/src/networkWrapper/protocols/abstract/common.js
+++ b/src/networkWrapper/protocols/abstract/common.js
@@ -14,12 +14,12 @@ let
 
 class AbstractWrapper extends KuzzleEventEmitter {
 
-  constructor (host, options) {
+  constructor (options = {}) {
     super();
 
-    _host = host;
-    _port = options && typeof options.port === 'number' ? options.port : 7512;
-    _ssl = options && typeof options.sslConnection === 'boolean' ? options.sslConnection : false;
+    _host = options.host;
+    _port = typeof options.port === 'number' ? options.port : 7512;
+    _ssl = typeof options.sslConnection === 'boolean' ? options.sslConnection : false;
 
     this.autoReplay = false;
     this.autoQueue = false;
@@ -32,13 +32,11 @@ class AbstractWrapper extends KuzzleEventEmitter {
     this.replayInterval = 10;
     this.state = 'offline';
 
-    if (options) {
-      Object.keys(options).forEach(opt => {
-        if (this.hasOwnProperty(opt) && Object.getOwnPropertyDescriptor(this, opt).writable) {
-          this[opt] = options[opt];
-        }
-      });
-    }
+    Object.keys(options).forEach(opt => {
+      if (this.hasOwnProperty(opt) && Object.getOwnPropertyDescriptor(this, opt).writable) {
+        this[opt] = options[opt];
+      }
+    });
   }
 
   get id () {
@@ -66,6 +64,15 @@ class AbstractWrapper extends KuzzleEventEmitter {
   }
 
   /**
+   * @abstract
+   * @param request
+   * @returns {Promise<any>}
+   */
+  send () {
+    throw new Error('Method "send" is not implemented');
+  }
+
+  /**
    * Called when the client's connection is established
    */
   clientConnected (state, wasConnected) {
@@ -84,7 +91,7 @@ class AbstractWrapper extends KuzzleEventEmitter {
   /**
    * Called when the client's connection is closed
    */
-  disconnect() {
+  close () {
     this.state = 'offline';
     if (this.autoQueue) {
       this.startQueuing();

--- a/src/networkWrapper/protocols/abstract/realtime.js
+++ b/src/networkWrapper/protocols/abstract/realtime.js
@@ -5,14 +5,15 @@ const
 
 class RTWrapper extends AbstractWrapper {
 
-  constructor (host, options) {
-    super(host, options);
+  constructor (options = {}) {
+    super(options);
 
-    this._autoReconnect = options && typeof options.autoReconnect === 'boolean' ? options.autoReconnect : true;
-    this._reconnectionDelay = options && typeof options.reconnectionDelay === 'number' ? options.reconnectionDelay : 1000;
+    this._autoReconnect = typeof options.autoReconnect === 'boolean' ? options.autoReconnect : true;
+    this._reconnectionDelay = typeof options.reconnectionDelay === 'number' ? options.reconnectionDelay : 1000;
 
-    if (options && options.offlineMode === 'auto' && this.autoReconnect) {
-      this.autoQueue = this.autoReplay = true;
+    if (options.offlineMode === 'auto' && this.autoReconnect) {
+      this.autoQueue = true;
+      this.autoReplay = true;
     }
 
     this.wasConnected = false;
@@ -64,7 +65,10 @@ class RTWrapper extends AbstractWrapper {
       this.startQueuing();
     }
 
-    this.emit('networkError', error);
+    const connectionError = new Error(`Unable to connect to kuzzle server at ${this.host}:${this.port}`);
+    connectionError.internal = error;
+
+    this.emit('networkError', connectionError);
     if (this.autoReconnect && !this.retrying && !this.stopRetryingToConnect) {
       this.retrying = true;
       setTimeout(() => {

--- a/src/networkWrapper/protocols/http.js
+++ b/src/networkWrapper/protocols/http.js
@@ -44,8 +44,12 @@ const
 
 class HttpWrapper extends AbtractWrapper {
 
-  constructor(host, options) {
-    super(host, options);
+  constructor(options = {}) {
+    super(options);
+
+    if (typeof this.host !== 'string' || this.host === '') {
+      throw new Error('options.host is required');
+    }
 
     // Application-side HTTP route overrides:
     if (options.http && options.http.customRoutes) {
@@ -101,7 +105,10 @@ class HttpWrapper extends AbtractWrapper {
         this.clientConnected();
       })
       .catch(err => {
-        this.emit('networkError', err);
+        const connectionError = new Error(`Unable to connect to kuzzle server at ${this.host}:${this.port}`);
+        connectionError.internal = err;
+
+        this.emit('networkError', connectionError);
         throw err;
       });
   }
@@ -197,13 +204,6 @@ class HttpWrapper extends AbtractWrapper {
         this.emit(payload.requestId, {error});
         return Promise.reject(error);
       });
-  }
-
-  /**
-   * Closes the connection
-   */
-  close () {
-    this.disconnect();
   }
 
   _sendHttpRequest (method, path, payload = {}) {

--- a/src/networkWrapper/protocols/socketio.js
+++ b/src/networkWrapper/protocols/socketio.js
@@ -5,8 +5,12 @@ const
 
 class SocketIO extends RTWrapper {
 
-  constructor(host, options) {
-    super(host, options);
+  constructor(options = {}) {
+    super(options);
+
+    if (typeof this.host !== 'string' || this.host === '') {
+      throw new Error('options.host is required');
+    }
 
     this.socket = null;
     this.forceDisconnect = false;
@@ -128,7 +132,7 @@ class SocketIO extends RTWrapper {
     this.state = 'offline';
     this.socket.close();
     this.socket = null;
-    this.disconnect();
+    super.close();
   }
 
   _addEventWrapper (event, callback, once = false) {

--- a/src/networkWrapper/protocols/websocket.js
+++ b/src/networkWrapper/protocols/websocket.js
@@ -7,8 +7,12 @@ let WebSocketClient;
 
 class WSNode extends RTWrapper {
 
-  constructor(host, options) {
-    super(host, options);
+  constructor(options = {}) {
+    super(options);
+
+    if (typeof this.host !== 'string' || this.host === '') {
+      throw new Error('options.host is required');
+    }
 
     WebSocketClient = typeof WebSocket !== 'undefined' ? WebSocket : require('uws');
     this.client = null;
@@ -115,7 +119,7 @@ class WSNode extends RTWrapper {
     }
     this.client = null;
     this.stopRetryingToConnect = true;
-    this.disconnect();
+    super.close();
   }
 }
 

--- a/test/kuzzle/getters.test.js
+++ b/test/kuzzle/getters.test.js
@@ -1,19 +1,14 @@
 const
   should = require('should'),
-  proxyquire = require('proxyquire'),
-  NetworkWrapperMock = require('../mocks/networkWrapper.mock');
-
-const Kuzzle = proxyquire('../../src/Kuzzle', {
-  './networkWrapper': function(protocol, host, options) {
-    return new NetworkWrapperMock(host, options);
-  }
-});
+  NetworkWrapperMock = require('../mocks/networkWrapper.mock'),
+  Kuzzle = require('../../src/Kuzzle');
 
 describe('Kuzzle getters', () => {
   let kuzzle;
 
   beforeEach(() => {
-    kuzzle = new Kuzzle('somewhere');
+    const network = new NetworkWrapperMock({host: 'somewhere'});
+    kuzzle = new Kuzzle(network);
   });
 
   it('should get "autoQueue" property from network instance', () => {

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -1,7 +1,8 @@
 const
   should = require('should'),
   sinon = require('sinon'),
-  proxyquire = require('proxyquire');
+  proxyquire = require('proxyquire'),
+  NetworkWrapperMock = require('../mocks/networkWrapper.mock');
 
 describe('Kuzzle listeners management', () => {
   const
@@ -25,7 +26,8 @@ describe('Kuzzle listeners management', () => {
 
 
   beforeEach(() => {
-    kuzzle = new Kuzzle('foo', {eventTimeout: 20});
+    const network = new NetworkWrapperMock();
+    kuzzle = new Kuzzle(network, {eventTimeout: 20});
     addListenerStub.reset();
     emitStub.reset();
   });

--- a/test/kuzzle/network.test.js
+++ b/test/kuzzle/network.test.js
@@ -1,21 +1,17 @@
 const
   should = require('should'),
-  proxyquire = require('proxyquire'),
   sinon = require('sinon'),
-  NetworkWrapperMock = require('../mocks/networkWrapper.mock');
+  NetworkWrapperMock = require('../mocks/networkWrapper.mock'),
+  Kuzzle = require('../../src/Kuzzle');
 
 describe('Kuzzle network methods', () => {
-  const Kuzzle = proxyquire('../../src/Kuzzle', {
-    './networkWrapper': function(protocol, host, options) {
-      return new NetworkWrapperMock(host, options);
-    }
-  });
-
   let kuzzle;
 
   beforeEach(() => {
-    kuzzle = new Kuzzle('somewhere');
-    kuzzle.network.close = sinon.stub();
+    const network = new NetworkWrapperMock({host: 'somewhere'});
+
+    network.close = sinon.stub();
+    kuzzle = new Kuzzle(network);
   });
 
   describe('#flushQueue', () => {

--- a/test/kuzzle/query.test.js
+++ b/test/kuzzle/query.test.js
@@ -1,8 +1,8 @@
 const
   should = require('should'),
   sinon = require('sinon'),
-  proxyquire = require('proxyquire'),
-  NetworkWrapperMock = require('../mocks/networkWrapper.mock');
+  NetworkWrapperMock = require('../mocks/networkWrapper.mock'),
+  Kuzzle = require('../../src/Kuzzle');
 
 describe('Kuzzle query management', () => {
   describe('#query', () => {
@@ -18,13 +18,9 @@ describe('Kuzzle query management', () => {
     let kuzzle;
 
     beforeEach(() => {
-      const Kuzzle = proxyquire('../../src/Kuzzle', {
-        './networkWrapper': function (protocol, host, options) {
-          return new NetworkWrapperMock(host, options);
-        }
-      });
+      const network = new NetworkWrapperMock({host: 'somewhere'});
 
-      kuzzle = new Kuzzle('foo');
+      kuzzle = new Kuzzle(network);
       kuzzle.network.query.resolves({result: {}});
     });
 

--- a/test/kuzzle/setters.test.js
+++ b/test/kuzzle/setters.test.js
@@ -1,20 +1,15 @@
 const
   should = require('should'),
   sinon = require('sinon'),
-  proxyquire = require('proxyquire'),
-  NetworkWrapperMock = require('../mocks/networkWrapper.mock');
-
-const Kuzzle = proxyquire('../../src/Kuzzle', {
-  './networkWrapper': function(protocol, host, options) {
-    return new NetworkWrapperMock(host, options);
-  }
-});
+  NetworkWrapperMock = require('../mocks/networkWrapper.mock'),
+  Kuzzle = require('../../src/Kuzzle');
 
 describe('Kuzzle setters', () => {
   let kuzzle;
 
   beforeEach(() => {
-    kuzzle = new Kuzzle('somewhere');
+    const network = new NetworkWrapperMock({host: 'somewhere'});
+    kuzzle = new Kuzzle(network);
   });
 
   describe('#autoQueue', () => {

--- a/test/mocks/networkWrapper.mock.js
+++ b/test/mocks/networkWrapper.mock.js
@@ -4,11 +4,11 @@ const
 
 class NetworkWrapperMock extends KuzzleEventEmitter {
 
-  constructor (host, options) {
+  constructor (options = {}) {
     super();
 
-    this.host = host;
     this.options = options || {};
+    this.host = this.options.host;
     this.port = this.options.port || 7512;
     this.state = 'offline';
     this.connectCalled = false;

--- a/test/network/http.test.js
+++ b/test/network/http.test.js
@@ -8,7 +8,8 @@ describe('HTTP networking module', () => {
   let network;
 
   beforeEach(() => {
-    network = new HttpWrapper('address', {
+    network = new HttpWrapper({
+      host: 'address',
       port: 1234
     });
   });
@@ -52,7 +53,8 @@ describe('HTTP networking module', () => {
     });
 
     it('should initialize http network with custom routes', () => {
-      const customNetwork = new HttpWrapper('address', {
+      const customNetwork = new HttpWrapper({
+        host: 'address',
         port: 1234,
         http: {
           customRoutes: {
@@ -357,7 +359,7 @@ describe('HTTP networking module', () => {
         'min-req-promise': {request: httpRequestStub}
       });
 
-      network = new MockHttpWrapper('address', {port: 1234});
+      network = new MockHttpWrapper({host: 'address', port: 1234});
     });
 
     it('should call http.request with empty body', () => {
@@ -411,7 +413,8 @@ describe('HTTP networking module', () => {
         return xhrStub;
       };
 
-      network = new HttpWrapper('address', {
+      network = new HttpWrapper({
+        host: 'address',
         port: 1234
       });
     });

--- a/test/network/networkWrapper.test.js
+++ b/test/network/networkWrapper.test.js
@@ -2,6 +2,7 @@ var
   should = require('should'),
   WS = require('../../src/networkWrapper/protocols/websocket'),
   SocketIO = require('../../src/networkWrapper/protocols/socketio'),
+  HttpWrapper = require('../../src/networkWrapper/protocols/http'),
   Wrapper = require('../../src/networkWrapper');
 
 /**
@@ -18,31 +19,35 @@ describe('Network Wrapper', function () {
   });
 
   it('should instantiate a WS object in NodeJS environment', function() {
-    should(Wrapper('websocket')).be.instanceof(WS);
+    should(Wrapper('websocket', {host: 'somewhere'})).be.instanceof(WS);
   });
 
   it('should instantiate a WS object if in a Web Browser with WebSocket support', function() {
     window = 'foo'; // eslint-disable-line
     WebSocket = 'bar'; // eslint-disable-line
-    should(Wrapper('websocket')).be.instanceof(WS);
+    should(Wrapper('websocket', {host: 'somewhere'})).be.instanceof(WS);
   });
 
   it('should throw if trying to instantiate a WS object in a Web Browser without WebSocket support', function () {
     window = 'foo'; // eslint-disable-line
-    should(function () { Wrapper('websocket'); }).throw('Aborting: no websocket support detected.');
+    should(function () { Wrapper('websocket', {host: 'somewhere'}); }).throw('Aborting: no websocket support detected.');
   });
 
   it('should instantiate a SocketIO object with the socket.io library', function () {
     window = { io: 'foobar' }; // eslint-disable-line
-    should(Wrapper('socketio')).be.instanceof(SocketIO);
+    should(Wrapper('socketio', {host: 'somewhere'})).be.instanceof(SocketIO);
   });
 
   it('should throw if trying to instantiate a SocketIO object without the socket.io library', function () {
     window = 'foo'; // eslint-disable-line
-    should(function () { Wrapper('socketio'); }).throw('Aborting: no socket.io library loaded.');
+    should(function () { Wrapper('socketio', {host: 'somewhere'}); }).throw('Aborting: no socket.io library loaded.');
+  });
+
+  it('should instantiate an HttpWrapper object', function () {
+    should(Wrapper('http', {host: 'somewhere'})).be.instanceof(HttpWrapper);
   });
 
   it('should throw if trying to instantiate a network wrapper with an unknown protocol', function () {
-    should(function () { Wrapper('foobar'); }).throw('Aborting: unknown protocol "foobar" (only "websocket" and "socketio" are available).');
+    should(function () { Wrapper('foobar', {host: 'somewhere'}); }).throw('Aborting: unknown protocol "foobar" (only "http", "websocket" and "socketio" are available).');
   });
 });

--- a/test/network/offlineQueue.test.js
+++ b/test/network/offlineQueue.test.js
@@ -14,7 +14,7 @@ describe('Offline queue management', function () {
   beforeEach(function () {
     var pastTime = 60050;
 
-    network = new AbstractWrapper('somewhere');
+    network = new AbstractWrapper();
 
     // queuing a bunch of 7 requests from 1min ago to right now, 10s apart
     now = Date.now();

--- a/test/network/socketio.test.js
+++ b/test/network/socketio.test.js
@@ -68,7 +68,8 @@ describe('SocketIO networking module', () => {
       close: sinon.spy()
     };
 
-    socketIO = new SocketIO('address', {
+    socketIO = new SocketIO({
+      host: 'address',
       port: 1234,
       autoReconnect: false,
       reconnectionDelay: 1234
@@ -105,7 +106,8 @@ describe('SocketIO networking module', () => {
   });
 
   it('should connect with the secure connection', () => {
-    socketIO = new SocketIO('address', {
+    socketIO = new SocketIO({
+      host: 'address',
       port: 1234,
       autoReconnect: false,
       reconnectionDelay: 1234,
@@ -259,7 +261,8 @@ describe('SocketIO networking module', () => {
     socketIO.socket.emit('connect_error', err);
 
     should(cb).be.calledOnce();
-    should(cb).be.calledWith(err);
+    should(cb.firstCall.args[0]).be.an.instanceOf(Error);
+    should(cb.firstCall.args[0].internal).be.equal(err);
 
     return should(promise).be.rejectedWith('foobar');
   });
@@ -318,7 +321,7 @@ describe('SocketIO exposed methods', () => {
       close: sinon.spy()
     };
 
-    socketIO = new SocketIO('address');
+    socketIO = new SocketIO({host: 'address'});
     socketIO.socket = socketStub;
 
     window = {io: sinon.stub().returns(socketStub)}; // eslint-disable-line

--- a/test/network/websocket.test.js
+++ b/test/network/websocket.test.js
@@ -23,7 +23,8 @@ describe('WebSocket networking module', () => {
       return clientStub;
     };
 
-    websocket = new WS('address', {
+    websocket = new WS({
+      host: 'address',
       port: 1234,
       autoReconnect: true,
       reconnectionDelay: 10
@@ -60,7 +61,8 @@ describe('WebSocket networking module', () => {
 
   it('should initialize a WS secure connection', () => {
     clientStub.on = sinon.stub();
-    websocket = new WS('address', {
+    websocket = new WS({
+      host: 'address',
       port: 1234,
       autoReconnect: false,
       reconnectionDelay: 1234,
@@ -172,7 +174,8 @@ describe('WebSocket networking module', () => {
   it('should not try to reconnect on a connection error with autoReconnect = false', () => {
     const cb = sinon.stub();
 
-    websocket = new WS('address', {
+    websocket = new WS({
+      host: 'address',
       port: 1234,
       autoReconnect: false,
       reconnectionDelay: 10
@@ -244,7 +247,9 @@ describe('WebSocket networking module', () => {
 
     clock.tick(10);
     should(cb).be.calledOnce();
-    should(cb.calledWith('foobar'));
+    should(cb.firstCall.args[0]).be.an.instanceOf(Error);
+    should(cb.firstCall.args[0].internal.status).be.equal(4666);
+    should(cb.firstCall.args[0].internal.message).be.equal('foobar');
     should(websocket.listeners('networkError').length).be.eql(1);
 
     cb.reset();
@@ -253,7 +258,9 @@ describe('WebSocket networking module', () => {
 
     clock.tick(10);
     should(cb).be.calledOnce();
-    should(cb.calledWith('foobar'));
+    should(cb.firstCall.args[0]).be.an.instanceOf(Error);
+    should(cb.firstCall.args[0].internal.status).be.equal(4666);
+    should(cb.firstCall.args[0].internal.message).be.equal('foobar');
     should(websocket.listeners('networkError').length).be.eql(1);
   });
 


### PR DESCRIPTION
## What does this PR do?

See [KZL-175](https://jira.kaliop.net/browse/KZL-175)

Change the signature of SDK constructor to match actual signature in Go SDK and enable developers to instantiate the SDK with their custom network protocol:
```js
// Before: 
const kuzzle = new Kuzzle('hostname', {protocol: 'websocket'});

// Now - with embed protocol:
const kuzzle = new Kuzzle('websocket', {host: 'hostname'});

// Now - with custom protocol:
const protocol = new MyCustomProtocol();
const kuzzle = new Kuzzle(protocol, {});
```


### Other changes

Expose also `AbstractNetwork` and `KuzzleEventEmitter`:
Thus, custom protocol can easily inherits from `AbstractNetwork` and only implements `connect` and `send` methods:
```js
const
  Kuzzle = require('kuzzle-sdk').Kuzzle,
  KuzzleAbstractNetwork = require('kuzzle-sdk').KuzzleAbstractNetwork;

class MyCustomProtocol extends KuzzleAbstractNetwork {
  connect() {
    // (...) do custom connection steps...

    // change state and resolve:
    this.state = 'ready';
    return Promise.resolve();
  }

  send(request) {
    // (...) here the protocol-specific code to send the request to kuzzle and get the result into `result` variable

    // Send back the result to SDK and resolve:
    this.emit(request.requestId, {result});
    return Promise.resolve();
  }
}

const protocol = new MyCustomProtocol();
const kuzzle = new Kuzzle(protocol);
kuzzle.connect()
.then(() => kuzzle.server.now())
.then(res => {
  console.log(`Current Kuzzle timestamp: ${res}`);
})
```

Another way to implement a custom protocol is to implement `isReady` and `query` methods, as well as javascript [Event API](https://nodejs.org/api/events.html):

```js
const
  Kuzzle = require('kuzzle-sdk').Kuzzle,
  KuzzleEventEmitter = require('kuzzle-sdk').KuzzleEventEmitter;

class MyCustomProtocol extends KuzzleEventEmitter {

  isReady() {
    return true;
  }

  query (request, options) {
    // (...) here the protocol-specific code to send the request to kuzzle and get the result into `result` variable

    // Resolves the response:
    return Promise.resolve({result});
  }
}

```


### Boyscout

Some minor cosmetic changes in network wrappers code.