### PR TITLE
Properly handle tokenExpired events

### DIFF
--- a/src/controllers/realtime/index.js
+++ b/src/controllers/realtime/index.js
@@ -116,6 +116,7 @@ class RealTimeController {
     }
 
     this.subscriptions = {};
+    this.kuzzle.jwt = undefined;
 
     const now = Date.now();
     if ((now - this.lastExpirationTimestamp) > expirationThrottleDelay) {

--- a/src/controllers/realtime/index.js
+++ b/src/controllers/realtime/index.js
@@ -1,16 +1,16 @@
 const Room = require('./room');
 
-class RealTimeController {
+const expirationThrottleDelay = 1000;
 
+class RealTimeController {
   /**
    * @param {Kuzzle} kuzzle
    */
   constructor (kuzzle) {
     this._kuzzle = kuzzle;
+    this.lastExpirationTimestamp = 0;
 
     this.subscriptions = {
-      filters: {},
-      channels: {}
     };
   }
 
@@ -68,7 +68,7 @@ class RealTimeController {
       throw new Error('Kuzzle.realtime.subscribe: a callback function is required');
     }
 
-    const room = new Room(this.kuzzle, index, collection, filters, callback, options);
+    const room = new Room(this, index, collection, filters, callback, options);
 
     return room.subscribe()
       .then(() => {
@@ -104,6 +104,24 @@ class RealTimeController {
       .then(response => {
         return response.result;
       });
+  }
+
+  /**
+   * Removes all subscriptions, and emit a "tokenExpired" event
+   * (tries to prevent event duplication by throttling it)
+   */
+  tokenExpired() {
+    for (const roomId of Object.keys(this.subscriptions)) {
+      this.subscriptions[roomId].forEach(room => room.removeListeners());
+    }
+
+    this.subscriptions = {};
+
+    const now = Date.now();
+    if ((now - this.lastExpirationTimestamp) > expirationThrottleDelay) {
+      this.lastExpirationTimestamp = now;
+      this.kuzzle.emit('tokenExpired');
+    }
   }
 }
 

--- a/test/controllers/realtime.test.js
+++ b/test/controllers/realtime.test.js
@@ -271,6 +271,8 @@ describe('Realtime Controller', () => {
     it('should clear all subscriptions and emit a "tokenExpired" event', () => {
       const stub = sinon.stub();
 
+      kuzzle.jwt = 'foobar';
+
       for (let i = 0; i < 10; i++) {
         kuzzle.realtime.subscriptions[uuidv4()] = [{removeListeners: stub}];
       }
@@ -280,6 +282,7 @@ describe('Realtime Controller', () => {
       should(kuzzle.realtime.subscriptions).be.empty();
       should(stub.callCount).be.eql(10);
       should(kuzzle.emit).calledOnce().calledWith('tokenExpired');
+      should(kuzzle.jwt).be.undefined();
     });
 
     it('should throttle to prevent emitting duplicate occurrences of the same event', () => {

--- a/test/controllers/realtime.test.js
+++ b/test/controllers/realtime.test.js
@@ -11,7 +11,8 @@ describe('Realtime Controller', () => {
 
   beforeEach(() => {
     kuzzle = {
-      query: sinon.stub().resolves()
+      query: sinon.stub().resolves(),
+      emit: sinon.stub()
     };
     kuzzle.realtime = new RealtimeController(kuzzle);
   });
@@ -96,22 +97,27 @@ describe('Realtime Controller', () => {
     beforeEach(() => {
       room = null;
 
-      mockrequire('../../src/controllers/realtime/room', function (kuz, index, collection, body, callback, opts = {}) {
-        room = {
-          kuzzle: kuz,
-          index,
-          collection,
-          body,
-          callback,
-          options: opts,
-          id: roomId,
-          subscribe: sinon.stub().resolves(subscribeResponse)
-        };
+      mockrequire(
+        '../../src/controllers/realtime/room',
+        function (controller, index, collection, body, callback, opts = {}) {
+          room = {
+            controller,
+            index,
+            collection,
+            body,
+            callback,
+            kuzzle: controller.kuzzle,
+            options: opts,
+            id: roomId,
+            subscribe: sinon.stub().resolves(subscribeResponse)
+          };
 
-        return room;
-      });
+          return room;
+        });
 
-      kuzzle.realtime = new (mockrequire.reRequire('../../src/controllers/realtime/index'))(kuzzle);
+      const MockRealtimeController =
+        mockrequire.reRequire('../../src/controllers/realtime/index');
+      kuzzle.realtime = new MockRealtimeController(kuzzle);
     });
 
     it('should throw an error if the "index" argument is not provided', () => {
@@ -245,7 +251,7 @@ describe('Realtime Controller', () => {
         });
     });
 
-    it('should call realtime/unsubiscribe query with the roomId and return a Promise which resolves the roomId', () => {
+    it('should call realtime/unsubscribe query with the roomId and return a Promise which resolves the roomId', () => {
       return kuzzle.realtime.unsubscribe(roomId, options)
         .then(res => {
           should(kuzzle.query)
@@ -258,6 +264,37 @@ describe('Realtime Controller', () => {
 
           should(res).be.equal(roomId);
         });
+    });
+  });
+
+  describe('#tokenExpired', () => {
+    it('should clear all subscriptions and emit a "tokenExpired" event', () => {
+      const stub = sinon.stub();
+
+      for (let i = 0; i < 10; i++) {
+        kuzzle.realtime.subscriptions[uuidv4()] = [{removeListeners: stub}];
+      }
+
+      kuzzle.realtime.tokenExpired();
+
+      should(kuzzle.realtime.subscriptions).be.empty();
+      should(stub.callCount).be.eql(10);
+      should(kuzzle.emit).calledOnce().calledWith('tokenExpired');
+    });
+
+    it('should throttle to prevent emitting duplicate occurrences of the same event', () => {
+      const stub = sinon.stub();
+
+      for (let i = 0; i < 10; i++) {
+        kuzzle.realtime.subscriptions[uuidv4()] = [{removeListeners: stub}];
+
+        kuzzle.realtime.tokenExpired();
+
+        should(kuzzle.realtime.subscriptions).be.empty();
+        should(stub.callCount).be.eql(i+1);
+      }
+
+      should(kuzzle.emit).calledOnce().calledWith('tokenExpired');
     });
   });
 });


### PR DESCRIPTION
# Description

The Kuzzle event `tokenExpired` should be triggered in two cases:
* when a request response contains `tokenExpired` error
* whenever a `TokenExpired` realtime event is received

The current SDK version only handles the first case, which causes many problems for clients using realtime, such as:
* realtime callbacks are not cleared, meaning clients handling manually the event have more and more of the same callbacks registered (and invoked)
* the `tokenExpired` event is not triggered upon receiving a TokenExpired realtime notification
* the JWT is not cleared upon receiving a TokenExpired realtime notification

This PR adds a proper TokenExpired realtime notification handling, ensuring that all the above problems are solved.