### PR TITLE
remove unused properties

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -391,24 +391,4 @@ class Kuzzle extends KuzzleEventEmitter {
   }
 }
 
-
-for (const prop of [
-  'autoQueue',
-  'autoReconnect',
-  'autoReplay',
-  'jwt',
-  'host',
-  'offlineQueue',
-  'offlineQueueLoader',
-  'port',
-  'queueFilter',
-  'queueMaxSize',
-  'queueTTL',
-  'reconnectionDelay',
-  'replayInterval',
-  'sslConnection'
-]) {
-  Object.defineProperty(Kuzzle.prototype, prop, {enumerable: true});
-}
-
 module.exports = Kuzzle;

--- a/src/networkWrapper/protocols/abstract/common.js
+++ b/src/networkWrapper/protocols/abstract/common.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const
-  uuidv4 = require('../../../uuidv4'),
   KuzzleEventEmitter = require('../../../eventEmitter');
 
-const
-  _id = uuidv4();
 // read-only properties
 let
   _host,
@@ -37,10 +34,6 @@ class AbstractWrapper extends KuzzleEventEmitter {
         this[opt] = options[opt];
       }
     });
-  }
-
-  get id () {
-    return _id;
   }
 
   get host () {
@@ -260,16 +253,6 @@ Discarded request: ${JSON.stringify(request)}`));
       this.send(request);
     });
   }
-}
-
-// make public getters enumerable
-for (const prop of [
-  'host',
-  'id',
-  'port',
-  'ssl'
-]) {
-  Object.defineProperty(AbstractWrapper.prototype, prop, {enumerable: true});
 }
 
 module.exports = AbstractWrapper;

--- a/src/networkWrapper/protocols/abstract/realtime.js
+++ b/src/networkWrapper/protocols/abstract/realtime.js
@@ -85,12 +85,4 @@ class RTWrapper extends AbstractWrapper {
   }
 }
 
-// make public properties enumerable
-for (const prop of [
-  'autoReconnect',
-  'reconnectionDelay'
-]) {
-  Object.defineProperty(RTWrapper.prototype, prop, {enumerable: true});
-}
-
 module.exports = RTWrapper;

--- a/src/networkWrapper/protocols/http.js
+++ b/src/networkWrapper/protocols/http.js
@@ -245,10 +245,4 @@ class HttpWrapper extends AbtractWrapper {
 
 }
 
-for (const prop of [
-  'protocol'
-]) {
-  Object.defineProperty(HttpWrapper.prototype, prop, {enumerable: true});
-}
-
 module.exports = HttpWrapper;


### PR DESCRIPTION
## What does this PR do?

This PR removes some unused properties from the SDK

1. `Kuzzle.network.id` is never used. Further, being defined in the module scope, its value would have been the same between several Kuzzle isntances sharing the same require
2. The attempt to make the getters enumerable just don't work.