### PR TITLE
KZL 1001 - Add KuzzleError

### DIFF
--- a/src/KuzzleError.js
+++ b/src/KuzzleError.js
@@ -1,0 +1,12 @@
+'use strict';
+
+class KuzzleError extends Error {
+  constructor (apiError) {
+    super(apiError.message);
+
+    this.status = apiError.status;
+    this.stack = apiError.stack;
+  }
+}
+
+module.exports = KuzzleError;

--- a/src/protocols/abstract/common.js
+++ b/src/protocols/abstract/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const
+  KuzzleError = require('../../KuzzleError'),
   uuidv4 = require('../../uuidv4'),
   KuzzleEventEmitter = require('../../eventEmitter');
 
@@ -83,10 +84,8 @@ Discarded request: ${JSON.stringify(request)}`));
     return new Promise((resolve, reject) => {
       this.once(request.requestId, response => {
         if (response.error) {
-          const error = new Error(response.error.message);
-          Object.assign(error, response.error);
-          error.status = response.status;
-          response.error = error;
+          const error = new KuzzleError(response.error);
+
           this.emit('queryError', error, request);
 
           if (request.action !== 'logout' && error.message === 'Token expired') {

--- a/test/protocol/query.test.js
+++ b/test/protocol/query.test.js
@@ -1,6 +1,7 @@
-var
+const
   should = require('should'),
   sinon = require('sinon'),
+  KuzzleError = require('../../src/KuzzleError'),
   AbstractWrapper = require('../../src/protocols/abstract/common');
 
 describe('Protocol query management', () => {
@@ -69,6 +70,7 @@ describe('Protocol query management', () => {
         .then(() => Promise.reject({message: 'No error'}))
         .catch(error => {
           should(eventStub).be.calledOnce();
+          should(error).be.instanceOf(KuzzleError);
           should(error.message).be.exactly('foo-bar');
         });
     });
@@ -101,6 +103,25 @@ describe('Protocol query management', () => {
           should(res.error).be.null();
           should(res.result).be.exactly(response.result);
           should(res.status).be.exactly(42);
+        });
+    });
+
+    it('should throw a KuzzleError on error', () => {
+      const response = {
+        error: {
+          message: 'foo-bar',
+          status: 442,
+          stack: 'you are the bug'
+        }
+      };
+
+      return protocol.query({ requestId: 'foobar', response: response })
+        .then(() => Promise.reject({message: 'No error'}))
+        .catch(error => {
+          should(error).be.instanceOf(KuzzleError);
+          should(error.message).be.eql('foo-bar');
+          should(error.status).be.eql(442);
+          should(error.stack).be.eql('you are the bug');
         });
     });
   });


### PR DESCRIPTION
## What does this PR do?

Adds a `KuzzleError` that extends `Error` class.  
The `KuzzleError` contains additional properties sent by Kuzzle: `status` and `stack`.