### PR TITLE
WebSocket: fix error object on connection error

### DIFF
--- a/src/protocols/websocket.js
+++ b/src/protocols/websocket.js
@@ -86,7 +86,8 @@ class WSNode extends RTWrapper {
       };
 
       this.client.onerror = error => {
-        const err = (error instanceof Error) && error || new Error(error);
+        const err = error ?
+          new Error(error.message || error) : new Error('Unexpected error');
 
         this.clientNetworkError(err);
 

--- a/src/protocols/websocket.js
+++ b/src/protocols/websocket.js
@@ -86,8 +86,12 @@ class WSNode extends RTWrapper {
       };
 
       this.client.onerror = error => {
-        const err = error ?
-          new Error(error.message || error) : new Error('Unexpected error');
+        let err = error;
+
+        if (!(error instanceof Error)) {
+          err = error ?
+            new Error(error.message || error) : new Error('Unexpected error');
+        }
 
         this.clientNetworkError(err);
 


### PR DESCRIPTION
# Description

On a websocket connection error, the error thrown by the SDK has the following message: `[object Object]`

This is because on a connection error, `ws` sends a complex object, but our error handler processes it as if it's a string.

# How to test it

Run this snippet:

```js
const {Kuzzle, WebSocket} = require('kuzzle-sdk');
const
  ws = new WebSocket('localhost'),
  kuzzle = new Kuzzle(ws);

kuzzle.connect().catch(err => console.error(err));
kuzzle.disconnect();
```

Before this PR, this prints: 

```
Error: [object Object]
    ... stack trace ...
```

With this PR:

```
Error: WebSocket was closed before the connection was established
    ... stack trace ...
```