### PR TITLE
Change incoherent method returns

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -83,7 +83,7 @@ class AuthController {
       controller: 'auth',
       action: 'deleteMyCredentials'
     }, options)
-      .then(response => response.result);
+      .then(response => response.result.acknowledged);
   }
 
   /**

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -36,7 +36,7 @@ class IndexController {
       controller: 'index',
       action : 'delete'
     }, options)
-      .then(response => response.result);
+      .then(response => response.result.acknowledged);
   }
 
   exists (index, options) {
@@ -98,7 +98,7 @@ class IndexController {
       controller: 'index',
       action: 'refresh'
     }, options)
-      .then(response => response.result);
+      .then(response => response.result._shards);
   }
 
   refreshInternal (options) {
@@ -106,7 +106,7 @@ class IndexController {
       controller: 'index',
       action: 'refreshInternal'
     }, options)
-      .then(response => response.result);
+      .then(response => response.result.acknowledged);
   }
 
   setAutoRefresh (index, autoRefresh, options) {
@@ -126,7 +126,7 @@ class IndexController {
         autoRefresh
       }
     }, options)
-      .then(response => response.result);
+      .then(response => response.result.response);
   }
 }
 

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -106,7 +106,7 @@ describe('Auth Controller', () => {
               action: 'deleteMyCredentials'
             }, options);
 
-          should(res).match({acknowledged: true});
+            should(res).be.exactly(true);
         });
     });
   });

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -106,7 +106,7 @@ describe('Auth Controller', () => {
               action: 'deleteMyCredentials'
             }, options);
 
-            should(res).be.exactly(true);
+          should(res).be.exactly(true);
         });
     });
   });

--- a/test/controllers/index.test.js
+++ b/test/controllers/index.test.js
@@ -67,7 +67,7 @@ describe('Index Controller', () => {
               index: 'index'
             }, options);
 
-          should(res.acknowledged).be.a.Boolean().and.be.true();
+          should(res).be.a.Boolean().and.be.true();
         });
     });
   });
@@ -204,7 +204,7 @@ describe('Index Controller', () => {
               index: 'index'
             }, options);
 
-          should(res).be.equal(result);
+          should(res).be.equal(result._shards);
         });
     });
   });
@@ -224,7 +224,7 @@ describe('Index Controller', () => {
               action: 'refreshInternal'
             }, options);
 
-          should(res.acknowledged).be.a.Boolean().and.be.true();
+          should(res).be.a.Boolean().and.be.true();
         });
     });
   });
@@ -237,7 +237,7 @@ describe('Index Controller', () => {
     });
 
     it('should call index/setAutoRefresh query to enable autorefresh and return a Promise which resolves true', () => {
-      kuzzle.query.resolves({result: true});
+      kuzzle.query.resolves({result: { response: true }});
 
       return kuzzle.index.setAutoRefresh('index', true, options)
         .then(res => {
@@ -255,7 +255,7 @@ describe('Index Controller', () => {
     });
 
     it('should call index/setAutoRefresh query to disable autorefresh and return a Promise which resolves false', () => {
-      kuzzle.query.resolves({result: false});
+      kuzzle.query.resolves({result: { response: false }});
 
       return kuzzle.index.setAutoRefresh('index', false, options)
         .then(res => {


### PR DESCRIPTION
## What does this PR do?

Simplify returned values for the following methods:
 - `index:delete`
 - `index:setAutoRefresh`
 - `index:refreshInternal`
 - `index:refresh`
 - `auth:deleteMyCredentials`