### PR TITLE
realtime: fix bug

### DIFF
--- a/src/controllers/realtime/index.js
+++ b/src/controllers/realtime/index.js
@@ -73,12 +73,12 @@ class RealTimeController {
     const room = new Room(this.kuzzle, index, collection, filters, callback, options);
 
     return room.subscribe()
-      .then(response => {
+      .then(() => {
         if (!this.subscriptions[room.id]) {
           this.subscriptions[room.id] = [];
         }
         this.subscriptions[room.id].push(room);
-        return response.result;
+        return room.id;
       });
   }
 

--- a/test/controllers/realtime.test.js
+++ b/test/controllers/realtime.test.js
@@ -157,7 +157,7 @@ describe('Realtime Controller', () => {
           should(room.callback).be.equal(cb);
           should(room.options).be.equal(options);
           should(room.subscribe).be.calledOnce();
-          should(res).be.equal(subscribeResponse.result);
+          should(res).be.equal(subscribeResponse.result.roomId);
         });
     });
 


### PR DESCRIPTION
## What does this PR do?
This PR makes `realtime::subscribe` javascript API consistent with other langages.

Instead of resolving to the object `{ channel: 'foo', roomId: 'bar' }`, it resolves to 'bar'

### How should this be manually tested?
You can now unsubscribe directly with the result of subscribe 
