### PR TITLE
Harmonize SDK

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -228,7 +228,7 @@ class AuthController {
       controller: 'auth',
       action: 'updateSelf'
     }, options)
-      .then(response => response.result);
+      .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   /**

--- a/src/controllers/bulk.js
+++ b/src/controllers/bulk.js
@@ -17,7 +17,7 @@ class BulkController {
         bulkData: data
       }
     }, options)
-      .then(response => response.result);
+      .then(response => response.result.hits);
   }
 
 }

--- a/src/controllers/bulk.js
+++ b/src/controllers/bulk.js
@@ -17,7 +17,7 @@ class BulkController {
         bulkData: data
       }
     }, options)
-      .then(response => response.result.hits);
+      .then(response => response.result.items);
   }
 
 }

--- a/src/controllers/collection.js
+++ b/src/controllers/collection.js
@@ -193,7 +193,7 @@ class CollectionController {
       controller: 'collection',
       action: 'updateSpecifications'
     }, options)
-      .then(response => response.result);
+      .then(response => response.result[index][collection]);
   }
 
   validateSpecifications (index, collection, specifications, options = {}) {

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -317,7 +317,7 @@ describe('Auth Controller', () => {
   });
 
   describe('updateSelf', () => {
-    it('should call auth/updateSelf query with the user content and return a Promise which resolves a json object', () => {
+    it('should call auth/updateSelf query with the user content and return a Promise which resolves a User object', () => {
       const body = {foo: 'bar'};
 
       kuzzle.query.resolves({
@@ -328,7 +328,7 @@ describe('Auth Controller', () => {
       });
 
       return kuzzle.auth.updateSelf(body, options)
-        .then(res => {
+        .then(user => {
           should(kuzzle.query)
             .be.calledOnce()
             .be.calledWith({
@@ -337,7 +337,9 @@ describe('Auth Controller', () => {
               body
             }, options);
 
-          should(res).match({_id: 'kuid', _source: {foo: 'bar'}});
+          should(user).be.an.instanceOf(User);
+          should(user._id).eql('kuid');
+          should(user.content).eql({foo: 'bar'});
         });
     });
   });

--- a/test/controllers/bulk.test.js
+++ b/test/controllers/bulk.test.js
@@ -17,7 +17,7 @@ describe('Bulk Controller', () => {
 
   describe('import', () => {
     it('should call bulk/import query with the bulk data and return a Promise which resolves json object', () => {
-      kuzzle.query.resolves({result: {hits: [
+      kuzzle.query.resolves({result: {items: [
         {create: {_id: 'foo'}, status: 200},
         {update: {_id: 'bar'}, status: 200}
       ]}});

--- a/test/controllers/bulk.test.js
+++ b/test/controllers/bulk.test.js
@@ -34,10 +34,10 @@ describe('Bulk Controller', () => {
               action: 'import'
             }, options);
 
-          should(res).match({hits: [
+          should(res).match([
             {create: {_id: 'foo'}, status: 200},
             {update: {_id: 'bar'}, status: 200}
-          ]});
+          ]);
         });
     });
   });

--- a/test/controllers/collection.test.js
+++ b/test/controllers/collection.test.js
@@ -409,7 +409,7 @@ describe('Collection Controller', () => {
     });
 
     it('should call collection/updateSpecifications query with the new specifications and return a Promise which resolves a json object', () => {
-      kuzzle.query.resolves({result: {foo: 'bar'}});
+      kuzzle.query.resolves({result: { index: { collection: {foo: 'bar'}}}});
 
       const specifications = {foo: 'bar'};
       return kuzzle.collection.updateSpecifications('index', 'collection', specifications, options)


### PR DESCRIPTION
## What does this PR do?

When harmonizing the documentation for the SDJ JS 6, I noticed a few things that deserve to be corrected

 - The method `auth:updateSelf` was returning a promise that resolve to a JSON object.  
:arrow_right:  Change the value resolved by the promise to a `User` object, like the `getCurrentUser` method

 - The method `collection:updateSpecification` return an object containing the index and the collection where the specifications were updated. 
:arrow_right: Return only the updated specifications
 
### How should this be manually tested?


  - Step 1 : Run tests
