### PR TITLE
Add method to use custom controllers in the SDK

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const
     WebSocket,
     SocketIO
   } = require('./src/protocols'),
+  BaseController = require('./src/controllers/base'),
   KuzzleAbstractProtocol = require('./src/protocols/abstract/common'),
   KuzzleEventEmitter = require('./src/eventEmitter');
 
@@ -20,6 +21,7 @@ module.exports = {
   Http,
   WebSocket,
   SocketIO,
+  BaseController,
   KuzzleAbstractProtocol,
   KuzzleEventEmitter
 };

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -440,8 +440,7 @@ Discarded request: ${JSON.stringify(request)}`));
   /**
    * Adds a new controller and make it available in the SDK.
    *
-   * @param {object} request
-   * @param {object} [options] - Optional arguments
+   * @param {BaseController} controller
    * @returns {Kuzzle}
    */
   useController (controller) {

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -9,6 +9,7 @@ const
   ServerController = require('./controllers/server'),
   SecurityController = require('./controllers/security'),
   MemoryStorageController = require('./controllers/memoryStorage'),
+  BaseController = require('./controllers/base'),
   uuidv4 = require('./uuidv4');
 
 const
@@ -433,6 +434,36 @@ Discarded request: ${JSON.stringify(request)}`));
       this._cleanQueue();
       this._dequeue();
     }
+    return this;
+  }
+
+  /**
+   * Adds a new controller and make it available in the SDK.
+   *
+   * @param {object} request
+   * @param {object} [options] - Optional arguments
+   * @returns {Kuzzle}
+   */
+  useController (controller) {
+    if (!(controller instanceof BaseController)) {
+      throw new Error('Controllers must inherits from the BaseController class.');
+    }
+
+    if (!(controller.name && controller.name.length > 0)) {
+      throw new Error('Controllers must have a name.');
+    }
+
+    if (!(controller.accessor && controller.accessor.length > 0)) {
+      throw new Error('Controllers must have an accessor.');
+    }
+
+    if (this[controller.accessor]) {
+      throw new Error(`There is already a controller with the accessor ${controller.accessor}. Please use another one.`);
+    }
+
+    controller.kuzzle = this;
+    this[controller.accessor] = controller;
+
     return this;
   }
 

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -458,7 +458,7 @@ Discarded request: ${JSON.stringify(request)}`));
     }
 
     if (this[controller.accessor]) {
-      throw new Error(`There is already a controller with the accessor ${controller.accessor}. Please use another one.`);
+      throw new Error(`There is already a controller with the accessor '${controller.accessor}'. Please use another one.`);
     }
 
     controller.kuzzle = this;

--- a/src/controllers/base.js
+++ b/src/controllers/base.js
@@ -1,0 +1,34 @@
+const _kuzzle = Symbol();
+
+class BaseController {
+
+  /**
+   * @param {string} name - Controller full name for API request.
+   * @param {string} accessor - Controller accessor name on Kuzzle object.
+   */
+  constructor (name, accessor) {
+    this.name = name;
+    this.accessor = accessor;
+  }
+
+  get kuzzle () {
+    return this[_kuzzle];
+  }
+
+  set kuzzle (kuzzle) {
+    this[_kuzzle] = kuzzle;
+  }
+
+  /**
+   * @param {object} request
+   * @param {object} [options] - Optional arguments
+   * @returns {Promise<object>}
+  */
+  query (request = {}, options = {}) {
+    request.controller = request.controller || this.name;
+
+    return this.kuzzle.query(request, options);
+  }
+}
+
+module.exports = BaseController;

--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -201,6 +201,10 @@ class HttpWrapper extends KuzzleAbstractProtocol {
       // NodeJS implementation, using http.request:
 
       const httpClient = require('min-req-promise');
+
+      if (path.indexOf(0) !== '/') {
+        path = `/${path}`;
+      }
       const url = `${this.protocol}://${this.host}:${this.port}${path}`;
 
       const headers = payload.headers || {};

--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -202,7 +202,7 @@ class HttpWrapper extends KuzzleAbstractProtocol {
 
       const httpClient = require('min-req-promise');
 
-      if (path.indexOf(0) !== '/') {
+      if (path[0] !== '/') {
         path = `/${path}`;
       }
       const url = `${this.protocol}://${this.host}:${this.port}${path}`;

--- a/test/kuzzle/useController.test.js
+++ b/test/kuzzle/useController.test.js
@@ -1,0 +1,111 @@
+const
+  should = require('should'),
+  sinon = require('sinon'),
+  ProtocolMock = require('../mocks/protocol.mock'),
+  BaseController = require('../../src/controllers/base'),
+  Kuzzle = require('../../src/Kuzzle');
+
+class CustomController extends BaseController {
+  constructor (name, accessor) {
+    super(name, accessor);
+  }
+
+  sayHello (message) {
+    const request = {
+      action: 'sayHello',
+      body: {
+        message
+      }
+    };
+
+    return this.query(request)
+      .then(response => response.result);
+  }
+}
+
+class WrongController {
+  constructor (name, accessor) {
+    this.name = name;
+    this.accessor = accessor;
+  }
+}
+
+describe('Kuzzle custom controllers management', () => {
+  describe('#useController', () => {
+    let
+      customController,
+      response,
+      kuzzle;
+
+    beforeEach(() => {
+      response = {
+        result: { }
+      };
+
+      const protocol = new ProtocolMock('somewhere');
+      customController = new CustomController('custom-plugin/custom', 'custom')
+
+      kuzzle = new Kuzzle(protocol);
+      kuzzle.protocol.query.resolves(response);
+    });
+
+    it('should add the controller to the controllers list', () => {
+      kuzzle.useController(customController);
+
+      should(kuzzle.custom).be.eql(customController);
+    });
+
+    it('should set the kuzzle object in the controller', () => {
+      kuzzle.useController(customController);
+
+      should(customController.kuzzle).be.eql(kuzzle);
+    });
+
+    it('should use the controller name by default for query()', async () => {
+      kuzzle.useController(customController);
+
+      await kuzzle.custom.sayHello('Wake up, and smell the ashes');
+
+      should(kuzzle.protocol.query).be.calledOnce();
+      should(kuzzle.protocol.query).be.calledWith(
+        sinon.match.has('controller', 'custom-plugin/custom')
+      );
+    });
+
+    it('should throw if the controller does not inherits from BaseController', () => {
+      const wrongController = new WrongController('wrong-plugin/wrong', 'wrong');
+
+      should(function () {
+        kuzzle.useController(wrongController);
+      }).throw('Controllers must inherits from the BaseController class.');
+    });
+
+    it('should throw if the controller does not have a name', () => {
+      const baseController = new BaseController('', 'wrong');
+
+      should(function () {
+        kuzzle.useController(baseController);
+      }).throw('Controllers must have a name.');
+    });
+
+    it('should throw if the controller does not have an accessor', () => {
+      const baseController = new BaseController('custom-plugin/custom', '');
+
+      should(function () {
+        kuzzle.useController(baseController);
+      }).throw('Controllers must have an accessor.');
+    });
+
+    it('should throw if the accessor is already taken', () => {
+      const
+        baseController1 = new BaseController('custom-plugin/custom', 'custom'),
+        baseController2 = new BaseController('custom-plugin/custom2', 'custom');
+
+      kuzzle.useController(baseController1);
+
+      should(function () {
+        kuzzle.useController(baseController2);
+      }).throw('There is already a controller with the accessor \'custom\'. Please use another one.');
+    });
+  });
+});

--- a/test/kuzzle/useController.test.js
+++ b/test/kuzzle/useController.test.js
@@ -43,7 +43,7 @@ describe('Kuzzle custom controllers management', () => {
       };
 
       const protocol = new ProtocolMock('somewhere');
-      customController = new CustomController('custom-plugin/custom', 'custom')
+      customController = new CustomController('custom-plugin/custom', 'custom');
 
       kuzzle = new Kuzzle(protocol);
       kuzzle.protocol.query.resolves(response);
@@ -61,15 +61,16 @@ describe('Kuzzle custom controllers management', () => {
       should(customController.kuzzle).be.eql(kuzzle);
     });
 
-    it('should use the controller name by default for query()', async () => {
+    it('should use the controller name by default for query()', () => {
       kuzzle.useController(customController);
 
-      await kuzzle.custom.sayHello('Wake up, and smell the ashes');
-
-      should(kuzzle.protocol.query).be.calledOnce();
-      should(kuzzle.protocol.query).be.calledWith(
-        sinon.match.has('controller', 'custom-plugin/custom')
-      );
+      return kuzzle.custom.sayHello('Wake up, and smell the ashes')
+        .then(() => {
+          should(kuzzle.protocol.query).be.calledOnce();
+          should(kuzzle.protocol.query).be.calledWith(
+            sinon.match.has('controller', 'custom-plugin/custom')
+          );
+        });
     });
 
     it('should throw if the controller does not inherits from BaseController', () => {

--- a/test/kuzzle/useController.test.js
+++ b/test/kuzzle/useController.test.js
@@ -6,8 +6,8 @@ const
   Kuzzle = require('../../src/Kuzzle');
 
 class CustomController extends BaseController {
-  constructor (name, accessor) {
-    super(name, accessor);
+  constructor (accessor) {
+    super('custom-plugin/custom', accessor);
   }
 
   sayHello (message) {
@@ -24,8 +24,7 @@ class CustomController extends BaseController {
 }
 
 class WrongController {
-  constructor (name, accessor) {
-    this.name = name;
+  constructor (accessor) {
     this.accessor = accessor;
   }
 }
@@ -43,7 +42,7 @@ describe('Kuzzle custom controllers management', () => {
       };
 
       const protocol = new ProtocolMock('somewhere');
-      customController = new CustomController('custom-plugin/custom', 'custom');
+      customController = new CustomController('custom');
 
       kuzzle = new Kuzzle(protocol);
       kuzzle.protocol.query.resolves(response);
@@ -74,7 +73,8 @@ describe('Kuzzle custom controllers management', () => {
     });
 
     it('should throw if the controller does not inherits from BaseController', () => {
-      const wrongController = new WrongController('wrong-plugin/wrong', 'wrong');
+      const wrongController = new WrongController('wrong');
+      wrongController.name = 'wrong-plugin/wrong';
 
       should(function () {
         kuzzle.useController(wrongController);
@@ -82,30 +82,31 @@ describe('Kuzzle custom controllers management', () => {
     });
 
     it('should throw if the controller does not have a name', () => {
-      const baseController = new BaseController('', 'wrong');
+      customController = new CustomController('wrong');
+      customController.name = '';
 
       should(function () {
-        kuzzle.useController(baseController);
+        kuzzle.useController(customController);
       }).throw('Controllers must have a name.');
     });
 
     it('should throw if the controller does not have an accessor', () => {
-      const baseController = new BaseController('custom-plugin/custom', '');
+      customController = new CustomController('');
 
       should(function () {
-        kuzzle.useController(baseController);
+        kuzzle.useController(customController);
       }).throw('Controllers must have an accessor.');
     });
 
     it('should throw if the accessor is already taken', () => {
       const
-        baseController1 = new BaseController('custom-plugin/custom', 'custom'),
-        baseController2 = new BaseController('custom-plugin/custom2', 'custom');
+        customController1 = new CustomController('custom'),
+        customController2 = new CustomController('custom');
 
-      kuzzle.useController(baseController1);
+      kuzzle.useController(customController1);
 
       should(function () {
-        kuzzle.useController(baseController2);
+        kuzzle.useController(customController2);
       }).throw('There is already a controller with the accessor \'custom\'. Please use another one.');
     });
   });


### PR DESCRIPTION
## What does this PR do?

Adds a `useController` method to the Kuzzle object to use custom defined controllers.  
This allows to call plugin routes from the SDK without using the `query` method.

If I have a plugin with the following action: 
```
    this.controllers = {
      test: {
        sayHello: 'sayHello'
      }
    };

    this.routes = [
      { verb: 'get', url: '/test/sayHello', controller: 'test', action: 'sayHello' }
    ];

  async sayHello (request) {
    const message = request.input.args.message || request.input.body.message;

    return message;
  }
```

Then I can define the following custom controller and use it in the SDK:
```
class TestController extends BaseController {
  constructor (accessor) {
    super('ctoi-le-plugin/test', accessor);
  }

  sayHello (message, options) {
    const request = {
      action: 'sayHello',
      body: {
        message
      }
    };

    return this.query(request, options)
      .then(response => response.result);
  }
}

const kuzzle = new Kuzzle(new WebSocket('localhost'));

kuzzle.useController(new TestController('test'))

console.log(await kuzzle.test.sayHello('Hello moto'))
```


### How should this be manually tested?

  - Step 1 : Run test
  - Step 2 : Try to use a custom controller for a plugin
