### PR TITLE
document:delete to return the id of the deleted document

### DIFF
--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -115,7 +115,7 @@ class DocumentController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(response => response.result);
+      .then(response => response.result._id);
   }
 
   deleteByQuery(index, collection, body = {}, options = {}) {

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -256,7 +256,7 @@ describe('Document Controller', () => {
               refresh: undefined
             }, options);
 
-          should(res._id).be.equal('document-id');
+          should(res).equal('document-id');
         });
     });
 
@@ -276,7 +276,7 @@ describe('Document Controller', () => {
               refresh: true
             }, {});
 
-          should(res._id).be.equal('document-id');
+          should(res).equal('document-id');
         });
     });
   });


### PR DESCRIPTION
## What does this PR do?

This PR aligns the result of the  `document:delete` with the other sdks by returning the id of the deleted document.
