### PR TITLE
get mapping on aliased index

### DIFF
--- a/src/CollectionMapping.js
+++ b/src/CollectionMapping.js
@@ -104,13 +104,18 @@ CollectionMapping.prototype.refresh = function (options, cb) {
   }
 
   this.kuzzle.query(this.collection.buildQueryArgs('collection', 'getMapping'), data, options, function (err, res) {
+    var index;
+
     if (err) {
       return cb ? cb(err) : false;
     }
 
-    if (res.result[self.collection.index]) {
-      if (res.result[self.collection.index].mappings[self.collection.collection]) {
-        self.mapping = res.result[self.collection.index].mappings[self.collection.collection].properties;
+    // this collection index can be an alias
+    index = Object.keys(res.result)[0];
+
+    if (index) {
+      if (res.result[index].mappings[self.collection.collection]) {
+        self.mapping = res.result[index].mappings[self.collection.collection].properties;
 
         // Mappings can be empty. The mapping property should never be "undefined"
         if (self.mapping === undefined) {

--- a/test/CollectionMapping/methods.test.js
+++ b/test/CollectionMapping/methods.test.js
@@ -174,7 +174,7 @@ describe('CollectionMapping methods', function () {
     });
 
     it('should return a "no mapping" error if the index is not found in the mapping', function (done) {
-      result = { result: {foobar: { mappings: { foo: { properties: { foo: {type: 'date'}}}}}}};
+      result = { result: {} };
 
       mapping.refresh(function (err, res) {
         should(err).be.an.Error();


### PR DESCRIPTION
When calling getMapping on an aliased index, no result is returned.

This PR fixes this by assuming the returned index is the requested one (which is always the case).