### PR TITLE
SearchResult - fix scroll next policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2982,12 +2982,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3002,17 +3004,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3129,7 +3134,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3141,6 +3147,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3155,6 +3162,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3162,12 +3170,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3186,6 +3196,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3266,7 +3277,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3278,6 +3290,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3399,6 +3412,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/controllers/searchResult/base.js
+++ b/src/controllers/searchResult/base.js
@@ -31,10 +31,11 @@ class SearchResultBase {
     }
 
     if (this._request.scroll) {
-      return _kuzzle.query(Object.assign({}, this._request, {
+      return _kuzzle.query({
+        controller: this._request.controller,
         action: this._scrollAction,
         scrollId: this._response.scrollId
-      }), this._options)
+      }, this._options)
         .then(response => {
           const result = response.result;
           this.fetched += result.hits.length;

--- a/src/controllers/searchResult/base.js
+++ b/src/controllers/searchResult/base.js
@@ -1,5 +1,3 @@
-const _get = require('lodash.get');
-
 let _kuzzle;
 
 class SearchResultBase {
@@ -59,8 +57,8 @@ class SearchResultBase {
           ? sort
           : Object.keys(sort)[0];
         const value = key === '_uid'
-          ? hit._id
-          : _get(hit._source, key);
+          ? this._request.collection + '#' + hit._id
+          : this._get(hit._source, key.split('.'));
 
         request.search_after.push(value);
       }
@@ -95,6 +93,19 @@ class SearchResultBase {
     }
 
     throw new Error('Unable to retrieve next results from search: missing scrollId, from/sort, or from/size params');
+  }
+
+  _get (object, path) {
+    if (!object) {
+      return object;
+    }
+
+    if (path.length === 1) {
+      return object[path[0]];
+    }
+
+    const key = path.shift();
+    return this._get(object[key], path);
   }
 
 }

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -162,7 +162,7 @@ describe('DocumentSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['foo', {bar: 'asc'}];
+        request.sort = ['foo', {bar: 'asc'}, {_id: 'desc'}];
 
         response = {
           hits: [
@@ -189,8 +189,8 @@ describe('DocumentSearchResult', () => {
                 controller: 'document',
                 action: 'search',
                 size: 2,
-                sort: ['foo', {bar: 'asc'}],
-                search_after: ['barbar', 2345]
+                sort: ['foo', {bar: 'asc'}, {_id: 'desc'}],
+                search_after: ['barbar', 2345, 'document2']
               }, options);
             should(res).be.equal(searchResult);
           });

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -124,12 +124,8 @@ describe('DocumentSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                index: 'index',
-                collection: 'collection',
-                body: {foo: 'bar'},
                 controller: 'document',
                 action: 'scroll',
-                scroll: '1m',
                 scrollId: 'scroll-id'
               }, options);
             should(res).be.equal(searchResult);

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -190,7 +190,7 @@ describe('DocumentSearchResult', () => {
                 action: 'search',
                 size: 2,
                 sort: ['foo', {bar: 'asc'}, {_uid: 'desc'}],
-                search_after: ['barbar', 2345, 'document2']
+                search_after: ['barbar', 2345, 'collection#document2']
               }, options);
             should(res).be.equal(searchResult);
           });

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -162,7 +162,7 @@ describe('DocumentSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['foo', {bar: 'asc'}, {_id: 'desc'}];
+        request.sort = ['foo', {bar: 'asc'}, {_uid: 'desc'}];
 
         response = {
           hits: [
@@ -189,7 +189,7 @@ describe('DocumentSearchResult', () => {
                 controller: 'document',
                 action: 'search',
                 size: 2,
-                sort: ['foo', {bar: 'asc'}, {_id: 'desc'}],
+                sort: ['foo', {bar: 'asc'}, {_uid: 'desc'}],
                 search_after: ['barbar', 2345, 'document2']
               }, options);
             should(res).be.equal(searchResult);

--- a/test/controllers/searchResult/profile.test.js
+++ b/test/controllers/searchResult/profile.test.js
@@ -131,10 +131,8 @@ describe('ProfileSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
                 controller: 'security',
                 action: 'scrollProfiles',
-                scroll: '1m',
                 scrollId: 'scroll-id'
               }, options);
             should(res).be.equal(searchResult);

--- a/test/controllers/searchResult/specifications.test.js
+++ b/test/controllers/searchResult/specifications.test.js
@@ -120,10 +120,8 @@ describe('SpecificationsSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
                 controller: 'collection',
                 action: 'scrollSpecifications',
-                scroll: '1m',
                 scrollId: 'scroll-id'
               }, options);
             should(res).be.equal(searchResult);

--- a/test/controllers/searchResult/user.test.js
+++ b/test/controllers/searchResult/user.test.js
@@ -133,10 +133,8 @@ describe('UserSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
                 controller: 'security',
                 action: 'scrollUsers',
-                scroll: '1m',
                 scrollId: 'scroll-id'
               }, options);
             should(res).be.equal(searchResult);


### PR DESCRIPTION
**:warning: depends on https://github.com/kuzzleio/sdk-javascript/pull/327**

Elasticsearch scroll method does not accept any other parameter than the scrollId. This PR only sends the proper parameters to the method.