### PR TITLE
Fix null id in arguments

### DIFF
--- a/src/networkWrapper/protocols/http.js
+++ b/src/networkWrapper/protocols/http.js
@@ -150,7 +150,7 @@ class HttpWrapper extends AbtractWrapper {
       else if (payload.hasOwnProperty(key)) {
         payload[key] = value;
       }
-      else {
+      else if (value !== undefined && value !== null) {
         queryArgs[key] = value;
       }
     }

--- a/test/network/http.test.js
+++ b/test/network/http.test.js
@@ -348,6 +348,35 @@ describe('HTTP networking module', () => {
 
       network.send(data);
     });
+
+    it('should not add null or undefined arguments to the query args', done => {
+      const data = {
+        requestId: 'requestId',
+        controller: 'foo',
+        action: 'bar',
+        _id: null,
+        toto: undefined
+      };
+
+      network.on('requestId', () => {
+        try {
+          should(network._sendHttpRequest).be.calledOnce();
+          should(network._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar');
+          should(network._sendHttpRequest.firstCall.args[2]).match({
+            requestId: 'requestId',
+            controller: 'foo',
+            action: 'bar'
+          });
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+
+      network.send(data);
+    });
+
   });
 
   describe('#sendHttpRequest NodeJS', () => {


### PR DESCRIPTION
## What does this PR do?

This PR prevent to add `null` or `undefined` arguments to the query args in http protocol.

Fix #324 

### How should this be manually tested?

Run this snippet at the root of `sdk-javascript` folder, the document id should not be the string `'null'`:
```javascript
const Kuzzle = require('./index').Kuzzle;

const kuzzle = new Kuzzle('http', { host: 'localhost', port: 7512 });

(async () => {
  try {
    await kuzzle.connect()
    await kuzzle.index.create('index');
    await kuzzle.collection.create('index', 'collection');

    const doc = await kuzzle.document.create(
      'index',
      'collection',
      null,
      { hello: 'world' },
      { refresh: 'wait_for' }
    );
    console.log(doc);

    const document = await kuzzle.document.get('index', 'collection', doc._id);

    console.log(document);
  } catch (error) {
    console.log(error);
  }
})()
```
