### PR TITLE
Fix undefined "volatile.sdkInstanceId" in sent queries

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -341,7 +341,7 @@ class Kuzzle extends KuzzleEventEmitter {
      * a developer simply wish to verify his token
      */
     if (this.jwt !== undefined
-      && !(request.controller === 'auth' 
+      && !(request.controller === 'auth'
       && request.action === 'checkToken')
     ) {
       request.jwt = this.jwt;

--- a/src/networkWrapper/protocols/abstract/common.js
+++ b/src/networkWrapper/protocols/abstract/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const
+  uuidv4 = require('../../../uuidv4'),
   KuzzleEventEmitter = require('../../../eventEmitter');
 
 // read-only properties
@@ -18,6 +19,7 @@ class AbstractWrapper extends KuzzleEventEmitter {
     _port = typeof options.port === 'number' ? options.port : 7512;
     _ssl = typeof options.sslConnection === 'boolean' ? options.sslConnection : false;
 
+    this.id = uuidv4();
     this.autoReplay = false;
     this.autoQueue = false;
     this.offlineQueue = [];

--- a/test/network/http.test.js
+++ b/test/network/http.test.js
@@ -15,6 +15,10 @@ describe('HTTP networking module', () => {
   });
 
   describe('#constructor', () => {
+    it('should expose an unique identifier', () => {
+      should(network.id).be.a.String();
+    });
+
     it('should initialize http network with default routes', () => {
       should(network.http.routes).match({
         auth: {

--- a/test/network/networkWrapper.test.js
+++ b/test/network/networkWrapper.test.js
@@ -1,4 +1,4 @@
-var
+const
   should = require('should'),
   WS = require('../../src/networkWrapper/protocols/websocket'),
   SocketIO = require('../../src/networkWrapper/protocols/socketio'),

--- a/test/network/socketio.test.js
+++ b/test/network/socketio.test.js
@@ -45,12 +45,11 @@ describe('SocketIO networking module', () => {
           }
         }
       },
-      emit: function(evt) {
-        let i;
+      emit: function(...args) {
+        const evt = args.shift();
 
-        const args = Array.prototype.slice.call(arguments, 1);
         if (socketStub.eventOnce[evt]) {
-          for (i in socketStub.eventOnce[evt]) {
+          for (const i in socketStub.eventOnce[evt]) {
             if (typeof socketStub.eventOnce[evt][i] === 'function') {
               socketStub.eventOnce[evt][i].apply(socketIO, args);
               delete socketStub.eventOnce[evt][i];
@@ -58,7 +57,7 @@ describe('SocketIO networking module', () => {
           }
         }
         if (socketStub.events[evt]) {
-          for (i in socketStub.events[evt]) {
+          for (const i in socketStub.events[evt]) {
             if (typeof socketStub.events[evt][i] === 'function') {
               socketStub.events[evt][i].apply(socketIO, args);
             }
@@ -81,6 +80,10 @@ describe('SocketIO networking module', () => {
 
   afterEach(() => {
     clock.restore();
+  });
+
+  it('should expose an unique identifier', () => {
+    should(socketIO.id).be.a.String();
   });
 
   it('should initialize network status when connecting', () => {

--- a/test/network/websocket.test.js
+++ b/test/network/websocket.test.js
@@ -18,8 +18,8 @@ describe('WebSocket networking module', () => {
     };
 
     window = 'foobar'; // eslint-disable-line
-    WebSocket = function () { // eslint-disable-line
-      wsargs = Array.prototype.slice.call(arguments);
+    WebSocket = function (...args) { // eslint-disable-line
+      wsargs = args;
       return clientStub;
     };
 
@@ -35,6 +35,10 @@ describe('WebSocket networking module', () => {
     clock.restore();
     WebSocket = undefined; // eslint-disable-line
     window = undefined; // eslint-disable-line
+  });
+
+  it('should expose an unique identifier', () => {
+    should(websocket.id).be.a.String();
   });
 
   it('should initialize network status when connecting', () => {


### PR DESCRIPTION
# Description

I noticed that, in the `volatile` object in sent queries, the `sdkInstanceId` property was undefined. This is due to the missing unique `id` in the network objects.

This PR adds back the missing id to the base network class, as well as the corresponding unit tests.

# Boyscout

Modernize some lines of codes here and there in the modified unit test files.
