### PR TITLE
Make kuzzle.query return the full response object from Kuzzle backend

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -347,8 +347,7 @@ class Kuzzle extends KuzzleEventEmitter {
       request.jwt = this.jwt;
     }
 
-    return this.network.query(request, options)
-      .then(response => response.result);
+    return this.network.query(request, options);
   }
 
   /**

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -33,7 +33,8 @@ class AuthController {
       controller: 'auth',
       action: 'checkToken',
       body: {token}
-    }, {queuable: false});
+    }, {queuable: false})
+      .then(response => response.result);
   }
 
   /**
@@ -50,7 +51,8 @@ class AuthController {
       controller: 'auth',
       action: 'createMyCredentials',
       body: credentials
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -64,7 +66,8 @@ class AuthController {
       strategy,
       controller: 'auth',
       action: 'credentialsExist'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -79,7 +82,8 @@ class AuthController {
       strategy,
       controller: 'auth',
       action: 'deleteMyCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -92,7 +96,7 @@ class AuthController {
       controller: 'auth',
       action: 'getCurrentUser'
     }, options)
-      .then(result => new User(this.kuzzle, result._id, result._source, result._meta));
+      .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   /**
@@ -106,7 +110,8 @@ class AuthController {
       strategy,
       controller: 'auth',
       action: 'getMyCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -120,7 +125,7 @@ class AuthController {
       controller: 'auth',
       action: 'getMyRights'
     }, options)
-      .then(res => res.hits);
+      .then(response => response.result.hits);
   }
 
   /**
@@ -133,7 +138,8 @@ class AuthController {
     return this.kuzzle.query({
       controller: 'auth',
       action: 'getStrategies'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -160,15 +166,15 @@ class AuthController {
       };
 
     return this.kuzzle.query(request, {queuable: false})
-      .then(result => {
+      .then(response => {
         try {
-          this.kuzzle.jwt = result.jwt;
+          this.kuzzle.jwt = response.result.jwt;
           this.kuzzle.emit('loginAttempt', {success: true});
         }
         catch (err) {
           return Promise.reject(err);
         }
-        return result.jwt;
+        return response.result.jwt;
       })
       .catch(err => {
         this.kuzzle.emit('loginAttempt', {success: false, error: err.message});
@@ -205,7 +211,8 @@ class AuthController {
       body: credentials,
       controller: 'auth',
       action: 'updateMyCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -220,7 +227,8 @@ class AuthController {
       body,
       controller: 'auth',
       action: 'updateSelf'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -237,7 +245,8 @@ class AuthController {
       body: credentials,
       controller: 'auth',
       action: 'validateMyCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
 }

--- a/src/controllers/bulk.js
+++ b/src/controllers/bulk.js
@@ -16,7 +16,8 @@ class BulkController {
       body: {
         bulkData: data
       }
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
 }

--- a/src/controllers/collection.js
+++ b/src/controllers/collection.js
@@ -30,7 +30,8 @@ class CollectionController {
       body,
       controller: 'collection',
       action: 'create'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   deleteSpecification (index, collection, options = {}) {
@@ -46,7 +47,8 @@ class CollectionController {
       collection,
       controller: 'collection',
       action: 'deleteSpecification'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   exists (index, collection, options = {}) {
@@ -62,7 +64,8 @@ class CollectionController {
       collection,
       controller: 'collection',
       action: 'exists'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getMapping (index, collection, options = {}) {
@@ -78,7 +81,8 @@ class CollectionController {
       collection,
       controller: 'collection',
       action: 'getMapping'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getSpecifications (index, collection, options = {}) {
@@ -94,7 +98,8 @@ class CollectionController {
       collection,
       controller: 'collection',
       action: 'getSpecifications'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   list (index, options = {}) {
@@ -112,7 +117,8 @@ class CollectionController {
     delete options.from;
     delete options.size;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   searchSpecifications (body = {}, options = {}) {
@@ -127,7 +133,7 @@ class CollectionController {
     }
 
     return this.kuzzle.query(request, options)
-      .then(response => new SpecificationsSearchResult(this.kuzzle, request, options, response));
+      .then(response => new SpecificationsSearchResult(this.kuzzle, request, options, response.result));
   }
 
   truncate (index, collection, options = {}) {
@@ -143,7 +149,8 @@ class CollectionController {
       collection,
       controller: 'collection',
       action: 'truncate'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   updateMapping (index, collection, body, options = {}) {
@@ -160,7 +167,8 @@ class CollectionController {
       body,
       controller: 'collection',
       action: 'updateMapping'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   updateSpecifications (index, collection, body, options = {}) {
@@ -177,7 +185,8 @@ class CollectionController {
       body,
       controller: 'collection',
       action: 'updateSpecifications'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   validateSpecifications (body, options = {}) {
@@ -185,7 +194,8 @@ class CollectionController {
       body,
       controller: 'collection',
       action: 'validateSpecifications'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 }
 

--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -35,7 +35,7 @@ class DocumentController {
     delete options.includeTrash;
 
     return this.kuzzle.query(request, options)
-      .then(response => response.count);
+      .then(response => response.result.count);
   }
 
   create (index, collection, _id, body, options = {}) {
@@ -60,7 +60,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   createOrReplace (index, collection, _id, body, options = {}) {
@@ -88,7 +89,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   delete (index, collection, _id, options = {}) {
@@ -112,7 +114,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   deleteByQuery(index, collection, body = {}, options = {}) {
@@ -133,7 +136,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   get (index, collection, _id, options = {}) {
@@ -157,7 +161,8 @@ class DocumentController {
     };
     delete options.includeTrash;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mCreate (index, collection, documents, options = {}) {
@@ -181,7 +186,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mCreateOrReplace (index, collection, documents, options = {}) {
@@ -205,7 +211,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mDelete (index, collection, ids, options = {}) {
@@ -229,7 +236,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mGet (index, collection, ids, options = {}) {
@@ -253,7 +261,8 @@ class DocumentController {
     };
     delete options.includeTrash;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mReplace (index, collection, documents, options = {}) {
@@ -276,7 +285,8 @@ class DocumentController {
       refresh: options.refresh
     };
     delete options.refresh;
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mUpdate (index, collection, documents, options = {}) {
@@ -300,7 +310,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   replace (index, collection, _id, body, options = {}) {
@@ -328,7 +339,8 @@ class DocumentController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   search (index, collection, body = {}, options = {}) {
@@ -352,7 +364,7 @@ class DocumentController {
     }
 
     return this.kuzzle.query(request, options)
-      .then(response => new DocumentSearchResult(this.kuzzle, request, options, response));
+      .then(response => new DocumentSearchResult(this.kuzzle, request, options, response.result));
   }
 
   update (index, collection, _id, body, options = {}) {
@@ -382,7 +394,8 @@ class DocumentController {
     delete options.refresh;
     delete options.retryOnConflict;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   validate (index, collection, body, options = {}) {
@@ -402,7 +415,8 @@ class DocumentController {
       body,
       controller: 'document',
       action: 'validate'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 }
 

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -22,7 +22,8 @@ class IndexController {
       index,
       controller: 'index',
       action : 'create'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   delete (index, options) {
@@ -34,7 +35,8 @@ class IndexController {
       index,
       controller: 'index',
       action : 'delete'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   exists (index, options) {
@@ -46,7 +48,8 @@ class IndexController {
       index,
       controller: 'index',
       action : 'exists'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getAutoRefresh (index, options) {
@@ -58,14 +61,16 @@ class IndexController {
       index,
       controller: 'index',
       action: 'getAutoRefresh'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   list (options) {
     return this.kuzzle.query({
       controller: 'index',
       action: 'list'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   mDelete (indexes, options) {
@@ -79,7 +84,8 @@ class IndexController {
       body: {
         indexes
       }
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   refresh (index, options) {
@@ -91,14 +97,16 @@ class IndexController {
       index,
       controller: 'index',
       action: 'refresh'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   refreshInternal (options) {
     return this.kuzzle.query({
       controller: 'index',
       action: 'refreshInternal'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   setAutoRefresh (index, autoRefresh, options) {
@@ -117,7 +125,8 @@ class IndexController {
       body: {
         autoRefresh
       }
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 }
 

--- a/src/controllers/memoryStorage.js
+++ b/src/controllers/memoryStorage.js
@@ -258,11 +258,11 @@ for (const action of Object.keys(commands)) {
     }
 
     return this.kuzzle.query(request, options)
-      .then(res => {
+      .then(response => {
         if (command.mapResults) {
-          return command.mapResults(res.result);
+          return command.mapResults(response.result);
         }
-        return res.result;
+        return response.result;
       });
   };
 }

--- a/src/controllers/realtime/index.js
+++ b/src/controllers/realtime/index.js
@@ -30,14 +30,15 @@ class RealTimeController {
       action: 'count',
       body: {roomId}
     }, options)
-      .then(response => response.count);
+      .then(response => response.result.count);
   }
 
   list (options = {}) {
     return this.kuzzle.query({
       controller: 'realtime',
       action: 'list'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   publish (index, collection, body, options = {}) {
@@ -59,7 +60,8 @@ class RealTimeController {
       action: 'publish'
     };
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   subscribe (index, collection, body, callback, options = {}) {
@@ -84,7 +86,7 @@ class RealTimeController {
           this.subscriptions[room.id] = [];
         }
         this.subscriptions[room.id].push(room);
-        return response;
+        return response.result;
       });
   }
 
@@ -108,7 +110,10 @@ class RealTimeController {
       controller: 'realtime',
       action: 'unsubscribe',
       body: {roomId}
-    }, options);
+    }, options)
+      .then(response => {
+        return response.result;
+      });
   }
 
   validate (index, collection, body, options = {}) {
@@ -128,7 +133,8 @@ class RealTimeController {
       body,
       controller: 'realtime',
       action: 'validate'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
 }

--- a/src/controllers/realtime/room.js
+++ b/src/controllers/realtime/room.js
@@ -50,8 +50,8 @@ class Room {
   subscribe () {
     return this.kuzzle.query(this.request, this.options)
       .then(response => {
-        this.id = response.roomId;
-        this.channel = response.channel;
+        this.id = response.result.roomId;
+        this.channel = response.result.channel;
 
         // we rely on kuzzle event emitter to not duplicate the listeners here
         this.kuzzle.network.on(this.channel, this._channelListener);

--- a/src/controllers/searchResult/base.js
+++ b/src/controllers/searchResult/base.js
@@ -32,10 +32,11 @@ class SearchResultBase {
         action: this.scrollAction,
         scrollId: this.response.scrollId
       }), this.options)
-        .then(r => {
-          this.fetched += r.hits.length;
-          this.response = r;
-          this.hits = r.hits;
+        .then(response => {
+          const result = response.result;
+          this.fetched += result.hits.length;
+          this.response = result;
+          this.hits = result.hits;
           return this;
         });
     }
@@ -58,10 +59,11 @@ class SearchResultBase {
       }
 
       return this.kuzzle.query(request, this.options)
-        .then(r => {
-          this.fetched += r.hits.length;
-          this.response = r;
-          this.hits = r.hits;
+        .then(response => {
+          const result = response.result;
+          this.fetched += result.hits.length;
+          this.response = result;
+          this.hits = result.hits;
           return this;
         });
     }
@@ -75,10 +77,11 @@ class SearchResultBase {
         action: this.searchAction,
         from: this.fetched
       }), this.options)
-        .then(r => {
-          this.fetched += r.hits.length;
-          this.response = r;
-          this.hits = r.hits;
+        .then(response => {
+          const result = response.result;
+          this.fetched += result.hits.length;
+          this.response = result;
+          this.hits = result.hits;
           return this;
         });
     }

--- a/src/controllers/security/index.js
+++ b/src/controllers/security/index.js
@@ -37,7 +37,8 @@ class SecurityController {
       body,
       controller: 'security',
       action: 'createCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   createFirstAdmin (_id, body, options = {}) {
@@ -58,7 +59,7 @@ class SecurityController {
     delete options.reset;
 
     return this.kuzzle.query(request, options)
-      .then(result => new User(this.kuzzle, result._id, result._source, result._meta));
+      .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   createOrReplaceProfile (_id, body, options = {}) {
@@ -79,7 +80,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new Profile(this.kuzzle, result._id, result._source.policies));
+      .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
   }
 
   createOrReplaceRole (_id, body, options = {}) {
@@ -100,7 +101,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new Role(this.kuzzle, result._id, result._source.controllers));
+      .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
   createProfile (_id, body, options = {}) {
@@ -121,7 +122,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new Profile(this.kuzzle, result._id, result._source.policies));
+      .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
   }
 
   createRole (_id, body, options = {}) {
@@ -142,7 +143,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new Role(this.kuzzle, result._id, result._source.controllers));
+      .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
   createUser (_id, body, options = {}) {
@@ -169,7 +170,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new User(this.kuzzle, result._id, result._source, result._meta));
+      .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   deleteCredentials (strategy, _id, options = {}) {
@@ -185,7 +186,8 @@ class SecurityController {
       _id,
       controller: 'security',
       action: 'deleteCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   deleteProfile (_id, options = {}) {
@@ -197,7 +199,8 @@ class SecurityController {
       _id,
       controller: 'security',
       action: 'deleteProfile'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   deleteRole (_id, options = {}) {
@@ -209,7 +212,8 @@ class SecurityController {
       _id,
       controller: 'security',
       action: 'deleteRole'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   deleteUser (_id, options = {}) {
@@ -221,14 +225,16 @@ class SecurityController {
       _id,
       controller: 'security',
       action: 'deleteUser'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getAllCredentialFields (options = {}) {
     return this.kuzzle.query({
       controller: 'security',
       action: 'getAllCredentialFields'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getCredentialFields (strategy, options = {}) {
@@ -240,7 +246,8 @@ class SecurityController {
       strategy,
       controller: 'security',
       action: 'getCredentialFields'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getCredentials (strategy, _id, options = {}) {
@@ -256,7 +263,8 @@ class SecurityController {
       _id,
       controller: 'security',
       action: 'getCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getCredentialsById (strategy, _id, options = {}) {
@@ -272,7 +280,8 @@ class SecurityController {
       _id,
       controller: 'security',
       action: 'getCredentialsById'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getProfile (_id, options = {}) {
@@ -285,14 +294,15 @@ class SecurityController {
       controller: 'security',
       action: 'getProfile'
     }, options)
-      .then(result => new Profile(this.kuzzle, result._id, result._source.policies));
+      .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
   }
 
   getProfileMapping (options = {}) {
     return this.kuzzle.query({
       controller: 'security',
       action: 'getProfileMapping'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getProfileRights (_id, options = {}) {
@@ -305,7 +315,7 @@ class SecurityController {
       controller: 'security',
       action: 'getProfileRights'
     }, options)
-      .then(result => result.hits);
+      .then(response => response.result.hits);
   }
 
   getRole (_id, options = {}) {
@@ -318,14 +328,15 @@ class SecurityController {
       controller: 'security',
       action: 'getRole'
     }, options)
-      .then(result => new Role(this.kuzzle, result._id, result._source.controllers));
+      .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
   getRoleMapping (options = {}) {
     return this.kuzzle.query({
       controller: 'security',
       action: 'getRoleMapping'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getUser (_id, options = {}) {
@@ -338,14 +349,15 @@ class SecurityController {
       controller: 'security',
       action: 'getUser'
     }, options)
-      .then(result => new User(this.kuzzle, result._id, result._source, result._meta));
+      .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   getUserMapping (options = {}) {
     return this.kuzzle.query({
       controller: 'security',
       action: 'getUserMapping'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   getUserRights (_id, options = {}) {
@@ -358,7 +370,7 @@ class SecurityController {
       controller: 'security',
       action: 'getUserRights'
     }, options)
-      .then(result => result.hits);
+      .then(response => response.result.hits);
   }
 
   hasCredentials (strategy, _id, options = {}) {
@@ -374,7 +386,8 @@ class SecurityController {
       _id,
       controller: 'security',
       action: 'hasCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   mDeleteProfiles (ids, options = {}) {
@@ -390,7 +403,8 @@ class SecurityController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mDeleteRoles (ids, options = {}) {
@@ -406,7 +420,8 @@ class SecurityController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mDeleteUsers (ids, options = {}) {
@@ -422,7 +437,8 @@ class SecurityController {
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options);
+    return this.kuzzle.query(request, options)
+      .then(response => response.result);
   }
 
   mGetProfiles (ids, options = {}) {
@@ -435,7 +451,7 @@ class SecurityController {
       action: 'mGetProfiles',
       body: {ids}
     }, options)
-      .then(result => result.hits.map(hit => new Profile(this.kuzzle, hit._id , hit._source.policies)));
+      .then(response => response.result.hits.map(hit => new Profile(this.kuzzle, hit._id , hit._source.policies)));
   }
 
   mGetRoles (ids, options = {}) {
@@ -448,7 +464,7 @@ class SecurityController {
       action: 'mGetRoles',
       body: {ids}
     }, options)
-      .then(result => result.hits.map(hit => new Role(this.kuzzle, hit._id, hit._source.controllers)));
+      .then(response => response.result.hits.map(hit => new Role(this.kuzzle, hit._id, hit._source.controllers)));
   }
 
   replaceUser (_id, body, options = {}) {
@@ -469,7 +485,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new User(this.kuzzle, result._id, result._source, result._meta));
+      .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   searchProfiles (body, options= {}) {
@@ -484,7 +500,7 @@ class SecurityController {
     }
 
     return this.kuzzle.query(request, options)
-      .then(result => new ProfileSearchResult(this.kuzzle, request, options, result));
+      .then(response => new ProfileSearchResult(this.kuzzle, request, options, response.result));
   }
 
   searchRoles (body, options = {}) {
@@ -499,7 +515,7 @@ class SecurityController {
     }
 
     return this.kuzzle.query(request, options)
-      .then(result => new RoleSearchResult(this.kuzzle, request, options, result));
+      .then(response => new RoleSearchResult(this.kuzzle, request, options, response.result));
   }
 
   searchUsers (body, options = {}) {
@@ -514,7 +530,7 @@ class SecurityController {
     }
 
     return this.kuzzle.query(request, options)
-      .then(result => new UserSearchResult(this.kuzzle, request, options, result));
+      .then(response => new UserSearchResult(this.kuzzle, request, options, response.result));
   }
 
   updateCredentials (strategy, _id, body, options = {}) {
@@ -534,7 +550,8 @@ class SecurityController {
       body,
       controller: 'security',
       action: 'updateCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   updateProfile (_id, body, options = {}) {
@@ -555,7 +572,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new Profile(this.kuzzle, result._id, result._source.policies));
+      .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
   }
 
   updateProfileMapping (body, options = {}) {
@@ -563,7 +580,8 @@ class SecurityController {
       body,
       controller: 'security',
       action: 'updateProfileMapping'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   updateRole (_id, body, options = {}) {
@@ -584,7 +602,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new Role(this.kuzzle, result._id, result._source.controllers));
+      .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
   updateRoleMapping (body, options = {}) {
@@ -592,7 +610,8 @@ class SecurityController {
       body,
       controller: 'security',
       action: 'updateRoleMapping'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   updateUser (_id, body, options = {}) {
@@ -613,7 +632,7 @@ class SecurityController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(result => new User(this.kuzzle, result._id, result._source, result._meta));
+      .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   updateUserMapping (body, options = {}) {
@@ -621,7 +640,8 @@ class SecurityController {
       body,
       controller: 'security',
       action: 'updateUserMapping'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   validateCredentials (strategy, _id, body, options = {}) {
@@ -641,7 +661,8 @@ class SecurityController {
       body,
       controller: 'security',
       action: 'validateCredentials'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 }
 

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -28,14 +28,14 @@ class ServerController {
       controller: 'server',
       action: 'adminExists'
     }, options)
-      .then(result => {
-        if (typeof result.exists !== 'boolean') {
+      .then(response => {
+        if (typeof response.result !== 'object' || typeof response.result.exists !== 'boolean') {
           const error = new Error('adminExists: bad response format');
           error.status = 400;
-          error.response = result;
+          error.response = response;
           return Promise.reject(error);
         }
-        return result.exists;
+        return response.result.exists;
       });
   }
 
@@ -50,7 +50,8 @@ class ServerController {
     return this.kuzzle.query({
       controller: 'server',
       action: 'getAllStats'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -63,7 +64,8 @@ class ServerController {
     return this.kuzzle.query({
       controller: 'server',
       action: 'getConfig'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -76,7 +78,8 @@ class ServerController {
     return this.kuzzle.query({
       controller: 'server',
       action: 'getLastStats'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -93,7 +96,8 @@ class ServerController {
       action: 'getStats',
       startTime,
       stopTime
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -106,7 +110,8 @@ class ServerController {
     return this.kuzzle.query({
       controller: 'server',
       action: 'info'
-    }, options);
+    }, options)
+      .then(response => response.result);
   }
 
   /**
@@ -120,14 +125,14 @@ class ServerController {
       controller: 'server',
       action: 'now'
     }, options)
-      .then(result => {
-        if (typeof result.now !== 'number') {
+      .then(response => {
+        if (typeof response.result !== 'object' || typeof response.result.now !== 'number') {
           const error = new Error('now: bad response format');
           error.status = 400;
-          error.response = result;
+          error.response = response;
           return Promise.reject(error);
         }
-        return result.now;
+        return response.result.now;
       });
   }
 }

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -19,9 +19,11 @@ describe('Auth Controller', () => {
   describe('checkToken', () => {
     it('should call auth/checkToken query with the token and return a Promise which resolves the token validity', () => {
       kuzzle.query.resolves({
-        valid: true,
-        state: 'Error message',
-        expiresAt: 42424242
+        result: {
+          valid: true,
+          state: 'Error message',
+          expiresAt: 42424242
+        }
       });
 
       return kuzzle.auth.checkToken('token', options)
@@ -49,8 +51,10 @@ describe('Auth Controller', () => {
       const credentials = {foo: 'bar'};
 
       kuzzle.query.resolves({
-        username: 'foo',
-        kuid: 'bar'
+        result: {
+          username: 'foo',
+          kuid: 'bar'
+        }
       });
 
       return kuzzle.auth.createMyCredentials('strategy', credentials, options)
@@ -71,7 +75,7 @@ describe('Auth Controller', () => {
 
   describe('credentialsExist', () => {
     it('should call auth/credentialExists query with the strategy name and return a Promise which resolves a boolean', () => {
-      kuzzle.query.resolves(true);
+      kuzzle.query.resolves({result: true});
 
       return kuzzle.auth.credentialsExist('strategy', options)
         .then(res => {
@@ -90,7 +94,7 @@ describe('Auth Controller', () => {
 
   describe('deleteMyCredentials', () => {
     it('should call auth/deleteMyCredentials query with the strategy name and return a Promise which resolves an acknowledgement', () => {
-      kuzzle.query.resolves({acknowledged: true});
+      kuzzle.query.resolves({result: {acknowledged: true}});
 
       return kuzzle.auth.deleteMyCredentials('strategy', options)
         .then(res => {
@@ -110,9 +114,9 @@ describe('Auth Controller', () => {
   describe('getCurrentUser', () => {
     it('should call auth/getCurrentUser query and return a Promise which resolves a User object', () => {
       kuzzle.query.resolves({
-        _id: 'id',
-        _source: {
-          name: 'Doe'
+        result: {
+          _id: 'id',
+          _source: {name: 'Doe'}
         }
       });
 
@@ -135,8 +139,10 @@ describe('Auth Controller', () => {
   describe('getMyCredentials', () => {
     it('should call auth/getMyCredentials query with the strategy name and return a Promise which resolves the user credentials', () => {
       kuzzle.query.resolves({
-        username: 'foo',
-        kuid: 'bar'
+        result: {
+          username: 'foo',
+          kuid: 'bar'
+        }
       });
 
       return kuzzle.auth.getMyCredentials('strategy', options)
@@ -156,9 +162,9 @@ describe('Auth Controller', () => {
 
   describe('getMyRights', () => {
     it('should call auth/getMyCredentials query with the strategy name and return a Promise which resolves the user permissions as an array', () => {
-      kuzzle.query.resolves({hits: [
+      kuzzle.query.resolves({result: {hits: [
         {controller: 'foo', action: 'bar', index: 'foobar', collection: '*', value: 'allowed'}
-      ]});
+      ]}});
 
       return kuzzle.auth.getMyRights(options)
         .then(res => {
@@ -177,7 +183,7 @@ describe('Auth Controller', () => {
 
   describe('getStrategies', () => {
     it('should call auth/getStrategies query and return a Promise which resolves the list of strategies as an array', () => {
-      kuzzle.query.resolves(['local', 'github', 'foo', 'bar']);
+      kuzzle.query.resolves({result: ['local', 'github', 'foo', 'bar']});
 
       return kuzzle.auth.getStrategies(options)
         .then(res => {
@@ -202,8 +208,10 @@ describe('Auth Controller', () => {
 
     beforeEach(() => {
       kuzzle.query.resolves({
-        _id: 'kuid',
-        jwt: 'jwt'
+        result: {
+          _id: 'kuid',
+          jwt: 'jwt'
+        }
       });
     });
 
@@ -256,7 +264,7 @@ describe('Auth Controller', () => {
   describe('logout', () => {
     beforeEach(() => {
       kuzzle.jwt = 'jwt';
-      kuzzle.query.resolves({aknowledged: true});
+      kuzzle.query.resolves({result: {aknowledged: true}});
     });
 
     it('should call auth/logout query and return an empty Promise', () => {
@@ -286,8 +294,10 @@ describe('Auth Controller', () => {
       const credentials = {foo: 'bar'};
 
       kuzzle.query.resolves({
-        username: 'foo',
-        kuid: 'bar'
+        result: {
+          username: 'foo',
+          kuid: 'bar'
+        }
       });
 
       return kuzzle.auth.updateMyCredentials('strategy', credentials, options)
@@ -311,9 +321,9 @@ describe('Auth Controller', () => {
       const body = {foo: 'bar'};
 
       kuzzle.query.resolves({
-        _id: 'kuid',
-        _source: {
-          foo: 'bar'
+        result: {
+          _id: 'kuid',
+          _source: {foo: 'bar'}
         }
       });
 
@@ -336,7 +346,7 @@ describe('Auth Controller', () => {
     it('should call auth/validateMyCredentials query with the strategy and its credentials and return a Promise which resolves a boolean', () => {
       const body = {foo: 'bar'};
 
-      kuzzle.query.resolves(true);
+      kuzzle.query.resolves({result: true});
 
       return kuzzle.auth.validateMyCredentials('strategy', body, options)
         .then(res => {

--- a/test/controllers/bulk.test.js
+++ b/test/controllers/bulk.test.js
@@ -17,10 +17,10 @@ describe('Bulk Controller', () => {
 
   describe('import', () => {
     it('should call bulk/import query with the bulk data and return a Promise which resolves json object', () => {
-      kuzzle.query.resolves({hits: [
+      kuzzle.query.resolves({result: {hits: [
         {create: {_id: 'foo'}, status: 200},
         {update: {_id: 'bar'}, status: 200}
-      ]});
+      ]}});
 
       const data = {foo: 'bar'};
 

--- a/test/controllers/collection.test.js
+++ b/test/controllers/collection.test.js
@@ -29,7 +29,7 @@ describe('Collection Controller', () => {
     });
 
     it('should call collection/create query and return a Promise which resolves an acknowledgement', () => {
-      kuzzle.query.resolves({acknowledged: true});
+      kuzzle.query.resolves({result: {acknowledged: true}});
 
       return kuzzle.collection.create('index', 'collection', null, options)
         .then(res => {
@@ -48,7 +48,7 @@ describe('Collection Controller', () => {
     });
 
     it('should handle a collection mapping, if one is provided', () => {
-      kuzzle.query.resolves({acknowledged: true});
+      kuzzle.query.resolves({result: {acknowledged: true}});
 
       return kuzzle.collection.create('index', 'collection', {properties: true}, options)
         .then(res => {
@@ -81,7 +81,7 @@ describe('Collection Controller', () => {
     });
 
     it('should call collection/deleteSpecification query and return a Promise which resolves an acknowledgement', () => {
-      kuzzle.query.resolves({acknowledged: true});
+      kuzzle.query.resolves({result: {acknowledged: true}});
 
       return kuzzle.collection.deleteSpecification('index', 'collection', options)
         .then(res => {
@@ -113,7 +113,7 @@ describe('Collection Controller', () => {
     });
 
     it('should call collection/exists query names and return a Promise which resolves a boolean', () => {
-      kuzzle.query.resolves(true);
+      kuzzle.query.resolves({result: true});
 
       return kuzzle.collection.exists('index', 'collection', options)
         .then(res => {
@@ -146,12 +146,14 @@ describe('Collection Controller', () => {
 
     it('should call collection/getMapping query and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({
-        index: {
-          mappings: {
-            collection: {
-              properties: {
-                field1: {type: 'foo'},
-                field2: {type: 'bar'}
+        result: {
+          index: {
+            mappings: {
+              collection: {
+                properties: {
+                  field1: {type: 'foo'},
+                  field2: {type: 'bar'}
+                }
               }
             }
           }
@@ -200,13 +202,15 @@ describe('Collection Controller', () => {
 
     it('should call collection/getSpecifications query and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({
-        index: 'index',
-        collection: 'collection',
-        validation: {
-          fields: {
-            foobar: {type: 'integer', mandatory: true, defaultValue: 42}
-          },
-          strict: true
+        result: {
+          index: 'index',
+          collection: 'collection',
+          validation: {
+            fields: {
+              foobar: {type: 'integer', mandatory: true, defaultValue: 42}
+            },
+            strict: true
+          }
         }
       });
 
@@ -244,12 +248,14 @@ describe('Collection Controller', () => {
 
     it('should call collection/list query and return a Promise which resolves collection list', () => {
       kuzzle.query.resolves({
-        collections: [
-          {name: 'foo', type: 'realtime'},
-          {name: 'bar', type: 'realtime'},
-          {name: 'foobar', type: 'stored'},
-          {name: 'barfoo', type: 'stored'}
-        ]
+        result: {
+          collections: [
+            {name: 'foo', type: 'realtime'},
+            {name: 'bar', type: 'realtime'},
+            {name: 'foobar', type: 'stored'},
+            {name: 'barfoo', type: 'stored'}
+          ]
+        }
       });
 
       return kuzzle.collection.list('index', options)
@@ -279,11 +285,13 @@ describe('Collection Controller', () => {
   describe('searchSpecifications', () => {
     it('should call collection/searchSpecifications query with search filter and return a Promise which resolves a SpecificationsSearchResult object', () => {
       kuzzle.query.resolves({
-        hits: [
-          {foo: 'bar'},
-          {bar: 'foo'}
-        ],
-        total: 2
+        result: {
+          hits: [
+            {foo: 'bar'},
+            {bar: 'foo'}
+          ],
+          total: 2
+        }
       });
 
       const body = {foo: 'bar'};
@@ -335,7 +343,7 @@ describe('Collection Controller', () => {
     });
 
     it('should call collection/truncate query and return a Promise which resolves an acknowledgement', () => {
-      kuzzle.query.resolves({acknowledged: true});
+      kuzzle.query.resolves({result: {acknowledged: true}});
 
       return kuzzle.collection.truncate('index', 'collection', options)
         .then(res => {
@@ -367,7 +375,7 @@ describe('Collection Controller', () => {
     });
 
     it('should call collection/updateMapping query with the new mapping and return a Promise which resolves a json object', () => {
-      kuzzle.query.resolves({foo: 'bar'});
+      kuzzle.query.resolves({result: {foo: 'bar'}});
 
       const body = {foo: 'bar'};
       return kuzzle.collection.updateMapping('index', 'collection', body, options)
@@ -401,7 +409,7 @@ describe('Collection Controller', () => {
     });
 
     it('should call collection/updateSpecifications query with the new specifications and return a Promise which resolves a json object', () => {
-      kuzzle.query.resolves({foo: 'bar'});
+      kuzzle.query.resolves({result: {foo: 'bar'}});
 
       const body = {foo: 'bar'};
       return kuzzle.collection.updateSpecifications('index', 'collection', body, options)
@@ -424,9 +432,11 @@ describe('Collection Controller', () => {
   describe('validateSpecifications', () => {
     it('should call collection/validateSpecifications query with the specifications to validate and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({
-        valid: false,
-        description: 'foo bar',
-        details: ['foo', 'bar']
+        result: {
+          valid: false,
+          description: 'foo bar',
+          details: ['foo', 'bar']
+        }
       });
 
       const body = {foo: 'bar'};

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -29,7 +29,7 @@ describe('Document Controller', () => {
     });
 
     it('should call document/count query and return a Promise which resolves a numeric value', () => {
-      kuzzle.query.resolves({count: 1234});
+      kuzzle.query.resolves({result: {count: 1234}});
 
       return kuzzle.document.count('index', 'collection', {foo: 'bar'}, options)
         .then(res => {
@@ -49,7 +49,7 @@ describe('Document Controller', () => {
     });
 
     it('should inject the "includeTrash" option into the request', () => {
-      kuzzle.query.resolves({count: 1234});
+      kuzzle.query.resolves({result: {count: 1234}});
 
       return kuzzle.document.count('index', 'collection', {foo: 'bar'}, {includeTrash: true})
         .then(res => {
@@ -94,7 +94,7 @@ describe('Document Controller', () => {
         _version: 1,
         _source: {foo: 'bar'}
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.create('index', 'collection', 'document-id', {foo: 'bar'}, options)
         .then(res => {
@@ -120,7 +120,7 @@ describe('Document Controller', () => {
         _version: 1,
         _source: {foo: 'bar'}
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.create('index', 'collection', 'document-id', {foo: 'bar'}, {refresh: true})
         .then(res => {
@@ -173,7 +173,7 @@ describe('Document Controller', () => {
         _source: {foo: 'bar'},
         created: false
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.createOrReplace('index', 'collection', 'document-id', {foo: 'bar'}, options)
         .then(res => {
@@ -200,7 +200,7 @@ describe('Document Controller', () => {
         _source: {foo: 'bar'},
         created: false
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.createOrReplace('index', 'collection', 'document-id', {foo: 'bar'}, {refresh: true})
         .then(res => {
@@ -241,7 +241,7 @@ describe('Document Controller', () => {
     });
 
     it('should call document/delete query and return a Promise which resolves the id of the deleted document', () => {
-      kuzzle.query.resolves({_id: 'document-id'});
+      kuzzle.query.resolves({result: {_id: 'document-id'}});
 
       return kuzzle.document.delete('index', 'collection', 'document-id', options)
         .then(res => {
@@ -261,7 +261,7 @@ describe('Document Controller', () => {
     });
 
     it('should inject the "refresh" option into the request', () => {
-      kuzzle.query.resolves({_id: 'document-id'});
+      kuzzle.query.resolves({result: {_id: 'document-id'}});
 
       return kuzzle.document.delete('index', 'collection', 'document-id', {refresh: true})
         .then(res => {
@@ -295,7 +295,7 @@ describe('Document Controller', () => {
     });
 
     it('should call document/deleteByQuery query and return a Promise which resolves the list of deleted document ids', () => {
-      kuzzle.query.resolves({hits: ['foo', 'bar', 'baz']});
+      kuzzle.query.resolves({result: {hits: ['foo', 'bar', 'baz']}});
 
       return kuzzle.document.deleteByQuery('index', 'collection', {foo: 'bar'}, options)
         .then(res => {
@@ -319,7 +319,7 @@ describe('Document Controller', () => {
     });
 
     it('should inject the "refresh" option into the request', () => {
-      kuzzle.query.resolves({hits: ['foo', 'bar', 'baz']});
+      kuzzle.query.resolves({result: {hits: ['foo', 'bar', 'baz']}});
 
       return kuzzle.document.deleteByQuery('index', 'collection', {foo: 'bar'}, {refresh: true})
         .then(res => {
@@ -364,10 +364,12 @@ describe('Document Controller', () => {
 
     it('should call document/get query and return a Promise which resolves the document', () => {
       kuzzle.query.resolves({
-        _id: 'document-id',
-        _index: 'index',
-        _type: 'collection',
-        _source: {foo: 'bar'},
+        result: {
+          _id: 'document-id',
+          _index: 'index',
+          _type: 'collection',
+          _source: {foo: 'bar'}
+        }
       });
 
       return kuzzle.document.get('index', 'collection', 'document-id', options)
@@ -392,10 +394,12 @@ describe('Document Controller', () => {
 
     it('should inject the "includeTrash" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'document-id',
-        _index: 'index',
-        _type: 'collection',
-        _source: {foo: 'bar'},
+        result: {
+          _id: 'document-id',
+          _index: 'index',
+          _type: 'collection',
+          _source: {foo: 'bar'}
+        }
       });
 
       return kuzzle.document.get('index', 'collection', 'document-id', {includeTrash: true})
@@ -453,7 +457,7 @@ describe('Document Controller', () => {
         }],
         total: 1
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mCreate('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options)
         .then(res => {
@@ -481,7 +485,7 @@ describe('Document Controller', () => {
         }],
         total: 1
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mCreate('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], {refresh: true})
         .then(res => {
@@ -535,7 +539,7 @@ describe('Document Controller', () => {
         }],
         total: 1
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mCreateOrReplace('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options)
         .then(res => {
@@ -563,7 +567,7 @@ describe('Document Controller', () => {
         }],
         total: 1
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mCreateOrReplace('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], {refresh: true})
         .then(res => {
@@ -610,7 +614,7 @@ describe('Document Controller', () => {
 
     it('should call document/mDelete query and return a Promise which resolves the list of deleted documents ids', () => {
       const result = ['document1', 'document2'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mDelete('index', 'collection', ['document1', 'document2'], options)
         .then(res => {
@@ -631,7 +635,7 @@ describe('Document Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       const result = ['document1', 'document2'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mDelete('index', 'collection', ['document1', 'document2'], {refresh: true})
         .then(res => {
@@ -684,7 +688,7 @@ describe('Document Controller', () => {
         ],
         total: 2
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mGet('index', 'collection', ['document1', 'document2'], options)
         .then(res => {
@@ -711,7 +715,7 @@ describe('Document Controller', () => {
         ],
         total: 2
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mGet('index', 'collection', ['document1', 'document2'], {includeTrash: true})
         .then(res => {
@@ -765,7 +769,7 @@ describe('Document Controller', () => {
         }],
         total: 1
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mReplace('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options)
         .then(res => {
@@ -793,7 +797,7 @@ describe('Document Controller', () => {
         }],
         total: 1
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mReplace('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], {refresh: true})
         .then(res => {
@@ -847,7 +851,7 @@ describe('Document Controller', () => {
         }],
         total: 1
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mUpdate('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options)
         .then(res => {
@@ -875,7 +879,7 @@ describe('Document Controller', () => {
         }],
         total: 1
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.mUpdate('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], {refresh: true})
         .then(res => {
@@ -927,7 +931,7 @@ describe('Document Controller', () => {
         _source: {foo: 'bar'},
         created: false
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.replace('index', 'collection', 'document-id', {foo: 'bar'}, options)
         .then(res => {
@@ -954,7 +958,7 @@ describe('Document Controller', () => {
         _source: {foo: 'bar'},
         created: false
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.replace('index', 'collection', 'document-id', {foo: 'bar'}, {refresh: true})
         .then(res => {
@@ -998,7 +1002,7 @@ describe('Document Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.search('index', 'collection', {foo: 'bar'}, options)
         .then(res => {
@@ -1034,7 +1038,7 @@ describe('Document Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.search('index', 'collection', {foo: 'bar'}, {includeTrash: true})
         .then(res => {
@@ -1069,7 +1073,7 @@ describe('Document Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.search('index', 'collection', {foo: 'bar'}, {from: 1, size: 2, scroll: '1m'})
         .then(res => {
@@ -1128,7 +1132,7 @@ describe('Document Controller', () => {
         _source: {foo: 'bar'},
         created: false
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.update('index', 'collection', 'document-id', {foo: 'bar'}, options)
         .then(res => {
@@ -1156,7 +1160,7 @@ describe('Document Controller', () => {
         _source: {foo: 'bar'},
         created: false
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.update('index', 'collection', 'document-id', {foo: 'bar'}, {refresh: true})
         .then(res => {
@@ -1184,7 +1188,7 @@ describe('Document Controller', () => {
         _source: {foo: 'bar'},
         created: false
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.update('index', 'collection', 'document-id', {foo: 'bar'}, {retryOnConflict: true})
         .then(res => {
@@ -1230,7 +1234,7 @@ describe('Document Controller', () => {
         errorMessages: {},
         valid: true
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.document.validate('index', 'collection', {foo: 'bar'}, options)
         .then(res => {

--- a/test/controllers/index.test.js
+++ b/test/controllers/index.test.js
@@ -23,8 +23,10 @@ describe('Index Controller', () => {
 
     it('should call index/create query and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({
-        acknowledged: true,
-        shards_acknowledged: true
+        result: {
+          acknowledged: true,
+          shards_acknowledged: true
+        }
       });
 
       return kuzzle.index.create('index', options)
@@ -52,7 +54,7 @@ describe('Index Controller', () => {
 
     it('should call index/delete query and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({
-        acknowledged: true
+        result: {acknowledged: true}
       });
 
       return kuzzle.index.delete('index', options)
@@ -78,7 +80,7 @@ describe('Index Controller', () => {
     });
 
     it('should call index/exists query and return a Promise which resolves a boolean', () => {
-      kuzzle.query.resolves(true);
+      kuzzle.query.resolves({result: true});
 
       return kuzzle.index.exists('index', options)
         .then(res => {
@@ -103,7 +105,7 @@ describe('Index Controller', () => {
     });
 
     it('should call index/getAutoRefresh query and return a Promise which resolves a boolean', () => {
-      kuzzle.query.resolves(true);
+      kuzzle.query.resolves({result: true});
 
       return kuzzle.index.getAutoRefresh('index', options)
         .then(res => {
@@ -126,7 +128,7 @@ describe('Index Controller', () => {
         total: 3,
         hits: ['foo', 'bar', 'baz']
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.index.list(options)
         .then(res => {
@@ -159,7 +161,7 @@ describe('Index Controller', () => {
       const result = {
         deleted: ['foo', 'bar']
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.index.mDelete(['foo', 'bar'], options)
         .then(res => {
@@ -191,7 +193,7 @@ describe('Index Controller', () => {
           total: 10
         }
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.index.refresh('index', options)
         .then(res => {
@@ -211,7 +213,7 @@ describe('Index Controller', () => {
   describe('refreshInternal', () => {
     it('should call index/refreshInternal query and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({
-        acknowledged: true
+        result: {acknowledged: true}
       });
 
       return kuzzle.index.refreshInternal(options)
@@ -236,7 +238,7 @@ describe('Index Controller', () => {
     });
 
     it('should call index/setAutoRefresh query to enable autorefresh and return a Promise which resolves true', () => {
-      kuzzle.query.resolves(true);
+      kuzzle.query.resolves({result: true});
 
       return kuzzle.index.setAutoRefresh('index', true, options)
         .then(res => {
@@ -254,7 +256,7 @@ describe('Index Controller', () => {
     });
 
     it('should call index/setAutoRefresh query to disable autorefresh and return a Promise which resolves false', () => {
-      kuzzle.query.resolves(false);
+      kuzzle.query.resolves({result: false});
 
       return kuzzle.index.setAutoRefresh('index', false, options)
         .then(res => {

--- a/test/controllers/realtime.test.js
+++ b/test/controllers/realtime.test.js
@@ -28,7 +28,7 @@ describe('Realtime Controller', () => {
     });
 
     it('should call realtime/count query with the roomId and return a Promise which resolves a number', () => {
-      kuzzle.query.resolves({roomId: 'roomId', count: 1234});
+      kuzzle.query.resolves({result: {roomId: 'roomId', count: 1234}});
 
       return kuzzle.realtime.count('roomId', options)
         .then(res => {
@@ -63,7 +63,7 @@ describe('Realtime Controller', () => {
           }
         }
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.realtime.list(options)
         .then(res => {
@@ -99,7 +99,7 @@ describe('Realtime Controller', () => {
     });
 
     it('should call realtime/publish query with the index, collection and body and return a Promise which resolves an acknowledgement', () => {
-      kuzzle.query.resolves({published: true});
+      kuzzle.query.resolves({result: {published: true}});
 
       return kuzzle.realtime.publish('index', 'collection', {foo: 'bar'}, options)
         .then(res => {
@@ -122,8 +122,7 @@ describe('Realtime Controller', () => {
     const
       roomId = uuidv4(),
       subscribeResponse = {
-        roomId,
-        channel: 'notification-channel'
+        result: {roomId, channel: 'notification-channel'}
       };
 
     let room;
@@ -192,7 +191,7 @@ describe('Realtime Controller', () => {
           should(room.callback).be.equal(cb);
           should(room.options).be.equal(options);
           should(room.subscribe).be.calledOnce();
-          should(res).be.equal(subscribeResponse);
+          should(res).be.equal(subscribeResponse.result);
         });
     });
 
@@ -239,6 +238,8 @@ describe('Realtime Controller', () => {
 
       kuzzle.realtime.subscriptions[roomId] = [room1, room2];
       kuzzle.realtime.subscriptions.foo = [room3];
+
+      kuzzle.query.resolves({result: roomId});
     });
 
     it('should throw an error if the "roomId" argument is not provided', () => {
@@ -279,8 +280,6 @@ describe('Realtime Controller', () => {
     });
 
     it('should call realtime/unsubiscribe query with the roomId and return a Promise which resolves the roomId', () => {
-      kuzzle.query.resolves(roomId);
-
       return kuzzle.realtime.unsubscribe(roomId, options)
         .then(res => {
           should(kuzzle.query)
@@ -320,7 +319,7 @@ describe('Realtime Controller', () => {
         errorMessages: {},
         valid: true
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.realtime.validate('index', 'collection', {foo: 'bar'}, options)
         .then(res => {

--- a/test/controllers/realtime/room.test.js
+++ b/test/controllers/realtime/room.test.js
@@ -123,10 +123,13 @@ describe('Room', () => {
   });
 
   describe('subscribe', () => {
-    it('should call realtime/subscribe action with subscribe filters and return a promise that resolve the roomId and channel', () => {
-      const result = {roomId: 'my-room-id', channel: 'subscription-channel'};
-      kuzzle.query.resolves(result);
+    const response = {result: {roomId: 'my-room-id', channel: 'subscription-channel'}};
 
+    beforeEach(() => {
+      kuzzle.query.resolves(response);
+    });
+
+    it('should call realtime/subscribe action with subscribe filters and return a promise that resolve the roomId and channel', () => {
       const
         opts = {opt: 'in', scope: 'in', state: 'done', users: 'all', volatile: {bar: 'foo'}},
         body = {foo: 'bar'},
@@ -149,14 +152,11 @@ describe('Room', () => {
               volatile: {bar: 'foo'}
             }, options);
 
-          should(res).be.equal(result);
+          should(res).be.equal(response);
         });
     });
 
     it('should set "id" and "channel" properties', () => {
-      const result = {roomId: 'my-room-id', channel: 'subscription-channel'};
-      kuzzle.query.resolves(result);
-
       const
         opts = {opt: 'in', scope: 'in', state: 'done', users: 'all', volatile: {bar: 'foo'}},
         body = {foo: 'bar'},
@@ -171,9 +171,6 @@ describe('Room', () => {
     });
 
     it('should call _channelListener while receiving data on the current channel', () => {
-      const result = {roomId: 'my-room-id', channel: 'subscription-channel'};
-      kuzzle.query.resolves(result);
-
       const
         opts = {opt: 'in', scope: 'in', state: 'done', users: 'all', volatile: {bar: 'foo'}},
         body = {foo: 'bar'},
@@ -194,9 +191,6 @@ describe('Room', () => {
     });
 
     it('should call _reSubscribeListener once reconnected', () => {
-      const result = {roomId: 'my-room-id', channel: 'subscription-channel'};
-      kuzzle.query.resolves(result);
-
       const
         opts = {opt: 'in', scope: 'in', state: 'done', users: 'all', volatile: {bar: 'foo'}},
         body = {foo: 'bar'},

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -114,7 +114,7 @@ describe('DocumentSearchResult', () => {
         };
         searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should call document/scroll action with scrollId parameter and resolve the current object', () => {
@@ -169,7 +169,7 @@ describe('DocumentSearchResult', () => {
         };
         searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should call document/search action with search_after parameter and resolve the current object', () => {
@@ -225,7 +225,7 @@ describe('DocumentSearchResult', () => {
         };
         searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should resolve null without calling kuzzle query if from parameter is greater than the search count', () => {

--- a/test/controllers/searchResult/profile.test.js
+++ b/test/controllers/searchResult/profile.test.js
@@ -123,7 +123,7 @@ describe('ProfileSearchResult', () => {
         };
         searchResult = new ProfileSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should call security/scrollProfiles action with scrollId parameter and resolve the current object', () => {
@@ -186,7 +186,7 @@ describe('ProfileSearchResult', () => {
         };
         searchResult = new ProfileSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should call security/searchProfiles action with search_after parameter and resolve the current object', () => {
@@ -250,7 +250,7 @@ describe('ProfileSearchResult', () => {
         };
         searchResult = new ProfileSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should resolve null without calling kuzzle query if from parameter is greater than the search count', () => {

--- a/test/controllers/searchResult/role.test.js
+++ b/test/controllers/searchResult/role.test.js
@@ -125,7 +125,7 @@ describe('RoleSearchResult', () => {
 
         searchResult = new RoleSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should resolve null without calling kuzzle query if from parameter is greater than the search count', () => {

--- a/test/controllers/searchResult/specifications.test.js
+++ b/test/controllers/searchResult/specifications.test.js
@@ -112,7 +112,7 @@ describe('SpecificationsSearchResult', () => {
         };
         searchResult = new SpecificationsSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should call collection/scrollSpecifications action with scrollId parameter and resolve the current object', () => {
@@ -165,7 +165,7 @@ describe('SpecificationsSearchResult', () => {
         };
         searchResult = new SpecificationsSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should call collection/searchSpecifications action with search_after parameter and resolve the current object', () => {
@@ -219,7 +219,7 @@ describe('SpecificationsSearchResult', () => {
         };
         searchResult = new SpecificationsSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should resolve null without calling kuzzle query if from parameter is greater than the search count', () => {

--- a/test/controllers/searchResult/user.test.js
+++ b/test/controllers/searchResult/user.test.js
@@ -125,7 +125,7 @@ describe('UserSearchResult', () => {
         };
         searchResult = new UserSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should call security/scrollUsers action with scrollId parameter and resolve the current object', () => {
@@ -190,7 +190,7 @@ describe('UserSearchResult', () => {
         };
         searchResult = new UserSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should call security/searchUsers action with search_after parameter and resolve the current object', () => {
@@ -256,7 +256,7 @@ describe('UserSearchResult', () => {
         };
         searchResult = new UserSearchResult(kuzzle, request, options, response);
 
-        kuzzle.query.resolves(nextResponse);
+        kuzzle.query.resolves({result: nextResponse});
       });
 
       it('should resolve null without calling kuzzle query if from parameter is greater than the search count', () => {

--- a/test/controllers/security.test.js
+++ b/test/controllers/security.test.js
@@ -45,7 +45,7 @@ describe('Security Controller', () => {
         username: 'foo',
         kuid: 'kuid'
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.createCredentials('strategy', 'kuid', {foo: 'bar'}, options)
         .then(res => {
@@ -79,10 +79,9 @@ describe('Security Controller', () => {
 
     it('should call security/createFirstAdmin query with the first admin content and credentials and return a Promise which resolves the created user object', () => {
       kuzzle.query.resolves({
-        _id: 'id',
-        _source: {
-          name: 'Doe',
-          profileIds: ['admin']
+        result: {
+          _id: 'id',
+          _source: {name: 'Doe', profileIds: ['admin']}
         }
       });
 
@@ -107,10 +106,9 @@ describe('Security Controller', () => {
 
     it('should inject the "reset" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'id',
-        _source: {
-          name: 'Doe',
-          profileIds: ['admin']
+        result: {
+          _id: 'id',
+          _source: {name: 'Doe', profileIds: ['admin']}
         }
       });
 
@@ -149,14 +147,14 @@ describe('Security Controller', () => {
 
     it('should call security/createOrReplaceProfile query with the profile content and return a Promise which resolves a Profile object', () => {
       kuzzle.query.resolves({
-        _id: 'profileId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 1,
-        _source: {
-          policies: ['foo', 'bar']
-        },
-        created: false
+        result: {
+          _id: 'profileId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 1,
+          _source: {policies: ['foo', 'bar']},
+          created: false
+        }
       });
 
       return kuzzle.security.createOrReplaceProfile('profileId', {foo: 'bar'}, options)
@@ -179,14 +177,14 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'profileId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 1,
-        _source: {
-          policies: ['foo', 'bar']
-        },
-        created: false
+        result: {
+          _id: 'profileId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 1,
+          _source: { policies: ['foo', 'bar'] },
+          created: false
+        }
       });
 
       return kuzzle.security.createOrReplaceProfile('profileId', {foo: 'bar'}, {refresh: true})
@@ -223,14 +221,14 @@ describe('Security Controller', () => {
 
     it('should call security/createOrReplaceRole query with the role content and return a Promise which resolves a Role object', () => {
       kuzzle.query.resolves({
-        _id: 'roleId',
-        _index: '%kuzzle',
-        _type: 'roles',
-        _version: 1,
-        _source: {
-          controllers: {foo: {actions: {bar: true}}}
-        },
-        created: false
+        result: {
+          _id: 'roleId',
+          _index: '%kuzzle',
+          _type: 'roles',
+          _version: 1,
+          _source: { controllers: {foo: {actions: {bar: true}}} },
+          created: false
+        }
       });
 
       return kuzzle.security.createOrReplaceRole('roleId', {foo: 'bar'}, options)
@@ -253,14 +251,14 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'roleId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 1,
-        _source: {
-          controllers: {foo: {actions: {bar: true}}}
-        },
-        created: false
+        result: {
+          _id: 'roleId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 1,
+          _source: { controllers: {foo: {actions: {bar: true}}} },
+          created: false
+        }
       });
 
       return kuzzle.security.createOrReplaceRole('roleId', {foo: 'bar'}, {refresh: true})
@@ -297,14 +295,14 @@ describe('Security Controller', () => {
 
     it('should call security/createProfile query with the profile content and return a Promise which resolves a Profile object', () => {
       kuzzle.query.resolves({
-        _id: 'profileId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 1,
-        _source: {
-          policies: ['foo', 'bar']
-        },
-        created: true
+        result: {
+          _id: 'profileId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 1,
+          _source: { policies: ['foo', 'bar'] },
+          created: true
+        }
       });
 
       return kuzzle.security.createProfile('profileId', {foo: 'bar'}, options)
@@ -327,14 +325,14 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'profileId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 1,
-        _source: {
-          policies: ['foo', 'bar']
-        },
-        created: true
+        result: {
+          _id: 'profileId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 1,
+          _source: { policies: ['foo', 'bar'] },
+          created: true
+        }
       });
 
       return kuzzle.security.createProfile('profileId', {foo: 'bar'}, {refresh: true})
@@ -371,14 +369,14 @@ describe('Security Controller', () => {
 
     it('should call security/createRole query with the role content and return a Promise which resolves a Role object', () => {
       kuzzle.query.resolves({
-        _id: 'roleId',
-        _index: '%kuzzle',
-        _type: 'roles',
-        _version: 1,
-        _source: {
-          controllers: {foo: {actions: {bar: true}}}
-        },
-        created: true
+        result: {
+          _id: 'roleId',
+          _index: '%kuzzle',
+          _type: 'roles',
+          _version: 1,
+          _source: { controllers: {foo: {actions: {bar: true}}} },
+          created: true
+        }
       });
 
       return kuzzle.security.createRole('roleId', {foo: 'bar'}, options)
@@ -401,14 +399,14 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'roleId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 1,
-        _source: {
-          controllers: {foo: {actions: {bar: true}}}
-        },
-        created: true
+        result: {
+          _id: 'roleId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 1,
+          _source: { controllers: {foo: {actions: {bar: true}}} },
+          created: true
+        }
       });
 
       return kuzzle.security.createRole('roleId', {foo: 'bar'}, {refresh: true})
@@ -478,15 +476,14 @@ describe('Security Controller', () => {
       };
 
       kuzzle.query.resolves({
-        _id: 'kuid',
-        _index: '%kuzzle',
-        _source: {
-          profileIds: ['profileId'],
-          name: 'John Doe',
-        },
-        _type: 'users',
-        _version: 1,
-        created: true
+        result: {
+          _id: 'kuid',
+          _index: '%kuzzle',
+          _source: { profileIds: ['profileId'], name: 'John Doe' },
+          _type: 'users',
+          _version: 1,
+          created: true
+        }
       });
 
       return kuzzle.security.createUser('userId', body, options)
@@ -517,15 +514,14 @@ describe('Security Controller', () => {
       };
 
       kuzzle.query.resolves({
-        _id: 'kuid',
-        _index: '%kuzzle',
-        _source: {
-          profileIds: ['profileId'],
-          name: 'John Doe',
-        },
-        _type: 'users',
-        _version: 1,
-        created: true
+        result: {
+          _id: 'kuid',
+          _index: '%kuzzle',
+          _source: { profileIds: ['profileId'], name: 'John Doe' },
+          _type: 'users',
+          _version: 1,
+          created: true
+        }
       });
 
       return kuzzle.security.createUser('userId', body, {refresh: true})
@@ -565,7 +561,7 @@ describe('Security Controller', () => {
       const result = {
         acknowledged: true
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.deleteCredentials('strategy', 'kuid', options)
         .then(res => {
@@ -594,7 +590,7 @@ describe('Security Controller', () => {
       const result = {
         _id: 'profileId'
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.deleteProfile('profileId', options)
         .then(res => {
@@ -622,7 +618,7 @@ describe('Security Controller', () => {
       const result = {
         _id: 'roleId'
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.deleteRole('roleId', options)
         .then(res => {
@@ -650,7 +646,7 @@ describe('Security Controller', () => {
       const result = {
         _id: 'kuid'
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.deleteUser('kuid', options)
         .then(res => {
@@ -673,7 +669,7 @@ describe('Security Controller', () => {
         local: ['username', 'password'],
         foo: ['bar']
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getAllCredentialFields(options)
         .then(res => {
@@ -698,7 +694,7 @@ describe('Security Controller', () => {
 
     it('should call security/getCredentialFields query and return a Promise which resolves the list of credendial fields', () => {
       const result = ['username', 'password'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getCredentialFields('strategy', options)
         .then(res => {
@@ -733,7 +729,7 @@ describe('Security Controller', () => {
         username: 'foo',
         kuid: 'kuid'
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getCredentials('strategy', 'kuid', options)
         .then(res => {
@@ -769,7 +765,7 @@ describe('Security Controller', () => {
         username: 'foo',
         kuid: 'kuid'
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getCredentialsById('strategy', 'userId', options)
         .then(res => {
@@ -796,12 +792,12 @@ describe('Security Controller', () => {
 
     it('should call security/getProfile query with the profile id a Promise which resolves a Profile object', () => {
       kuzzle.query.resolves({
-        _id: 'profileId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 1,
-        _source: {
-          policies: ['foo', 'bar']
+        result: {
+          _id: 'profileId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 1,
+          _source: { policies: ['foo', 'bar'] }
         }
       });
 
@@ -827,7 +823,7 @@ describe('Security Controller', () => {
       const result = {
         mapping: {foo: 'bar'}
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getProfileMapping(options)
         .then(res => {
@@ -857,7 +853,7 @@ describe('Security Controller', () => {
           {controller: 'foo', action: 'bar', index: 'index', collection: 'collecton', value: 'allowed'}
         ]
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getProfileRights('profileId', options)
         .then(res => {
@@ -883,12 +879,12 @@ describe('Security Controller', () => {
 
     it('should call security/getRole query with the role id a Promise which resolves a Role object', () => {
       kuzzle.query.resolves({
-        _id: 'roleId',
-        _index: '%kuzzle',
-        _type: 'roles',
-        _version: 1,
-        _source: {
-          controllers: {foo: {actions: {bar: true}}}
+        result: {
+          _id: 'roleId',
+          _index: '%kuzzle',
+          _type: 'roles',
+          _version: 1,
+          _source: { controllers: {foo: {actions: {bar: true}}} }
         }
       });
 
@@ -914,7 +910,7 @@ describe('Security Controller', () => {
       const result = {
         mapping: {foo: 'bar'}
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getRoleMapping(options)
         .then(res => {
@@ -939,14 +935,13 @@ describe('Security Controller', () => {
 
     it('should call security/getUser query with the user id a Promise which resolves a User object', () => {
       kuzzle.query.resolves({
-        _id: 'kuid',
-        _index: '%kuzzle',
-        _source: {
-          profileIds: ['profileId'],
-          name: 'John Doe',
-        },
-        _type: 'users',
-        _version: 1
+        result: {
+          _id: 'kuid',
+          _index: '%kuzzle',
+          _source: { profileIds: ['profileId'], name: 'John Doe'},
+          _type: 'users',
+          _version: 1
+        }
       });
 
       return kuzzle.security.getUser('kuid', options)
@@ -972,7 +967,7 @@ describe('Security Controller', () => {
       const result = {
         mapping: {foo: 'bar'}
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getUserMapping(options)
         .then(res => {
@@ -1002,7 +997,7 @@ describe('Security Controller', () => {
           {controller: 'foo', action: 'bar', index: 'index', collection: 'collecton', value: 'allowed'}
         ]
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.getUserRights('kuid', options)
         .then(res => {
@@ -1033,7 +1028,7 @@ describe('Security Controller', () => {
     });
 
     it('should call security/hasCredentials query and return a Promise which resolves a boolean', () => {
-      kuzzle.query.resolves(true);
+      kuzzle.query.resolves({result: true});
 
       return kuzzle.security.hasCredentials('strategy', 'kuid', options)
         .then(res => {
@@ -1066,7 +1061,7 @@ describe('Security Controller', () => {
 
     it('should call security/mDeleteProfiles query and return a Promise which resolves the list of deleted profiles ids', () => {
       const result = ['profile1', 'profile2'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.mDeleteProfiles(['profile1', 'profile2'], options)
         .then(res => {
@@ -1085,7 +1080,7 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       const result = ['profile1', 'profile2'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.mDeleteProfiles(['profile1', 'profile2'], {refresh: true})
         .then(res => {
@@ -1118,7 +1113,7 @@ describe('Security Controller', () => {
 
     it('should call security/mDeleteRoles query and return a Promise which resolves the list of deleted roles ids', () => {
       const result = ['role1', 'role2'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.mDeleteRoles(['role1', 'role2'], options)
         .then(res => {
@@ -1137,7 +1132,7 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       const result = ['role1', 'role2'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.mDeleteRoles(['role1', 'role2'], {refresh: true})
         .then(res => {
@@ -1170,7 +1165,7 @@ describe('Security Controller', () => {
 
     it('should call security/mDeleteUsers query and return a Promise which resolves the list of deleted users ids', () => {
       const result = ['user1', 'user2'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.mDeleteUsers(['user1', 'user2'], options)
         .then(res => {
@@ -1189,7 +1184,7 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       const result = ['user1', 'user2'];
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.mDeleteUsers(['user1', 'user2'], {refresh: true})
         .then(res => {
@@ -1228,7 +1223,7 @@ describe('Security Controller', () => {
         ],
         total: 2
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.mGetProfiles(['profile1', 'profile2'], options)
         .then(res => {
@@ -1275,7 +1270,7 @@ describe('Security Controller', () => {
         ],
         total: 2
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.mGetRoles(['role1', 'role2'], options)
         .then(res => {
@@ -1316,15 +1311,14 @@ describe('Security Controller', () => {
 
     it('should call security/replaceUser query with the user content and return a Promise which resolves a User object', () => {
       kuzzle.query.resolves({
-        _id: 'kuid',
-        _index: '%kuzzle',
-        _source: {
-          profileIds: ['profileId'],
-          name: 'John Doe',
-        },
-        _type: 'users',
-        _version: 2,
-        created: false
+        result: {
+          _id: 'kuid',
+          _index: '%kuzzle',
+          _source: { profileIds: ['profileId'], name: 'John Doe' },
+          _type: 'users',
+          _version: 2,
+          created: false
+        }
       });
 
       return kuzzle.security.replaceUser('userId', {foo: 'bar'}, options)
@@ -1348,15 +1342,14 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'kuid',
-        _index: '%kuzzle',
-        _source: {
-          profileIds: ['profileId'],
-          name: 'John Doe',
-        },
-        _type: 'users',
-        _version: 1,
-        created: true
+        result: {
+          _id: 'kuid',
+          _index: '%kuzzle',
+          _source: { profileIds: ['profileId'], name: 'John Doe' },
+          _type: 'users',
+          _version: 1,
+          created: true
+        }
       });
 
       return kuzzle.security.replaceUser('userId', {foo: 'bar'}, {refresh: true})
@@ -1389,7 +1382,7 @@ describe('Security Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.searchProfiles({roles: ['foo', 'bar']}, options)
         .then(res => {
@@ -1420,7 +1413,7 @@ describe('Security Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.searchProfiles({roles: ['foo', 'bar']}, {from: 1, size: 2, scroll: '1m'})
         .then(res => {
@@ -1454,7 +1447,7 @@ describe('Security Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.searchRoles({controllers: ['foo', 'bar']}, options)
         .then(res => {
@@ -1484,7 +1477,7 @@ describe('Security Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.searchRoles({controllers: ['foo', 'bar']}, {from: 1, size: 2})
         .then(res => {
@@ -1517,7 +1510,7 @@ describe('Security Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.searchUsers({foo: 'bar'}, options)
         .then(res => {
@@ -1548,7 +1541,7 @@ describe('Security Controller', () => {
         ],
         total: 3
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.searchUsers({foo: 'bar'}, {from: 1, size: 2, scroll: '1m'})
         .then(res => {
@@ -1596,7 +1589,7 @@ describe('Security Controller', () => {
         username: 'foo',
         kuid: 'kuid'
       };
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.security.updateCredentials('strategy', 'kuid', {foo: 'bar'}, options)
         .then(res => {
@@ -1630,14 +1623,14 @@ describe('Security Controller', () => {
 
     it('should call security/updateProfile query with the profile content and return a Promise which resolves a Profile object', () => {
       kuzzle.query.resolves({
-        _id: 'profileId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 2,
-        _source: {
-          policies: ['foo', 'bar']
-        },
-        created: false
+        result: {
+          _id: 'profileId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 2,
+          _source: { policies: ['foo', 'bar'] },
+          created: false
+        }
       });
 
       return kuzzle.security.updateProfile('profileId', {foo: 'bar'}, options)
@@ -1660,14 +1653,14 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'profileId',
-        _index: '%kuzzle',
-        _type: 'profiles',
-        _version: 2,
-        _source: {
-          policies: ['foo', 'bar']
-        },
-        created: false
+        result: {
+          _id: 'profileId',
+          _index: '%kuzzle',
+          _type: 'profiles',
+          _version: 2,
+          _source: { policies: ['foo', 'bar'] },
+          created: false
+        }
       });
 
       return kuzzle.security.updateProfile('profileId', {foo: 'bar'}, {refresh: true})
@@ -1691,7 +1684,7 @@ describe('Security Controller', () => {
 
   describe('updateProfileMapping', () => {
     it('should call security/updateProfileMapping query with the new mapping and return a Promise which resolves an acknowledgement', () => {
-      kuzzle.query.resolves({acknowledged: true});
+      kuzzle.query.resolves({result: {acknowledged: true}});
 
       return kuzzle.security.updateProfileMapping({foo: 'bar'}, options)
         .then(res => {
@@ -1723,14 +1716,14 @@ describe('Security Controller', () => {
 
     it('should call security/updateRole query with the role content and return a Promise which resolves a Role object', () => {
       kuzzle.query.resolves({
-        _id: 'roleId',
-        _index: '%kuzzle',
-        _type: 'roles',
-        _version: 2,
-        _source: {
-          controllers: {foo: {actions: {bar: true}}}
-        },
-        created: false
+        result: {
+          _id: 'roleId',
+          _index: '%kuzzle',
+          _type: 'roles',
+          _version: 2,
+          _source: { controllers: {foo: {actions: {bar: true}}} },
+          created: false
+        }
       });
 
       return kuzzle.security.updateRole('roleId', {foo: 'bar'}, options)
@@ -1753,14 +1746,14 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'roleId',
-        _index: '%kuzzle',
-        _type: 'roles',
-        _version: 2,
-        _source: {
-          controllers: {foo: {actions: {bar: true}}}
-        },
-        created: false
+        result: {
+          _id: 'roleId',
+          _index: '%kuzzle',
+          _type: 'roles',
+          _version: 2,
+          _source: { controllers: {foo: {actions: {bar: true}}} },
+          created: false
+        }
       });
 
       return kuzzle.security.updateRole('roleId', {foo: 'bar'}, {refresh: true})
@@ -1784,7 +1777,7 @@ describe('Security Controller', () => {
 
   describe('updateRoleMapping', () => {
     it('should call security/updateRoleMapping query with the new mapping and return a Promise which resolves an acknowledgement', () => {
-      kuzzle.query.resolves({acknowledged: true});
+      kuzzle.query.resolves({result: {acknowledged: true}});
 
       return kuzzle.security.updateRoleMapping({foo: 'bar'}, options)
         .then(res => {
@@ -1816,15 +1809,14 @@ describe('Security Controller', () => {
 
     it('should call security/updateUser query with the user content to update and return a Promise which resolves a User object', () => {
       kuzzle.query.resolves({
-        _id: 'kuid',
-        _index: '%kuzzle',
-        _source: {
-          profileIds: ['profileId'],
-          name: 'John Doe',
-        },
-        _type: 'users',
-        _version: 2,
-        created: false
+        result: {
+          _id: 'kuid',
+          _index: '%kuzzle',
+          _source: { profileIds: ['profileId'], name: 'John Doe' },
+          _type: 'users',
+          _version: 2,
+          created: false
+        }
       });
 
       return kuzzle.security.updateUser('userId', {foo: 'bar'}, options)
@@ -1848,15 +1840,14 @@ describe('Security Controller', () => {
 
     it('should inject the "refresh" option into the request', () => {
       kuzzle.query.resolves({
-        _id: 'kuid',
-        _index: '%kuzzle',
-        _source: {
-          profileIds: ['profileId'],
-          name: 'John Doe',
-        },
-        _type: 'users',
-        _version: 2,
-        created: false
+        result: {
+          _id: 'kuid',
+          _index: '%kuzzle',
+          _source: { profileIds: ['profileId'], name: 'John Doe' },
+          _type: 'users',
+          _version: 2,
+          created: false
+        }
       });
 
       return kuzzle.security.updateUser('userId', {foo: 'bar'}, {refresh: true})
@@ -1881,7 +1872,7 @@ describe('Security Controller', () => {
 
   describe('updateUserMapping', () => {
     it('should call security/updateUserMapping query with the new mapping and return a Promise which resolves an acknowledgement', () => {
-      kuzzle.query.resolves({acknowledged: true});
+      kuzzle.query.resolves({result: {acknowledged: true}});
 
       return kuzzle.security.updateUserMapping({foo: 'bar'}, options)
         .then(res => {
@@ -1918,7 +1909,7 @@ describe('Security Controller', () => {
     });
 
     it('should call security/validateCredentials query with the user credentials and return a Promise which resolves a boolean', () => {
-      kuzzle.query.resolves(true);
+      kuzzle.query.resolves({result: true});
 
       return kuzzle.security.validateCredentials('strategy', 'kuid', {foo: 'bar'}, options)
         .then(res => {

--- a/test/controllers/server.test.js
+++ b/test/controllers/server.test.js
@@ -20,7 +20,7 @@ describe('Server Controller', () => {
     };
 
     it('should call query with the right arguments and return Promise which resolves a boolean value', () => {
-      kuzzle.query.resolves({exists: true});
+      kuzzle.query.resolves({result: {exists: true}});
 
       return kuzzle.server.adminExists()
         .then(res => {
@@ -37,7 +37,7 @@ describe('Server Controller', () => {
           should(res).be.exactly(true);
 
           kuzzle.query.reset();
-          kuzzle.query.resolves({exists: false});
+          kuzzle.query.resolves({result: {exists: false}});
           return kuzzle.server.adminExists();
         })
         .then(res => {
@@ -45,6 +45,11 @@ describe('Server Controller', () => {
           should(kuzzle.query).be.calledWith(expectedQuery);
           should(res).be.exactly(false);
         });
+    });
+
+    it('should reject the promise if receiving a response in bad format (missing result)', () => {
+      kuzzle.query.resolves({foo: 'bar'});
+      return should(kuzzle.server.adminExists()).be.rejectedWith({status: 400, message: 'adminExists: bad response format'});
     });
 
     it('should reject the promise if receiving a response in bad format (missing "exists" attribute)', () => {
@@ -96,7 +101,7 @@ describe('Server Controller', () => {
       };
 
     it('should call query with the right arguments and return Promise which resolves all the statistics frames', () => {
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.server.getAllStats()
         .then(res => {
@@ -149,7 +154,7 @@ describe('Server Controller', () => {
       };
 
     it('should call query with the right arguments and return Promise which resolves the configuration', () => {
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.server.getConfig()
         .then(res => {
@@ -209,7 +214,7 @@ describe('Server Controller', () => {
       };
 
     it('should call query with the right arguments and return Promise which resolves the last statistic frame', () => {
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.server.getLastStats()
         .then(res => {
@@ -263,7 +268,7 @@ describe('Server Controller', () => {
       };
 
     it('should call query with the right arguments and return Promise which resolves the requested statistics frames', () => {
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       const expectedQuery = {
         controller: 'server',
@@ -369,7 +374,7 @@ describe('Server Controller', () => {
       };
 
     it('should call query with the right arguments and return Promise which resolves the server informations', () => {
-      kuzzle.query.resolves(result);
+      kuzzle.query.resolves({result});
 
       return kuzzle.server.info()
         .then(res => {
@@ -403,7 +408,7 @@ describe('Server Controller', () => {
     };
 
     it('should call query with the right arguments and return Promise which resolves current server timestamp', () => {
-      kuzzle.query.resolves({now: 12345});
+      kuzzle.query.resolves({result: {now: 12345}});
 
       return kuzzle.server.now()
         .then(res => {
@@ -422,13 +427,18 @@ describe('Server Controller', () => {
         });
     });
 
-    it('should reject the promise if receiving a response in bad format (missing "now" attribute)', () => {
+    it('should reject the promise if receiving a response in bad format (missing result)', () => {
       kuzzle.query.resolves({foo: 'bar'});
       return should(kuzzle.server.now()).be.rejectedWith({status: 400, message: 'now: bad response format'});
     });
 
+    it('should reject the promise if receiving a response in bad format (missing "now" attribute)', () => {
+      kuzzle.query.resolves({result: {foo: 'bar'}});
+      return should(kuzzle.server.now()).be.rejectedWith({status: 400, message: 'now: bad response format'});
+    });
+
     it('should reject the promise if receiving a response in bad format (bad type for "now" attribute)', () => {
-      kuzzle.query.resolves({now: 'bar'});
+      kuzzle.query.resolves({result: {now: 'bar'}});
       return should(kuzzle.server.now()).be.rejectedWith({status: 400, message: 'now: bad response format'});
     });
 

--- a/test/kuzzle/query.test.js
+++ b/test/kuzzle/query.test.js
@@ -13,6 +13,9 @@ describe('Kuzzle query management', () => {
         collection: 'collection',
         index: 'index',
         body: {some: 'query'}
+      },
+      response = {
+        result: {foo: 'bar'}
       };
 
     let kuzzle;
@@ -21,7 +24,7 @@ describe('Kuzzle query management', () => {
       const network = new NetworkWrapperMock({host: 'somewhere'});
 
       kuzzle = new Kuzzle(network);
-      kuzzle.network.query.resolves({result: {}});
+      kuzzle.network.query.resolves(response);
     });
 
     it('should generate a valid request object with no "options" argument and no callback', () => {
@@ -50,6 +53,11 @@ describe('Kuzzle query management', () => {
         volatile: {sdkInstanceId: kuzzle.network.id, sdkVersion: kuzzle.sdkVersion},
         requestId: sinon.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
       });
+    });
+
+    it('should return the good response from Kuzzle', () => {
+      return kuzzle.query(query, {foo: 'bar', baz: 'yolo'})
+        .then(res => should(res).be.equal(response));
     });
 
     it('should manage arguments properly if no options are provided', () => {


### PR DESCRIPTION
## What does this PR do?

Make kuzzle.query return value consistent with other sdks, and give access to the whole Kuzzle response.

Given we have following response from Kuzzle:
```json
{
  "status": 200,
  "error": null,
  "result": {"foo": "bar"},
  "volatile": {"you": "'win"}
}
```

Before this PR: 

* `kuzzle.query` resolved only the result (`{foo: 'bar'}`)

* Some actions resolved directly the result from `Kuzzle.query`
example: `server.getAllStats` (https://github.com/kuzzleio/sdk-javascript/blob/6.x/src/controllers/server.js#L49 ):
```javascript
return this.kuzzle.query({
  controller: 'server',
  action: 'getAllStats'
}, options);
```

* Some other parsed the query result to resolve the pertinent value (exemlpe
example: `server.now` (https://github.com/kuzzleio/sdk-javascript/blob/6.x/src/controllers/server.js#L118):
```javascript
return this.kuzzle.query({
  controller: 'server',
  action: 'now'
}, options)
  .then(result => result.now);
```

Now:

* `kuzzle.query` act as a low-level method which resolves the whole response from the backend, giving access to the response's status, the volatile data, etc.

* Consequently, each controller's actions must parse the response to resolve the `response.result` object.
Examples:

`server.getAllstats`:
```javascript
return this.kuzzle.query({
  controller: 'server',
  action: 'getAllStats'
}, options)
  .then(response => response.result);
```

`server.now`:
```javascript
return this.kuzzle.query({
  controller: 'server',
  action: 'now'
}, options)
  .then(response => response.result.now);
```