### PR TITLE
Move offline queue from protocol to kuzzle

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -81,6 +81,22 @@ class Kuzzle extends KuzzleEventEmitter {
     this.network.addListener('offlineQueuePop', data => this.emit('offlineQueuePop', data));
     this.network.addListener('queryError', (err, query) => this.emit('queryError', err, query));
 
+    // offline queue
+    this._autoQueue = typeof options.autoQueue === 'boolean' ? options.autoQueue : false;
+    this._autoReplay = typeof options.autoReplay === 'boolean' ? options.autoReplay : false;
+    this._offlineQueue = [];
+    this._offlineQueueLoader = typeof options.offlineQueueLoader === 'function' ? options.offlineQueueLoader : null;
+    this._queueFilter = typeof options.queueFilter === 'function' ? options.queueFilter : null;
+    this._queueMaxSize = typeof options.queueMaxSize === 'number' ? options.queueMaxSize : 500;
+    this._queueTTL = typeof options.queueTTL === 'number' ? options.queueTTL : 120000;
+
+    if (options.offlineMode === 'auto') {
+      this._autoQueue = true;
+      this._autoReplay = true;
+    }
+    this.queuing = false;
+    this.replayInterval = 10;
+
     this.network.addListener('tokenExpired', () => {
       this.jwt = undefined;
       this.emit('tokenExpired');
@@ -88,12 +104,12 @@ class Kuzzle extends KuzzleEventEmitter {
   }
 
   get autoQueue () {
-    return this.network.autoQueue;
+    return this._autoQueue;
   }
 
   set autoQueue (value) {
-    this._checkPropertyType('autoQueue', 'boolean', value);
-    this.network.autoQueue = value;
+    this._checkPropertyType('_autoQueue', 'boolean', value);
+    this._autoQueue = value;
   }
 
   get autoReconnect () {
@@ -106,12 +122,12 @@ class Kuzzle extends KuzzleEventEmitter {
   }
 
   get autoReplay () {
-    return this.network.autoReplay;
+    return this._autoReplay;
   }
 
   set autoReplay (value) {
-    this._checkPropertyType('autoReplay', 'boolean', value);
-    this.network.autoReplay = value;
+    this._checkPropertyType('_autoReplay', 'boolean', value);
+    this._autoReplay = value;
   }
 
   get jwt () {
@@ -141,16 +157,16 @@ class Kuzzle extends KuzzleEventEmitter {
   }
 
   get offlineQueue () {
-    return this.network.offlineQueue;
+    return this._offlineQueue;
   }
 
   get offlineQueueLoader () {
-    return this.network.offlineQueueLoader;
+    return this._offlineQueueLoader;
   }
 
   set offlineQueueLoader (value) {
-    this._checkPropertyType('offlineQueueLoader', 'function', value);
-    this.network.offlineQueueLoader = value;
+    this._checkPropertyType('_offlineQueueLoader', 'function', value);
+    this._offlineQueueLoader = value;
   }
 
   get port () {
@@ -158,30 +174,30 @@ class Kuzzle extends KuzzleEventEmitter {
   }
 
   get queueFilter () {
-    return this.network.queueFilter;
+    return this._queueFilter;
   }
 
   set queueFilter (value) {
-    this._checkPropertyType('queueFilter', 'function', value);
-    this.network.queueFilter = value;
+    this._checkPropertyType('_queueFilter', 'function', value);
+    this._queueFilter= value;
   }
 
   get queueMaxSize () {
-    return this.network.queueMaxSize;
+    return this._queueMaxSize;
   }
 
   set queueMaxSize (value) {
-    this._checkPropertyType('queueMaxSize', 'number', value);
-    this.network.queueMaxSize = value;
+    this._checkPropertyType('_queueMaxSize', 'number', value);
+    this._queueMaxSize = value;
   }
 
   get queueTTL () {
-    return this.network.queueTTL;
+    return this._queueTTL;
   }
 
   set queueTTL (value) {
-    this._checkPropertyType('queueTTL', 'number', value);
-    this.network.queueTTL = value;
+    this._checkPropertyType('_queueTTL', 'number', value);
+    this._queueTTL = value;
   }
 
   get reconnectionDelay () {
@@ -189,12 +205,12 @@ class Kuzzle extends KuzzleEventEmitter {
   }
 
   get replayInterval () {
-    return this.network.replayInterval;
+    return this._replayInterval;
   }
 
   set replayInterval (value) {
-    this._checkPropertyType('replayInterval', 'number', value);
-    this.network.replayInterval = value;
+    this._checkPropertyType('_replayInterval', 'number', value);
+    this._replayInterval = value;
   }
 
   get sslConnection () {
@@ -229,11 +245,26 @@ class Kuzzle extends KuzzleEventEmitter {
       return Promise.resolve();
     }
 
+    if (this.autoQueue) {
+      this.startQueuing();
+    }
+
     this.network.addListener('connect', () => {
+      if (this.autoQueue) {
+        this.stopQueuing();
+      }
+
+      if (this.autoReplay) {
+        this.playQueue();
+      }
+
       this.emit('connected');
     });
 
     this.network.addListener('networkError', error => {
+      if (this.autoQueue) {
+        this.startQueuing();
+      }
       this.emit('networkError', error);
     });
 
@@ -242,6 +273,14 @@ class Kuzzle extends KuzzleEventEmitter {
     });
 
     this.network.addListener('reconnect', () => {
+      if (this.autoQueue) {
+        this.stopQueuing();
+      }
+
+      if (this.autoReplay) {
+        this.playQueue();
+      }
+
       if (this.jwt) {
         this.checkToken(this.jwt, (err, res) => {
           // shouldn't obtain an error but let's invalidate the token anyway
@@ -282,7 +321,7 @@ class Kuzzle extends KuzzleEventEmitter {
    * @returns {Kuzzle}
    */
   flushQueue () {
-    this.network.flushQueue();
+    this._offlineQueue = [];
     return this;
   }
 
@@ -347,14 +386,36 @@ class Kuzzle extends KuzzleEventEmitter {
       request.jwt = this.jwt;
     }
 
-    return this.network.query(request, options);
+    let queuable = true;
+    if (options && options.queuable === false) {
+      queuable = false;
+    }
+
+    if (this.queueFilter) {
+      queuable = queuable && this.queueFilter(request);
+    }
+
+    if (this.queuing && queuable) {
+      this._cleanQueue();
+      this.emit('offlineQueuePush', {request});
+      return new Promise((resolve, reject) => {
+        this.offlineQueue.push({
+          resolve,
+          reject,
+          request,
+          ts: Date.now()
+        });
+      });
+    }
+
+    return this.network.query(request);
   }
 
   /**
    * Starts the requests queuing.
    */
   startQueuing () {
-    this.network.startQueuing();
+    this.queuing = true;
     return this;
   }
 
@@ -362,23 +423,18 @@ class Kuzzle extends KuzzleEventEmitter {
    * Stops the requests queuing.
    */
   stopQueuing () {
-    this.network.stopQueuing();
+    this.queuing = false;
     return this;
-  }
-
-  /**
-   * @DEPRECATED
-   * See Kuzzle.prototype.playQueue();
-   */
-  replayQueue () {
-    return this.playQueue();
   }
 
   /**
    * Plays the requests queued during offline mode.
    */
   playQueue () {
-    this.network.playQueue();
+    if (this.network.isReady()) {
+      this._cleanQueue();
+      this._dequeue();
+    }
     return this;
   }
 
@@ -388,6 +444,82 @@ class Kuzzle extends KuzzleEventEmitter {
     if (wrongType) {
       throw new Error(`Expected ${prop} to be a ${typestr}, ${typeof value} received`);
     }
+  }
+
+  /**
+   * Clean up the queue, ensuring the queryTTL and queryMaxSize properties are respected
+   */
+  _cleanQueue () {
+    const now = Date.now();
+    let lastDocumentIndex = -1;
+
+    if (this.queueTTL > 0) {
+      this.offlineQueue.forEach((query, index) => {
+        if (query.ts < now - this.queueTTL) {
+          lastDocumentIndex = index;
+        }
+      });
+
+      if (lastDocumentIndex !== -1) {
+        this.offlineQueue
+          .splice(0, lastDocumentIndex + 1)
+          .forEach(droppedRequest => {
+            this.emit('offlineQueuePop', droppedRequest.query);
+          });
+      }
+    }
+
+    if (this.queueMaxSize > 0 && this.offlineQueue.length > this.queueMaxSize) {
+      this.offlineQueue
+        .splice(0, this.offlineQueue.length - this.queueMaxSize)
+        .forEach(droppedRequest => {
+          this.emit('offlineQueuePop', droppedRequest.query);
+        });
+    }
+  }
+
+  /**
+   * Play all queued requests, in order.
+   */
+  _dequeue () {
+    const
+      uniqueQueue = {},
+      dequeuingProcess = () => {
+        if (this.offlineQueue.length > 0) {
+          this.network.query(this.offlineQueue[0].request)
+            .then(this.offlineQueue[0].resolve)
+            .catch(this.offlineQueue[0].reject);
+          this.emit('offlineQueuePop', this.offlineQueue.shift());
+
+          setTimeout(() => {
+            dequeuingProcess();
+          }, Math.max(0, this.replayInterval));
+        }
+      };
+
+    if (this.offlineQueueLoader) {
+      if (typeof this.offlineQueueLoader !== 'function') {
+        throw new Error('Invalid value for offlineQueueLoader property. Expected: function. Got: ' + typeof this.offlineQueueLoader);
+      }
+
+      const additionalQueue = this.offlineQueueLoader();
+      if (Array.isArray(additionalQueue)) {
+        this._offlineQueue = additionalQueue
+          .concat(this.offlineQueue)
+          .filter(query => {
+            // throws if the request does not contain required attributes
+            if (!query.request || query.request.requestId === undefined || !query.request.action || !query.request.controller) {
+              throw new Error('Invalid offline queue request. One or more missing properties: requestId, action, controller.');
+            }
+
+            return uniqueQueue.hasOwnProperty(query.request.requestId) ? false : (uniqueQueue[query.request.requestId] = true);
+          });
+      } else {
+        throw new Error('Invalid value returned by the offlineQueueLoader function. Expected: array. Got: ' + typeof additionalQueue);
+      }
+    }
+
+    dequeuingProcess();
   }
 }
 

--- a/src/networkWrapper/protocols/abstract/common.js
+++ b/src/networkWrapper/protocols/abstract/common.js
@@ -20,15 +20,6 @@ class AbstractWrapper extends KuzzleEventEmitter {
     _ssl = typeof options.sslConnection === 'boolean' ? options.sslConnection : false;
 
     this.id = uuidv4();
-    this.autoReplay = false;
-    this.autoQueue = false;
-    this.offlineQueue = [];
-    this.offlineQueueLoader = null;
-    this.queueFilter = null;
-    this.queueMaxSize = 500;
-    this.queueTTL = 120000;
-    this.queuing = false;
-    this.replayInterval = 10;
     this.state = 'offline';
 
     Object.keys(options).forEach(opt => {
@@ -73,14 +64,6 @@ class AbstractWrapper extends KuzzleEventEmitter {
   clientConnected (state, wasConnected) {
     this.state = state || 'ready';
     this.emit(wasConnected && 'reconnect' || 'connect');
-
-    if (this.autoQueue) {
-      this.stopQueuing();
-    }
-
-    if (this.autoReplay) {
-      this.playQueue();
-    }
   }
 
   /**
@@ -88,151 +71,15 @@ class AbstractWrapper extends KuzzleEventEmitter {
    */
   close () {
     this.state = 'offline';
-    if (this.autoQueue) {
-      this.startQueuing();
-    }
   }
 
-  /**
-   * Empties the offline queue without replaying it.
-   */
-  flushQueue () {
-    this.offlineQueue = [];
-  }
-
-  /**
-   * Replays the requests queued during offline mode.
-   */
-  playQueue () {
-    if (this.isReady()) {
-      this._cleanQueue();
-      this._dequeue();
-    }
-  }
-
-  /**
-   * Starts the requests queuing. Works only during offline mode, and if the autoQueue option is set to false.
-   */
-  startQueuing () {
-    this.queuing = true;
-  }
-
-  /**
-   * Stops the requests queuing. Works only during offline mode, and if the autoQueue option is set to false.
-   */
-  stopQueuing () {
-    this.queuing = false;
-  }
-
-  query (request, options) {
-    let queuable = options && (options.queuable !== false) || true;
-
-    if (this.queueFilter) {
-      queuable = queuable && this.queueFilter(request);
-    }
-
-    if (this.queuing && queuable) {
-      this._cleanQueue();
-      this.emit('offlineQueuePush', {request});
-      return new Promise((resolve, reject) => {
-        this.offlineQueue.push({
-          resolve,
-          reject,
-          request,
-          ts: Date.now()
-        });
-      });
-    }
-
-    if (this.isReady()) {
-      return this._emitRequest(request);
-    }
-
-    return Promise.reject(new Error(`Unable to execute request: not connected to a Kuzzle server.
+  query (request) {
+    if (!this.isReady()) {
+      this.emit('discarded', request);
+      return Promise.reject(new Error(`Unable to execute request: not connected to a Kuzzle server.
 Discarded request: ${JSON.stringify(request)}`));
-  }
-
-  isReady () {
-    return this.state === 'ready';
-  }
-
-  /**
-   * Clean up the queue, ensuring the queryTTL and queryMaxSize properties are respected
-   */
-  _cleanQueue () {
-    const now = Date.now();
-    let lastDocumentIndex = -1;
-
-    if (this.queueTTL > 0) {
-      this.offlineQueue.forEach((query, index) => {
-        if (query.ts < now - this.queueTTL) {
-          lastDocumentIndex = index;
-        }
-      });
-
-      if (lastDocumentIndex !== -1) {
-        this.offlineQueue
-          .splice(0, lastDocumentIndex + 1)
-          .forEach(droppedRequest => {
-            this.emit('offlineQueuePop', droppedRequest.query);
-          });
-      }
     }
 
-    if (this.queueMaxSize > 0 && this.offlineQueue.length > this.queueMaxSize) {
-      this.offlineQueue
-        .splice(0, this.offlineQueue.length - this.queueMaxSize)
-        .forEach(droppedRequest => {
-          this.emit('offlineQueuePop', droppedRequest.query);
-        });
-    }
-  }
-
-  /**
-   * Play all queued requests, in order.
-   */
-  _dequeue () {
-    const
-      uniqueQueue = {},
-      dequeuingProcess = () => {
-        if (this.offlineQueue.length > 0) {
-          this._emitRequest(this.offlineQueue[0].request)
-            .then(this.offlineQueue[0].resolve)
-            .catch(this.offlineQueue[0].reject);
-          this.emit('offlineQueuePop', this.offlineQueue.shift());
-
-          setTimeout(() => {
-            dequeuingProcess();
-          }, Math.max(0, this.replayInterval));
-        }
-      };
-
-    if (this.offlineQueueLoader) {
-      if (typeof this.offlineQueueLoader !== 'function') {
-        throw new Error('Invalid value for offlineQueueLoader property. Expected: function. Got: ' + typeof this.offlineQueueLoader);
-      }
-
-      const additionalQueue = this.offlineQueueLoader();
-      if (Array.isArray(additionalQueue)) {
-        this.offlineQueue = additionalQueue
-          .concat(this.offlineQueue)
-          .filter(query => {
-            // throws if the request does not contain required attributes
-            if (!query.request || query.request.requestId === undefined || !query.request.action || !query.request.controller) {
-              throw new Error('Invalid offline queue request. One or more missing properties: requestId, action, controller.');
-            }
-
-            return uniqueQueue.hasOwnProperty(query.request.requestId) ? false : (uniqueQueue[query.request.requestId] = true);
-          });
-      } else {
-        throw new Error('Invalid value returned by the offlineQueueLoader function. Expected: array. Got: ' + typeof additionalQueue);
-      }
-    }
-
-    dequeuingProcess();
-  }
-
-  _emitRequest (request) {
     return new Promise((resolve, reject) => {
       this.once(request.requestId, response => {
         if (response.error) {
@@ -255,6 +102,11 @@ Discarded request: ${JSON.stringify(request)}`));
       this.send(request);
     });
   }
+
+  isReady () {
+    return this.state === 'ready';
+  }
+
 }
 
 module.exports = AbstractWrapper;

--- a/src/networkWrapper/protocols/abstract/realtime.js
+++ b/src/networkWrapper/protocols/abstract/realtime.js
@@ -11,11 +11,6 @@ class RTWrapper extends AbstractWrapper {
     this._autoReconnect = typeof options.autoReconnect === 'boolean' ? options.autoReconnect : true;
     this._reconnectionDelay = typeof options.reconnectionDelay === 'number' ? options.reconnectionDelay : 1000;
 
-    if (options.offlineMode === 'auto' && this.autoReconnect) {
-      this.autoQueue = true;
-      this.autoReplay = true;
-    }
-
     this.wasConnected = false;
     this.stopRetryingToConnect = false;
     this.retrying = false;
@@ -31,9 +26,6 @@ class RTWrapper extends AbstractWrapper {
 
   connect() {
     this.state = 'connecting';
-    if (this.autoQueue) {
-      this.startQueuing();
-    }
   }
 
   /**
@@ -61,9 +53,6 @@ class RTWrapper extends AbstractWrapper {
    */
   clientNetworkError(error) {
     this.state = 'offline';
-    if (this.autoQueue) {
-      this.startQueuing();
-    }
 
     const connectionError = new Error(`Unable to connect to kuzzle server at ${this.host}:${this.port}`);
     connectionError.internal = error;

--- a/src/networkWrapper/protocols/http.js
+++ b/src/networkWrapper/protocols/http.js
@@ -73,10 +73,6 @@ class HttpWrapper extends AbtractWrapper {
    * Connect to the websocket server
    */
   connect () {
-    if (this.autoQueue) {
-      this.startQueuing();
-    }
-
     if (this.state === 'ready') {
       return Promise.resolve();
     }

--- a/test/kuzzle/connect.test.js
+++ b/test/kuzzle/connect.test.js
@@ -32,8 +32,22 @@ describe('Kuzzle connect', () => {
       });
   });
 
+  it('should start queuing when connecting if autoQueue is set', () => {
+    const kuzzle = new Kuzzle(networks.somewhere);
+    kuzzle.network.isReady.returns(false);
+
+    kuzzle.autoQueue = true;
+    kuzzle.startQueuing = sinon.stub();
+
+    return kuzzle.connect()
+      .then(() => {
+        should(kuzzle.startQueuing)
+          .be.calledOnce();
+      });
+  });
+
   describe('=> Connection Events', () => {
-    it('should registered listeners upon receiving a "error" event', () => {
+    it('should register listeners upon receiving a "error" event', () => {
       const
         kuzzle = new Kuzzle(networks.nowhere),
         eventStub = sinon.stub();
@@ -44,7 +58,7 @@ describe('Kuzzle connect', () => {
         .catch(() => should(eventStub).be.calledOnce());
     });
 
-    it('should registered listeners upon receiving a "connect" event', () => {
+    it('should register listeners upon receiving a "connect" event', () => {
       const
         kuzzle = new Kuzzle(networks.somewhere),
         eventStub = sinon.stub();
@@ -57,7 +71,7 @@ describe('Kuzzle connect', () => {
         });
     });
 
-    it('should registered listeners upon receiving a "reconnect" event', () => {
+    it('should register listeners upon receiving a "reconnect" event', () => {
       const
         kuzzle = new Kuzzle(networks.somewhereagain),
         eventStub = sinon.stub();
@@ -129,5 +143,159 @@ describe('Kuzzle connect', () => {
           should(eventStub).be.calledOnce();
         });
     });
+
+    it('should stop queuing once connected if autoQueue option is set', () => {
+      const
+        kuzzle = new Kuzzle(networks.somewhere);
+
+      kuzzle.autoQueue = true;
+      kuzzle.stopQueuing = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          should(kuzzle.stopQueuing)
+            .be.calledOnce();
+        });
+    });
+
+    it('should not stop queuing once connected if autoQueue option is not set', () => {
+      const
+        kuzzle = new Kuzzle(networks.somewhere);
+
+      kuzzle.autoQueue = false;
+      kuzzle.stopQueuing = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          should(kuzzle.stopQueuing)
+            .not.be.called();
+        });
+    });
+
+    it('should play the queue once connected is autoReplay is set', () => {
+      const
+        kuzzle = new Kuzzle(networks.somewhere);
+
+      kuzzle.autoReplay = true;
+      kuzzle.playQueue = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          should(kuzzle.playQueue)
+            .be.calledOnce();
+        });
+    });
+
+    it('should not replay the queue once connected if autoReplay is not set', () => {
+      const
+        kuzzle = new Kuzzle(networks.somewhere);
+
+      kuzzle.autoQueue = true;
+      kuzzle.autoReplay = false;
+      kuzzle.stopQueuing = sinon.stub();
+      kuzzle.playQueue = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          // already called by the mock
+          //kuzzle.network.emit('connect');
+
+          should(kuzzle.stopQueuing)
+            .be.calledOnce();
+          should(kuzzle.playQueue)
+            .not.be.called();
+        });
+    });
+
+    it('should start queuing on error if autoQueue is set', () => {
+      const
+        kuzzle = new Kuzzle(networks.nowhere);
+
+      kuzzle.autoQueue = true;
+      kuzzle.startQueuing = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          throw new Error('no error');
+        })
+        .catch(() => {
+          should(kuzzle.startQueuing)
+            .be.calledTwice(); // once on connect ant the second time on error
+        });
+    });
+
+    it('should not start queuing on error is autoQueue is not set', () => {
+      const
+        kuzzle = new Kuzzle(networks.nowhere);
+
+      kuzzle.autoQueue = false;
+      kuzzle.startQueuing = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          throw new Error('no error');
+        })
+        .catch(() => {
+          should(kuzzle.startQueuing)
+            .not.be.called();
+        });
+    });
+
+    it('should stop queuing once reconnected if autoQueue is set', () => {
+      const
+        kuzzle = new Kuzzle(networks.somewhereagain);
+
+      kuzzle.autoQueue = true;
+      kuzzle.stopQueuing = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          should(kuzzle.stopQueuing)
+            .be.calledOnce();
+        });
+    });
+
+    it('should not stop queuing once reconnected if autoQueue is not set', () => {
+      const
+        kuzzle = new Kuzzle(networks.somewhereagain);
+
+      kuzzle.autoQueue = false;
+      kuzzle.stopQueuing = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          should(kuzzle.stopQueuing)
+            .not.be.called();
+        });
+    });
+
+    it('should play the queue once reconnected if autoReplay is set', () => {
+      const
+        kuzzle = new Kuzzle(networks.somewhereagain);
+
+      kuzzle.autoReplay = true;
+      kuzzle.playQueue = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          should(kuzzle.playQueue)
+            .be.calledOnce();
+        });
+    });
+
+    it('should not play the queue once reconnected if autoReplay is not set', () => {
+      const
+        kuzzle = new Kuzzle(networks.somewhereagain);
+
+      kuzzle.autoReplay = false;
+      kuzzle.playQueue = sinon.stub();
+
+      return kuzzle.connect()
+        .then(() => {
+          should(kuzzle.playQueue)
+            .not.be.called();
+        });
+    });
+
   });
 });

--- a/test/kuzzle/constructor.test.js
+++ b/test/kuzzle/constructor.test.js
@@ -93,7 +93,7 @@ describe('Kuzzle constructor', () => {
     should(kuzzle.realtime).be.an.instanceof(RealTimeController);
   });
 
-  it('should expose the documented properties wwith their default values', () => {
+  it('should expose the documented properties with their default values', () => {
     const
       version = require('../../package').version,
       kuzzle = new Kuzzle(networkMock);
@@ -151,5 +151,16 @@ describe('Kuzzle constructor', () => {
     should(kuzzle.network).be.an.instanceof(NetworkWrapperMock);
     should(kuzzle.sdkVersion).be.a.String().and.be.equal(version);
     should(kuzzle.jwt).be.undefined();
+  });
+
+  it('should set autoQueue and autoReplay if offlineMode is set to auto', () => {
+    const kuzzle = new Kuzzle(networkMock, {
+      autoQueue: false,
+      autoReplay : true,
+      offlineMode: 'auto'
+    });
+
+    should(kuzzle.autoQueue).be.true();
+    should(kuzzle.autoReplay).be.true();
   });
 });

--- a/test/kuzzle/getters.test.js
+++ b/test/kuzzle/getters.test.js
@@ -11,8 +11,8 @@ describe('Kuzzle getters', () => {
     kuzzle = new Kuzzle(network);
   });
 
-  it('should get "autoQueue" property from network instance', () => {
-    kuzzle.network.autoQueue = 'foo-bar';
+  it('should get "autoQueue" property from private _autoQueue one', () => {
+    kuzzle._autoQueue = 'foo-bar';
     should(kuzzle.autoQueue).be.equal('foo-bar');
   });
 
@@ -21,8 +21,8 @@ describe('Kuzzle getters', () => {
     should(kuzzle.autoReconnect).be.equal('foo-bar');
   });
 
-  it('should get "autoReplay" property from network instance', () => {
-    kuzzle.network.autoReplay = 'foo-bar';
+  it('should get "autoReplay" property from private _autoReplay one', () => {
+    kuzzle._autoReplay = 'foo-bar';
     should(kuzzle.autoReplay).be.equal('foo-bar');
   });
 
@@ -36,13 +36,13 @@ describe('Kuzzle getters', () => {
     should(kuzzle.host).be.equal('foo-bar');
   });
 
-  it('should get "offlineQueue" property from network instance', () => {
-    kuzzle.network.offlineQueue = 'foo-bar';
+  it('should get "offlineQueue" property from private _offlineQueue one', () => {
+    kuzzle._offlineQueue = 'foo-bar';
     should(kuzzle.offlineQueue).be.equal('foo-bar');
   });
 
-  it('should get "offlineQueueLoader" property from network instance', () => {
-    kuzzle.network.offlineQueueLoader = 'foo-bar';
+  it('should get "offlineQueueLoader" property from private _offlineQueueLoader one', () => {
+    kuzzle._offlineQueueLoader = 'foo-bar';
     should(kuzzle.offlineQueueLoader).be.equal('foo-bar');
   });
 
@@ -51,18 +51,18 @@ describe('Kuzzle getters', () => {
     should(kuzzle.port).be.equal('foo-bar');
   });
 
-  it('should get "queueFilter" property from network instance', () => {
-    kuzzle.network.queueFilter = 'foo-bar';
+  it('should get "queueFilter" property from private _queueFilter one', () => {
+    kuzzle._queueFilter = 'foo-bar';
     should(kuzzle.queueFilter).be.equal('foo-bar');
   });
 
-  it('should get "queueMaxSize" property from network instance', () => {
-    kuzzle.network.queueMaxSize = 'foo-bar';
+  it('should get "queueMaxSize" property from private _queueMaxSize one', () => {
+    kuzzle._queueMaxSize = 'foo-bar';
     should(kuzzle.queueMaxSize).be.equal('foo-bar');
   });
 
-  it('should get "queueTTL" property from network instance', () => {
-    kuzzle.network.queueTTL = 'foo-bar';
+  it('should get "queueTTL" property from private _queueTTL one', () => {
+    kuzzle._queueTTL = 'foo-bar';
     should(kuzzle.queueTTL).be.equal('foo-bar');
   });
 
@@ -71,8 +71,8 @@ describe('Kuzzle getters', () => {
     should(kuzzle.reconnectionDelay).be.equal('foo-bar');
   });
 
-  it('should get "replayInterval" property from network instance', () => {
-    kuzzle.network.replayInterval = 'foo-bar';
+  it('should get "replayInterval" property from private _replayInterval one', () => {
+    kuzzle._replayInterval = 'foo-bar';
     should(kuzzle.replayInterval).be.equal('foo-bar');
   });
 

--- a/test/kuzzle/network.test.js
+++ b/test/kuzzle/network.test.js
@@ -14,50 +14,6 @@ describe('Kuzzle network methods', () => {
     kuzzle = new Kuzzle(network);
   });
 
-  describe('#flushQueue', () => {
-    it('should return Kuzzle instance', () => {
-      should(kuzzle.flushQueue()).be.exactly(kuzzle);
-    });
-
-    it('should call network flushQueue method', () => {
-      kuzzle.flushQueue();
-      should(kuzzle.network.flushQueue).be.calledOnce();
-    });
-  });
-
-  describe('#playQueue', () => {
-    it('should return Kuzzle instance', () => {
-      should(kuzzle.playQueue()).be.exactly(kuzzle);
-    });
-
-    it('should call network playQueue method', () => {
-      kuzzle.playQueue();
-      should(kuzzle.network.playQueue).be.calledOnce();
-    });
-  });
-
-  describe('#startQueuing', () => {
-    it('should return Kuzzle instance', () => {
-      should(kuzzle.startQueuing()).be.exactly(kuzzle);
-    });
-
-    it('should call network startQueuing method', () => {
-      kuzzle.startQueuing();
-      should(kuzzle.network.startQueuing).be.calledOnce();
-    });
-  });
-
-  describe('#stopQueuing', () => {
-    it('should return Kuzzle instance', () => {
-      should(kuzzle.stopQueuing()).be.exactly(kuzzle);
-    });
-
-    it('should call network stopQueuing method', () => {
-      kuzzle.stopQueuing();
-      should(kuzzle.network.stopQueuing).be.calledOnce();
-    });
-  });
-
   describe('#disconnect', () => {
     it('should close network connection', () => {
       kuzzle.disconnect();

--- a/test/kuzzle/setters.test.js
+++ b/test/kuzzle/setters.test.js
@@ -19,14 +19,14 @@ describe('Kuzzle setters', () => {
       }).throw();
     });
 
-    it('should set network.autoQueue property', () => {
+    it('should set private _autoQueue property', () => {
       should(kuzzle.network.autoQueue).be.undefined();
 
       kuzzle.autoQueue = true;
-      should(kuzzle.network.autoQueue).be.a.Boolean().and.be.true();
+      should(kuzzle._autoQueue).be.a.Boolean().and.be.true();
 
       kuzzle.autoQueue = false;
-      should(kuzzle.network.autoQueue).be.a.Boolean().and.be.false();
+      should(kuzzle._autoQueue).be.a.Boolean().and.be.false();
     });
   });
 
@@ -55,14 +55,14 @@ describe('Kuzzle setters', () => {
       }).throw();
     });
 
-    it('should set network.autoReplay property', () => {
+    it('should set priavet _autoReplay property', () => {
       should(kuzzle.network.autoReplay).be.undefined();
 
       kuzzle.autoReplay = true;
-      should(kuzzle.network.autoReplay).be.a.Boolean().and.be.true();
+      should(kuzzle._autoReplay).be.a.Boolean().and.be.true();
 
       kuzzle.autoReplay = false;
-      should(kuzzle.network.autoReplay).be.a.Boolean().and.be.false();
+      should(kuzzle._autoReplay).be.a.Boolean().and.be.false();
     });
   });
 
@@ -110,11 +110,11 @@ describe('Kuzzle setters', () => {
     });
 
     it('should set network.offlineQueueLoader property', () => {
-      should(kuzzle.network.offlineQueueLoader).be.undefined();
+      should(kuzzle.offlineQueueLoader).be.null();
 
       const cb = sinon.stub();
       kuzzle.offlineQueueLoader = cb;
-      should(kuzzle.network.offlineQueueLoader).be.equal(cb);
+      should(kuzzle.offlineQueueLoader).be.equal(cb);
     });
   });
 
@@ -125,12 +125,12 @@ describe('Kuzzle setters', () => {
       }).throw();
     });
 
-    it('should set network.queueFilter property', () => {
-      should(kuzzle.network.queueFilter).be.undefined();
+    it('should set private _queueFilter property', () => {
+      should(kuzzle.queueFilter).be.null();
 
       const cb = sinon.stub();
       kuzzle.queueFilter = cb;
-      should(kuzzle.network.queueFilter).be.equal(cb);
+      should(kuzzle._queueFilter).be.equal(cb);
     });
   });
 
@@ -141,11 +141,9 @@ describe('Kuzzle setters', () => {
       }).throw();
     });
 
-    it('should set network.queueMaxSize property', () => {
-      should(kuzzle.network.queueMaxSize).be.undefined();
-
+    it('should set priavert _queueMaxSize property', () => {
       kuzzle.queueMaxSize = 1234;
-      should(kuzzle.network.queueMaxSize).be.equal(1234);
+      should(kuzzle._queueMaxSize).be.equal(1234);
     });
   });
 
@@ -156,11 +154,9 @@ describe('Kuzzle setters', () => {
       }).throw();
     });
 
-    it('should set network.queueTTL property', () => {
-      should(kuzzle.network.queueTTL).be.undefined();
-
+    it('should set private _queueTTL property', () => {
       kuzzle.queueTTL = 1234;
-      should(kuzzle.network.queueTTL).be.equal(1234);
+      should(kuzzle._queueTTL).be.equal(1234);
     });
   });
 
@@ -171,11 +167,9 @@ describe('Kuzzle setters', () => {
       }).throw();
     });
 
-    it('should set network.replayInterval property', () => {
-      should(kuzzle.network.replayInterval).be.undefined();
-
+    it('should set private _replayInterval property', () => {
       kuzzle.replayInterval = 1234;
-      should(kuzzle.network.replayInterval).be.equal(1234);
+      should(kuzzle._replayInterval).be.equal(1234);
     });
   });
 });

--- a/test/network/offlineQueue.test.js
+++ b/test/network/offlineQueue.test.js
@@ -2,25 +2,28 @@ var
   should = require('should'),
   rewire = require('rewire'),
   sinon = require('sinon'),
-  AbstractWrapper = rewire('../../src/networkWrapper/protocols/abstract/common');
+  NetworkWrapperMock = require('../mocks/networkWrapper.mock'),
+  Kuzzle = rewire('../../src/Kuzzle');
 
 describe('Offline queue management', function () {
-  var
+  let
     clock,
     now,
-    network,
     reset;
 
   beforeEach(function () {
-    var pastTime = 60050;
+    let pastTime = 60050;
 
-    network = new AbstractWrapper();
+    const network = new NetworkWrapperMock({host: 'somewhere'});
+
+    network.close = sinon.stub();
+    kuzzle = new Kuzzle(network);
 
     // queuing a bunch of 7 requests from 1min ago to right now, 10s apart
     now = Date.now();
     clock = sinon.useFakeTimers(now);
 
-    reset = AbstractWrapper.__set__({
+    reset = Kuzzle.__set__({
       setTimeout: clock.setTimeout,
       setInterval: clock.setInterval,
       clearTimeout: clock.clearTimeout,
@@ -28,7 +31,7 @@ describe('Offline queue management', function () {
     });
 
     while (pastTime >= 0) {
-      network.offlineQueue.push({ts: now - pastTime, request: {requestId: pastTime, action: 'foo', controller: 'bar'}, cb: function () {}});
+      kuzzle.offlineQueue.push({ts: now - pastTime, request: {requestId: pastTime, action: 'foo', controller: 'bar'}, cb: function () {}});
       pastTime -= 10000;
     }
   });
@@ -44,181 +47,198 @@ describe('Offline queue management', function () {
       var eventStub = sinon.stub();
 
       // setting the request TTL to 5s
-      network.queueTTL = 5000;
-      network.addListener('offlineQueuePop', eventStub);
+      kuzzle.queueTTL = 5000;
+      kuzzle.addListener('offlineQueuePop', eventStub);
 
-      network._cleanQueue();
+      kuzzle._cleanQueue();
 
       // should keep only the latest requests, dating from a few ms ago
-      should(network.offlineQueue.length).be.exactly(1);
-      should(network.offlineQueue[0].ts).be.above(now - network.queueTTL);
+      should(kuzzle.offlineQueue.length).be.exactly(1);
+      should(kuzzle.offlineQueue[0].ts).be.above(now - kuzzle.queueTTL);
       should(eventStub.callCount).be.exactly(6);
     });
 
     it('should ignore requests timestamps if queueTTL is 0', function () {
-      var numRequests = network.offlineQueue.length;
+      var numRequests = kuzzle.offlineQueue.length;
 
-      network.queueTTL = 0;
-      network._cleanQueue();
-      should(network.offlineQueue.length).be.exactly(numRequests);
+      kuzzle.queueTTL = 0;
+      kuzzle._cleanQueue();
+      should(kuzzle.offlineQueue.length).be.exactly(numRequests);
     });
 
     it('should remove older requests until the queueMaxSize condition is met', function () {
-      var
-        lastRequest = network.offlineQueue[network.offlineQueue.length - 1],
+      const
+        lastRequest = kuzzle.offlineQueue[kuzzle.offlineQueue.length - 1],
         eventStub = sinon.stub();
 
-      network.queueMaxSize = 1;
-      network.addListener('offlineQueuePop', eventStub);
-      network._cleanQueue();
+      kuzzle.queueMaxSize = 1;
+      kuzzle.addListener('offlineQueuePop', eventStub);
+      kuzzle._cleanQueue();
 
-      should(network.offlineQueue.length).be.exactly(1);
-      should(network.offlineQueue[0]).match(lastRequest);
+      should(kuzzle.offlineQueue.length).be.exactly(1);
+      should(kuzzle.offlineQueue[0]).match(lastRequest);
       should(eventStub.callCount).be.exactly(6);
     });
 
     it('should not remove any request if queueMaxSize is 0', function () {
-      var numRequests = network.offlineQueue.length;
+      const numRequests = kuzzle.offlineQueue.length;
 
-      network.queueMaxSize = 0;
-      network._cleanQueue();
-      should(network.offlineQueue.length).be.exactly(numRequests);
+      kuzzle.queueMaxSize = 0;
+      kuzzle._cleanQueue();
+      should(kuzzle.offlineQueue.length).be.exactly(numRequests);
     });
   });
 
   describe('#dequeue', function () {
     beforeEach(function () {
-      network._emitRequest = sinon.stub().resolves();
-      network.queuing = true;
+      kuzzle.network.query = sinon.stub().resolves();
+      kuzzle.queuing = true;
     });
 
     it('should play all queued requests', function () {
       var
-        numRequests = network.offlineQueue.length,
+        numRequests = kuzzle.offlineQueue.length,
         eventStub = sinon.stub();
 
-      network.addListener('offlineQueuePop', eventStub);
-      network._dequeue();
+      kuzzle.addListener('offlineQueuePop', eventStub);
+      kuzzle._dequeue();
 
-      clock.tick(numRequests * network.replayInterval + 50);
+      clock.tick(numRequests * kuzzle.replayInterval + 50);
 
-      should(network._emitRequest.callCount).be.exactly(numRequests);
-      should(network.offlineQueue).be.an.Array();
-      should(network.offlineQueue.length).be.exactly(0);
+      should(kuzzle.network.query.callCount).be.exactly(numRequests);
+      should(kuzzle.offlineQueue).be.an.Array();
+      should(kuzzle.offlineQueue.length).be.exactly(0);
       should(eventStub.callCount).be.exactly(numRequests);
     });
 
     it('should also load the queue provided by the offlineQueueLoader property', function () {
-      var
-        numRequests = network.offlineQueue.length,
+      const
+        numRequests = kuzzle.offlineQueue.length,
         eventStub = sinon.stub();
 
-      network.offlineQueueLoader = function () {
+      kuzzle.offlineQueueLoader = function () {
         return [
           {request: {requestId: 'foo', action: 'action', controller: 'controller'}},
           {request: {requestId: 'foo2', action: 'action', controller: 'controller'}}
         ];
       };
-      network.addListener('offlineQueuePop', eventStub);
-      network._dequeue();
+      kuzzle.addListener('offlineQueuePop', eventStub);
+      kuzzle._dequeue();
 
-      clock.tick((numRequests + 2) * network.replayInterval + 50);
+      clock.tick((numRequests + 2) * kuzzle.replayInterval + 50);
 
-      should(network._emitRequest.callCount).be.exactly(numRequests + 2);
-      should(network.offlineQueue).be.an.Array();
-      should(network.offlineQueue.length).be.exactly(0);
+      should(kuzzle.network.query.callCount).be.exactly(numRequests + 2);
+      should(kuzzle.offlineQueue).be.an.Array();
+      should(kuzzle.offlineQueue.length).be.exactly(0);
       should(eventStub.callCount).be.exactly(numRequests + 2);
     });
 
     it('should filter duplicates from the offlineQueueLoader and the cached queue ', function () {
-      var
-        numRequests = network.offlineQueue.length,
+      const
+        numRequests = kuzzle.offlineQueue.length,
         eventStub = sinon.stub();
 
       this.timeout(200);
-      network.offlineQueueLoader = function () {
+      kuzzle.offlineQueueLoader = function () {
         return [
           {request: {requestId: 'foo', action: 'action', controller: 'controller'}},
           {request: {requestId: '50050', action: 'action', controller: 'controller'}}
         ];
       };
-      network.addListener('offlineQueuePop', eventStub);
-      network._dequeue();
+      kuzzle.addListener('offlineQueuePop', eventStub);
+      kuzzle._dequeue();
 
-      clock.tick((numRequests + 1) * network.replayInterval + 50);
+      clock.tick((numRequests + 1) * kuzzle.replayInterval + 50);
 
-      should(network._emitRequest.callCount).be.exactly(numRequests + 1);
-      should(network.offlineQueue).be.an.Array();
-      should(network.offlineQueue.length).be.exactly(0);
+      should(kuzzle.network.query.callCount).be.exactly(numRequests + 1);
+      should(kuzzle.offlineQueue).be.an.Array();
+      should(kuzzle.offlineQueue.length).be.exactly(0);
       should(eventStub.callCount).be.exactly(numRequests + 1);
     });
 
     it('should throw on erroneous queries returned by the offlineQueueLoader property', function () {
-      network.offlineQueueLoader = function () {
+      kuzzle.offlineQueueLoader = function () {
         return [
           {}
         ];
       };
 
-      should(function () {network._dequeue();}).throw();
+      should(function () {kuzzle._dequeue();}).throw();
     });
 
     it('should throw if the offlineQueueLoader property is not a function', function () {
-      network.offlineQueueLoader = 'foobar';
-      should(function () {network._dequeue();}).throw();
+      kuzzle._offlineQueueLoader = 'foobar';
+      should(function () {kuzzle._dequeue();}).throw();
     });
 
     it('should throw if the offlineQueueLoader function does not return an array', function () {
-      network.offlineQueueLoader = function () {
+      kuzzle._offlineQueueLoader = function () {
         return false;
       };
 
-      should(function () {network._dequeue();}).throw();
+      should(function () {kuzzle._dequeue();}).throw();
     });
   });
 
   describe('#flushQueue', function () {
-    it('should empty the queue when asked to', function () {
-      network.offlineQueue.push({ts: 'foo', request: {}, cb: function () {}});
-      network.offlineQueue.push({ts: 'foo', request: {}, cb: function () {}});
-      network.offlineQueue.push({ts: 'foo', request: {}, cb: function () {}});
-      network.offlineQueue.push({ts: 'foo', request: {}, cb: function () {}});
+    it('should return Kuzzle instance', () => {
+      should(kuzzle.flushQueue()).be.exactly(kuzzle);
+    });
 
-      network.flushQueue();
-      should(network.offlineQueue.length).be.exactly(0);
+    it('should empty the queue when asked to', () => {
+      kuzzle._offlineQueue.push({ts: 'foo', request: {}, cb: function () {}});
+      kuzzle._offlineQueue.push({ts: 'foo', request: {}, cb: function () {}});
+      kuzzle._offlineQueue.push({ts: 'foo', request: {}, cb: function () {}});
+      kuzzle._offlineQueue.push({ts: 'foo', request: {}, cb: function () {}});
+
+      kuzzle.flushQueue();
+      should(kuzzle._offlineQueue.length).be.exactly(0);
+
     });
   });
 
   describe('#playQueue', function () {
     beforeEach(function () {
-      network._dequeue = sinon.stub().resolves();
+      kuzzle._dequeue = sinon.stub().resolves();
+    });
+
+    it('should return Kuzzle instance', () => {
+      should(kuzzle.playQueue()).be.exactly(kuzzle);
     });
 
     it('should play the queue if the instance is connected', function () {
-      network.isReady = sinon.stub().returns(true);
-      network.playQueue();
-      should(network._dequeue).be.calledOnce();
+      kuzzle.network.isReady = sinon.stub().returns(true);
+      kuzzle.playQueue();
+      should(kuzzle._dequeue).be.calledOnce();
     });
 
     it('should not play the queue if the instance is offline', function () {
-      network.isReady = sinon.stub().returns(false);
-      network.playQueue();
-      should(network._dequeue).not.be.called();
+      kuzzle.network.isReady = sinon.stub().returns(false);
+      kuzzle.playQueue();
+      should(kuzzle._dequeue).not.be.called();
     });
   });
 
   describe('#startQueuing', function () {
+    it('should return Kuzzle instance', () => {
+      should(kuzzle.startQueuing()).be.exactly(kuzzle);
+    });
+
     it('should set queuing property', function () {
-      network.startQueuing();
-      should(network.queuing).be.true();
+      kuzzle.startQueuing();
+      should(kuzzle.queuing).be.true();
     });
   });
 
   describe('#stopQueuing', function () {
+    it('should return Kuzzle instance', () => {
+      should(kuzzle.stopQueuing()).be.exactly(kuzzle);
+    });
+
     it('should unset queuing property', function () {
-      network.queuing = true;
-      network.stopQueuing();
-      should(network.queuing).be.false();
+      kuzzle.queuing = true;
+      kuzzle.stopQueuing();
+      should(kuzzle.queuing).be.false();
     });
   });
 });

--- a/test/network/socketio.test.js
+++ b/test/network/socketio.test.js
@@ -89,13 +89,6 @@ describe('SocketIO networking module', () => {
   it('should initialize network status when connecting', () => {
     socketIO.connect();
     should(socketIO.state).be.eql('connecting');
-    should(socketIO.queuing).be.false();
-  });
-
-  it('should start queuing if autoQueue option is set', () => {
-    socketIO.autoQueue = true;
-    socketIO.connect();
-    should(socketIO.queuing).be.true();
   });
 
   it('should connect with the right parameters', () => {
@@ -154,42 +147,6 @@ describe('SocketIO networking module', () => {
     should(socketIO.stopRetryingToConnect).be.false();
   });
 
-  it('should stop queuing when the client connection is established if autoQueue option is set', () => {
-    socketIO.queuing = true;
-    socketIO.autoQueue = true;
-
-    socketIO.connect();
-    socketIO.socket.emit('connect');
-    should(socketIO.queuing).be.false();
-  });
-
-  it('should not stop queuing when the client connection is established if autoQueue option is not set', () => {
-    socketIO.queuing = true;
-    socketIO.autoQueue = false;
-
-    socketIO.connect();
-    socketIO.socket.emit('connect');
-    should(socketIO.queuing).be.true();
-  });
-
-  it('should play the queue when the client connection is established if autoReplay option is set', () => {
-    socketIO.playQueue = sinon.stub();
-    socketIO.autoReplay = true;
-
-    socketIO.connect();
-    socketIO.socket.emit('connect');
-    should(socketIO.playQueue).be.calledOnce();
-  });
-
-  it('should not play the queue when the client connection is established if autoReplay option is not set', () => {
-    socketIO.playQueue = sinon.stub();
-    socketIO.autoReplay = false;
-
-    socketIO.connect();
-    socketIO.socket.emit('connect');
-    should(socketIO.playQueue).not.be.called();
-  });
-
   it('should call listeners on a "reconnect" event', () => {
     const cb = sinon.stub();
 
@@ -223,32 +180,6 @@ describe('SocketIO networking module', () => {
     should(cb).be.calledOnce();
   });
 
-  it('should start queuing when the client is disconnected if autoQueue option is set', () => {
-    socketIO.queuing = false;
-    socketIO.autoQueue = true;
-
-    const promise = socketIO.connect();
-    socketIO.socket.emit('disconnect');
-
-    clock.tick(10);
-    should(socketIO.queuing).be.true();
-
-    return should(promise).be.rejectedWith('An error occurred, kuzzle may not be ready yet');
-  });
-
-  it('should not start queuing when the client is disconnected if autoQueue option is not set', () => {
-    socketIO.queuing = false;
-    socketIO.autoQueue = false;
-
-    const promise = socketIO.connect();
-    socketIO.socket.emit('disconnect');
-
-    clock.tick(10);
-    should(socketIO.queuing).be.false();
-
-    return should(promise).be.rejectedWith('An error occurred, kuzzle may not be ready yet');
-  });
-
   it('should call listeners on a connect error event', () => {
     const
       cb = sinon.stub(),
@@ -268,36 +199,6 @@ describe('SocketIO networking module', () => {
     should(cb.firstCall.args[0].internal).be.equal(err);
 
     return should(promise).be.rejectedWith('foobar');
-  });
-
-  it('should start queuing when the client is disconnected with an error, if autoQueue option is set', () => {
-    const err = new Error('foobar');
-
-    socketIO.queuing = false;
-    socketIO.autoQueue = true;
-    socketIO.forceDisconnect = true;
-
-    socketIO.connect();
-    socketIO.socket.emit('connect');
-    socketIO.socket.emit('connect_error', err);
-
-    clock.tick(10);
-    should(socketIO.queuing).be.true();
-  });
-
-  it('should not start queuing when the client is disconnected with an error, if autoQueue option is not set', () => {
-    const err = new Error('foobar');
-
-    socketIO.queuing = false;
-    socketIO.autoQueue = false;
-    socketIO.forceDisconnect = true;
-
-    socketIO.connect();
-    socketIO.socket.emit('connect');
-    socketIO.socket.emit('connect_error', err);
-
-    clock.tick(10);
-    should(socketIO.queuing).be.false();
   });
 
   it('should call connectError handler on unattended disconnect event', () => {

--- a/test/network/websocket.test.js
+++ b/test/network/websocket.test.js
@@ -44,13 +44,6 @@ describe('WebSocket networking module', () => {
   it('should initialize network status when connecting', () => {
     websocket.connect();
     should(websocket.state).be.eql('connecting');
-    should(websocket.queuing).be.false();
-  });
-
-  it('should start queuing if autoQueue option is set', () => {
-    websocket.autoQueue = true;
-    websocket.connect();
-    should(websocket.queuing).be.true();
   });
 
   it('should initialize a WS connection properly', () => {
@@ -100,42 +93,6 @@ describe('WebSocket networking module', () => {
     should(websocket.state).be.eql('connected');
     should(websocket.wasConnected).be.true();
     should(websocket.stopRetryingToConnect).be.false();
-  });
-
-  it('should stop queuing when the client connection is established if autoQueue option is set', () => {
-    websocket.queuing = true;
-    websocket.autoQueue = true;
-
-    websocket.connect();
-    clientStub.onopen();
-    should(websocket.queuing).be.false();
-  });
-
-  it('should not stop queuing when the client connection is established if autoQueue option is not set', () => {
-    websocket.queuing = true;
-    websocket.autoQueue = false;
-
-    websocket.connect();
-    clientStub.onopen();
-    should(websocket.queuing).be.true();
-  });
-
-  it('should play the queue when the client connection is established if autoReplay option is set', () => {
-    websocket.playQueue = sinon.stub();
-    websocket.autoReplay = true;
-
-    websocket.connect();
-    clientStub.onopen();
-    should(websocket.playQueue).be.calledOnce();
-  });
-
-  it('should not play the queue when the client connection is established if autoReplay option is not set', () => {
-    websocket.playQueue = sinon.stub();
-    websocket.autoReplay = false;
-
-    websocket.connect();
-    clientStub.onopen();
-    should(websocket.playQueue).not.be.called();
   });
 
   it('should call listeners on a "reconnect" event', () => {
@@ -216,28 +173,6 @@ describe('WebSocket networking module', () => {
     should(websocket.listeners('disconnect').length).be.eql(1);
   });
 
-  it('should start queuing when the client is disconnected if autoQueue option is set', () => {
-    websocket.queuing = false;
-    websocket.autoQueue = true;
-
-    websocket.connect();
-    clientStub.onclose(1000);
-
-    clock.tick(10);
-    should(websocket.queuing).be.true();
-  });
-
-  it('should not start queuing when the client is disconnected if autoQueue option is not set', () => {
-    websocket.queuing = false;
-    websocket.autoQueue = false;
-
-    websocket.connect();
-    clientStub.onclose(1000);
-
-    clock.tick(10);
-    should(websocket.queuing).be.false();
-  });
-
   it('should call error listeners on a "disconnect" event with an abnormal websocket code', () => {
     const cb = sinon.stub();
 
@@ -266,28 +201,6 @@ describe('WebSocket networking module', () => {
     should(cb.firstCall.args[0].internal.status).be.equal(4666);
     should(cb.firstCall.args[0].internal.message).be.equal('foobar');
     should(websocket.listeners('networkError').length).be.eql(1);
-  });
-
-  it('should start queuing when the client is disconnected with an error, if autoQueue option is set', () => {
-    websocket.queuing = false;
-    websocket.autoQueue = true;
-
-    websocket.connect();
-    clientStub.onclose(4666, 'foobar');
-
-    clock.tick(10);
-    should(websocket.queuing).be.true();
-  });
-
-  it('should not start queuing when the client is disconnected with an error, if autoQueue option is not set', () => {
-    websocket.queuing = false;
-    websocket.autoQueue = false;
-
-    websocket.connect();
-    clientStub.onclose(4666, 'foobar');
-
-    clock.tick(10);
-    should(websocket.queuing).be.false();
   });
 
   it('should be able to register ephemeral callbacks on an event', () => {


### PR DESCRIPTION
## What does this PR do?

This PR refactors the offline queue mechanism of the Javascript sdk to move its logic from the protocols to Kuzzle.
