### PR TITLE
Fix 343 unhandled rejection on connect

### DIFF
--- a/src/protocols/abstract/realtime.js
+++ b/src/protocols/abstract/realtime.js
@@ -60,9 +60,14 @@ class RTWrapper extends KuzzleAbstractProtocol {
     this.emit('networkError', connectionError);
     if (this.autoReconnect && !this.retrying && !this.stopRetryingToConnect) {
       this.retrying = true;
-      setTimeout(() => {
-        this.retrying = false;
-        this.connect(this.host);
+
+      setTimeout(async () => {
+        try {
+          this.retrying = false;
+          await this.connect(this.host);
+        } catch (error) {
+          this.clientNetworkError(error);
+        }
       }, this.reconnectionDelay);
     } else {
       this.emit('disconnect');

--- a/src/protocols/abstract/realtime.js
+++ b/src/protocols/abstract/realtime.js
@@ -61,13 +61,9 @@ class RTWrapper extends KuzzleAbstractProtocol {
     if (this.autoReconnect && !this.retrying && !this.stopRetryingToConnect) {
       this.retrying = true;
 
-      setTimeout(async () => {
-        try {
-          this.retrying = false;
-          await this.connect(this.host);
-        } catch (error) {
-          this.clientNetworkError(error);
-        }
+      setTimeout(() => {
+        this.retrying = false;
+        this.connect(this.host).catch(err => this.clientNetworkError(err));
       }, this.reconnectionDelay);
     } else {
       this.emit('disconnect');

--- a/test/protocol/websocket.test.js
+++ b/test/protocol/websocket.test.js
@@ -121,7 +121,7 @@ describe('WebSocket networking module', () => {
     should(websocket.listeners('networkError').length).be.eql(1);
 
     websocket.connect();
-    websocket.connect = sinon.stub();
+    websocket.connect = sinon.stub().rejects();
     clientStub.onopen();
     clientStub.onerror();
     should(websocket.retrying).be.true();


### PR DESCRIPTION
## What does this PR do?

Fix #343 unhandled rejection on connect retry.

### How should this be manually tested?

  - Step 1 : Run this snippet without Kuzzle running:

```js
const {
  Kuzzle,
  Websocket
} = require('./index');

const
  websocketProtocol = new Websocket({ host: 'localhost', port: 7512 }),
  kuzzle = new Kuzzle(websocketProtocol);

  kuzzle.on('networkError', error => {
    console.error(`Network Error: ${error.message}`);
  });

(async () => {
  try {
    await kuzzle.connect();

    console.log(await kuzzle.server.now());
  } catch (error) {
    console.log(error);
  } finally {
    kuzzle.disconnect();
  }
})()

```

