### PR TITLE
deleteByQuery - return value

### DIFF
--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -137,7 +137,7 @@ class DocumentController {
     delete options.refresh;
 
     return this.kuzzle.query(request, options)
-      .then(response => response.result);
+      .then(response => response.result.ids);
   }
 
   get (index, collection, _id, options = {}) {

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -295,7 +295,7 @@ describe('Document Controller', () => {
     });
 
     it('should call document/deleteByQuery query and return a Promise which resolves the list of deleted document ids', () => {
-      kuzzle.query.resolves({result: {hits: ['foo', 'bar', 'baz']}});
+      kuzzle.query.resolves({result: {ids: ['foo', 'bar', 'baz']}});
 
       return kuzzle.document.deleteByQuery('index', 'collection', {foo: 'bar'}, options)
         .then(res => {
@@ -310,16 +310,16 @@ describe('Document Controller', () => {
               refresh: undefined
             }, options);
 
-          should(res.hits).be.an.Array();
-          should(res.hits.length).be.equal(3);
-          should(res.hits[0]).be.equal('foo');
-          should(res.hits[1]).be.equal('bar');
-          should(res.hits[2]).be.equal('baz');
+          should(res).be.an.Array();
+          should(res.length).be.equal(3);
+          should(res[0]).be.equal('foo');
+          should(res[1]).be.equal('bar');
+          should(res[2]).be.equal('baz');
         });
     });
 
     it('should inject the "refresh" option into the request', () => {
-      kuzzle.query.resolves({result: {hits: ['foo', 'bar', 'baz']}});
+      kuzzle.query.resolves({result: {ids: ['foo', 'bar', 'baz']}});
 
       return kuzzle.document.deleteByQuery('index', 'collection', {foo: 'bar'}, {refresh: true})
         .then(res => {
@@ -334,11 +334,11 @@ describe('Document Controller', () => {
               refresh: true
             }, {});
 
-          should(res.hits).be.an.Array();
-          should(res.hits.length).be.equal(3);
-          should(res.hits[0]).be.equal('foo');
-          should(res.hits[1]).be.equal('bar');
-          should(res.hits[2]).be.equal('baz');
+          should(res).be.an.Array();
+          should(res.length).be.equal(3);
+          should(res[0]).be.equal('foo');
+          should(res[1]).be.equal('bar');
+          should(res[2]).be.equal('baz');
         });
     });
   });


### PR DESCRIPTION
This PR fixes the output format  of the `document.deleteByQuery` to return an array of delete ids instead of the api result object.

Related: https://github.com/kuzzleio/documentation/pull/540