### PR TITLE
Fixed call to checkToken after reconnection

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -275,7 +275,7 @@ class Kuzzle extends KuzzleEventEmitter {
       }
 
       if (this.jwt) {
-        this.checkToken(this.jwt, (err, res) => {
+        this.auth.checkToken(this.jwt).then((err, res) => {
           // shouldn't obtain an error but let's invalidate the token anyway
           if (err || !res.valid) {
             this.jwt = undefined;


### PR DESCRIPTION
Fixes a call to `checkToken` upon reconnection to Kuzzle. The previous version was surely a copy/paste error based on v5.

### How should this be manually tested?

- connect to Kuzzle
- add a listener on the `reconnected` event
- disconnect from Kuzzle (one way to do it is to `docker-compose stop kuzzle`)
- reconnect to Kuzzle
- the callback attached to your listened should be triggered