### PR TITLE
[HTTP] Do not send unsafe headers in browser mode

### DIFF
--- a/src/networkWrapper/protocols/http.js
+++ b/src/networkWrapper/protocols/http.js
@@ -155,8 +155,6 @@ class HttpWrapper extends AbtractWrapper {
       }
     }
 
-    payload.headers['Content-Length'] = Buffer.byteLength(payload.body || '');
-
     const
       route = this.http.routes[payload.controller] && this.http.routes[payload.controller][payload.action];
 
@@ -209,8 +207,11 @@ class HttpWrapper extends AbtractWrapper {
       const httpClient = require('min-req-promise');
       const url = `${this.protocol}://${this.host}:${this.port}${path}`;
 
+      const headers = payload.headers || {};
+      headers['Content-Length'] = Buffer.byteLength(payload.body || '');
+
       return httpClient.request(url, method, {
-        headers: payload.headers,
+        headers,
         body: payload.body
       })
         .then(response => JSON.parse(response.body));


### PR DESCRIPTION
fix #292

inject `Content-length` header only in nodejs implemenation
(in browser mode, this header is automatically injected by the browser and should not be changed)
