### PR TITLE
fix jwt in query

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -341,8 +341,8 @@ class Kuzzle extends KuzzleEventEmitter {
      * a developer simply wish to verify his token
      */
     if (this.jwt !== undefined
-      && request.controller !== 'auth'
-      && request.action !== 'checkToken'
+      && !(request.controller === 'auth' 
+      && request.action === 'checkToken')
     ) {
       request.jwt = this.jwt;
     }


### PR DESCRIPTION
## What does this PR do?

Fix a bug where the JWT would not be set if the controller would be `auth` and the action different from `checkToken`
