### PR TITLE
Kzl 791 fix exception when publish msg with rest api

### DIFF
--- a/src/controllers/realtime/room.js
+++ b/src/controllers/realtime/room.js
@@ -71,7 +71,7 @@ class Room {
   }
 
   _channelListener (data) {
-    const fromSelf = data.volatile !== undefined && data.volatile.sdkInstanceId === this.kuzzle.network.id;
+    const fromSelf = data.volatile && data.volatile.sdkInstanceId === this.kuzzle.network.id;
     if (this.subscribeToSelf || !fromSelf) {
       this.callback(data);
     }


### PR DESCRIPTION
## What does this PR do?
Fix exception when subscribed to a channel in which someone publish a message using REST API

See https://jira.kaliop.net/browse/KZL-791

### How should this be manually tested?

Use the following client :+1: 
 ``` JS
const Kuzzle  = require('kuzzle-sdk').Kuzzle;


const kuzzle = new Kuzzle('websocket', {host: 'localhost'});

async function run() {
  await kuzzle.connect();
  const roomID = await kuzzle.realtime.subscribe('obix', 'firmwares', {}, (r) => {
    console.log(r);
  })
  
  await kuzzle.realtime.publish('obix', 'firmware', {msg: 'hello world'})
}

run()
```

Use rest API to publish a message:

``` HTTP
POST http://localhost:7512/obix/firmwares/_publish HTTP/1.1
Content-Type: application/json

{
  "msg" : "Heelo REST API"
}
```

=> No more exception
