### PR TITLE
KZL-547 - Update validateSpecifications signature to take index and collection

### DIFF
--- a/src/controllers/collection.js
+++ b/src/controllers/collection.js
@@ -171,7 +171,7 @@ class CollectionController {
       .then(response => response.result);
   }
 
-  updateSpecifications (index, collection, body, options = {}) {
+  updateSpecifications (index, collection, specifications, options = {}) {
     if (!index) {
       throw new Error('Kuzzle.collection.updateSpecifications: index is required');
     }
@@ -179,9 +179,13 @@ class CollectionController {
       throw new Error('Kuzzle.collection.updateSpecifications: collection is required');
     }
 
+    const body = {
+      [index]: {
+        [collection]: specifications
+      }
+    };
+
     return this.kuzzle.query({
-      index,
-      collection,
       body,
       controller: 'collection',
       action: 'updateSpecifications'
@@ -189,7 +193,20 @@ class CollectionController {
       .then(response => response.result);
   }
 
-  validateSpecifications (body, options = {}) {
+  validateSpecifications (index, collection, specifications, options = {}) {
+    if (!index) {
+      throw new Error('Kuzzle.collection.validateSpecifications: index is required');
+    }
+    if (!collection) {
+      throw new Error('Kuzzle.collection.validateSpecifications: collection is required');
+    }
+
+    const body = {
+      [index]: {
+        [collection]: specifications
+      }
+    };
+
     return this.kuzzle.query({
       body,
       controller: 'collection',

--- a/src/controllers/collection.js
+++ b/src/controllers/collection.js
@@ -179,7 +179,7 @@ class CollectionController {
       throw new Error('Kuzzle.collection.updateSpecifications: collection is required');
     }
     if (!specifications) {
-      throw new Error('Kuzzle.collection.updateSpecifications: specifications is required');
+      throw new Error('Kuzzle.collection.updateSpecifications: specifications are required');
     }
 
     const body = {
@@ -204,7 +204,7 @@ class CollectionController {
       throw new Error('Kuzzle.collection.validateSpecifications: collection is required');
     }
     if (!specifications) {
-      throw new Error('Kuzzle.collection.updateSpecifications: specifications is required');
+      throw new Error('Kuzzle.collection.updateSpecifications: specifications are required');
     }
 
     const body = {

--- a/src/controllers/collection.js
+++ b/src/controllers/collection.js
@@ -178,6 +178,9 @@ class CollectionController {
     if (!collection) {
       throw new Error('Kuzzle.collection.updateSpecifications: collection is required');
     }
+    if (!specifications) {
+      throw new Error('Kuzzle.collection.updateSpecifications: specifications is required');
+    }
 
     const body = {
       [index]: {
@@ -199,6 +202,9 @@ class CollectionController {
     }
     if (!collection) {
       throw new Error('Kuzzle.collection.validateSpecifications: collection is required');
+    }
+    if (!specifications) {
+      throw new Error('Kuzzle.collection.updateSpecifications: specifications is required');
     }
 
     const body = {

--- a/test/controllers/collection.test.js
+++ b/test/controllers/collection.test.js
@@ -411,17 +411,19 @@ describe('Collection Controller', () => {
     it('should call collection/updateSpecifications query with the new specifications and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({result: {foo: 'bar'}});
 
-      const body = {foo: 'bar'};
-      return kuzzle.collection.updateSpecifications('index', 'collection', body, options)
+      const specifications = {foo: 'bar'};
+      return kuzzle.collection.updateSpecifications('index', 'collection', specifications, options)
         .then(res => {
           should(kuzzle.query)
             .be.calledOnce()
             .be.calledWith({
-              body,
+              body: {
+                index: {
+                  collection: specifications
+                }
+              },
               controller: 'collection',
-              action: 'updateSpecifications',
-              index: 'index',
-              collection: 'collection'
+              action: 'updateSpecifications'
             }, options);
 
           should(res).match({foo: 'bar'});
@@ -439,13 +441,17 @@ describe('Collection Controller', () => {
         }
       });
 
-      const body = {foo: 'bar'};
-      return kuzzle.collection.validateSpecifications(body, options)
+      const specifications = {foo: 'bar'};
+      return kuzzle.collection.validateSpecifications('index', 'collection', specifications, options)
         .then(res => {
           should(kuzzle.query)
             .be.calledOnce()
             .be.calledWith({
-              body,
+              body: {
+                index: {
+                  collection: specifications
+                }
+              },
               controller: 'collection',
               action: 'validateSpecifications'
             }, options);


### PR DESCRIPTION
## What does this PR do?

Before the method `validateSpecifications` didn't take an index an a collection in parameters and could be used for any collection.  
This PR change the signature to match the rest of the collection controller. The method now take an index and a collection in addition to the specifications for this collection.

I also modify the `updateSpecifications` method. The method was taking an index and collection in parameter but it didn't scope the specifications to the collection. 

Related PR: https://github.com/kuzzleio/sdk-javascript/pull/318, https://github.com/kuzzleio/sdk-go/pull/211, https://github.com/kuzzleio/sdk-c/pull/13, https://github.com/kuzzleio/sdk-cpp/pull/11, https://github.com/kuzzleio/sdk-java/pull/13, https://github.com/kuzzleio/documentation-V2/pull/51
### How should this be manually tested?

  - Step 1 : Create `my-index` and `my-collection`
  - Step 2 : Download this script at the sdk-js root and run it: https://gist.github.com/Aschen/41f6c5cf349d81cc1000b16983b7c946
 - Step 3 : It should create specifications for your collection
