### PR TITLE
[build] Update webpack build config to fix raw web usage

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,11 +5,11 @@ const
 
 module.exports = {
   mode: 'production',
-  entry: './src/Kuzzle.js',
+  entry: './index.js',
   output: {
     path: `${__dirname}/dist`,
     filename: 'kuzzle.js',
-    library: 'Kuzzle',
+    library: 'KuzzleSDK',
     libraryTarget: 'umd'
   },
   watch: false,
@@ -48,7 +48,8 @@ module.exports = {
   plugins: [
     new webpack.IgnorePlugin(/^(http|min-req-promise|package|uws)$/),
     new webpack.DefinePlugin({
-      SDKVERSION: JSON.stringify(version)
+      SDKVERSION: JSON.stringify(version),
+      BUILT: true
     }),
     new webpack.BannerPlugin('Kuzzle javascript SDK version ' + version),
     new webpack.optimize.OccurrenceOrderPlugin()


### PR DESCRIPTION
## What does this PR do?

Update webpack build config to fix undefined protocol classes in raw web usage : 
* change webpack entrypoint to include all classes
* rename library name to avoid `Kuzzle.Kuzzle ...` 
* add `BUILT` global constant to avoid exception when used in raw web

now to use in raw web : 
### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 :
  - Step 2 :
  - Step 3 :  
  ...

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
