### PR TITLE
'ms:sort' needs its options in the request's body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2961,7 +2961,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3376,7 +3377,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3432,6 +3434,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3475,12 +3478,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/controllers/memoryStorage.js
+++ b/src/controllers/memoryStorage.js
@@ -127,7 +127,7 @@ const
     sismember: {getter: true, required: ['_id', 'member'], mapResults: Boolean},
     smembers: getId,
     smove: {required: ['_id', 'destination', 'member'], mapResults: Boolean},
-    sort: {getter: true, required: ['_id'], opts: ['alpha', 'by', 'direction', 'get', 'limit']},
+    sort: {required: ['_id'], opts: ['alpha', 'by', 'direction', 'get', 'limit']},
     spop: {required: ['_id'], opts: ['count'], mapResults: mapStringToArray },
     srandmember: {getter: true, required: ['_id'], opts: ['count'], mapResults: mapStringToArray},
     srem: {required: ['_id', 'members']},

--- a/test/controllers/memoryStorage.test.js
+++ b/test/controllers/memoryStorage.test.js
@@ -1086,12 +1086,12 @@ describe('MemoryStorage Controller', function () {
   });
 
   it('#sort', function () {
-    return testReadCommand(
+    return testWriteCommand(
       'sort',
       ['key'],
       {alpha: true, by: 'foo', direction: 'asc', get: ['foo', 'bar'], limit: {count: 0, offset: 1}},
-      {_id: 'key'},
-      {alpha: true, by: 'foo', direction: 'asc', get: ['foo', 'bar'], limit: {count: 0, offset: 1}},
+      {_id: 'key', body: {alpha: true, by: 'foo', direction: 'asc', get: ['foo', 'bar'], limit: {count: 0, offset: 1}}},
+      {},
       ['foo', 'bar', 'baz'],
       ['foo', 'bar', 'baz']
     );


### PR DESCRIPTION
# Description

The memory storage `sort` method is configured as a getter, meaning that its options are put at the root level of the sent json query. 
But, as stated by the [API documentation](https://docs-v2.kuzzle.io/api/1/controller-memory-storage/sort/), these options are expected in the "body" part of the request (because of the "store" option).

So, in its current state, options set for this command using the SDK are ignored by Kuzzle. 

This PR puts the options at their expected location, making Kuzzle correctly process the sort command.
