### PR TITLE
Fix return value for index#list and index#mDelete

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -70,7 +70,7 @@ class IndexController {
       controller: 'index',
       action: 'list'
     }, options)
-      .then(response => response.result);
+      .then(response => response.result.indexes);
   }
 
   mDelete (indexes, options) {
@@ -85,7 +85,7 @@ class IndexController {
         indexes
       }
     }, options)
-      .then(response => response.result);
+      .then(response => response.result.deleted);
   }
 
   refresh (index, options) {

--- a/test/controllers/index.test.js
+++ b/test/controllers/index.test.js
@@ -125,8 +125,7 @@ describe('Index Controller', () => {
   describe('list', () => {
     it('should call index/list query and return a Promise which resolves the list of available indexes', () => {
       const result = {
-        total: 3,
-        hits: ['foo', 'bar', 'baz']
+        indexes: ['foo', 'bar', 'baz']
       };
       kuzzle.query.resolves({result});
 
@@ -139,7 +138,7 @@ describe('Index Controller', () => {
               action: 'list'
             }, options);
 
-          should(res).be.equal(result);
+          should(res).be.equal(result.indexes);
         });
     });
   });
@@ -173,7 +172,7 @@ describe('Index Controller', () => {
               body: {indexes: ['foo', 'bar']}
             }, options);
 
-          should(res).be.equal(result);
+          should(res).be.equal(result.deleted);
         });
     });
   });


### PR DESCRIPTION
## What does this PR do?

This PR fix the return value for index#list and index#mDelete.  
They now returns array of strings instead of an object containing only one property.

### How should this be manually tested?

  - Step 1 : Create some indexes `for i in {1..10}; do; curl -H "Content-Type: application/json" -X POST "http://localhost:7512/test$i/_create" &; sleep 0.05; done`
  - Step 2 : List them `await kuzzle.index.list() ` and check return value
  - Step 3 : Delete them `await kuzzle.index.mDelete(['test1', 'test2']) and check return value
