### PR TITLE
[fix] search API: "sort" and "search_after" must be in the requests body

### DIFF
--- a/src/controllers/searchResult/base.js
+++ b/src/controllers/searchResult/base.js
@@ -45,15 +45,16 @@ class SearchResultBase {
           return this;
         });
     }
-    else if (this._request.size && this._request.sort) {
+    else if (this._request.size && this._request.body.sort) {
       const
         request = Object.assign({}, this._request, {
-          action: this._searchAction,
-          search_after: []
+          action: this._searchAction
         }),
-        hit = this._response.hits && this._response.hits[this._response.hits.length -1];
+        hit = this._response.hits[this._response.hits.length -1];
 
-      for (const sort of this._request.sort) {
+      request.body.search_after = [];
+
+      for (const sort of this._request.body.sort) {
         const key = typeof sort === 'string'
           ? sort
           : Object.keys(sort)[0];
@@ -61,7 +62,7 @@ class SearchResultBase {
           ? this._request.collection + '#' + hit._id
           : this._get(hit._source, key.split('.'));
 
-        request.search_after.push(value);
+        request.body.search_after.push(value);
       }
 
       return _kuzzle.query(request, this._options)

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -20,7 +20,11 @@ describe('DocumentSearchResult', () => {
     request = {
       index: 'index',
       collection: 'collection',
-      body: {foo: 'bar'},
+      body: {
+        query: {
+          foo: 'bar'
+        }
+      },
       controller: 'document',
       action: 'search',
     };
@@ -158,7 +162,7 @@ describe('DocumentSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['foo', {bar: 'asc'}, {_uid: 'desc'}];
+        request.body.sort = ['foo', {bar: 'asc'}, {_uid: 'desc'}];
 
         response = {
           hits: [
@@ -181,12 +185,16 @@ describe('DocumentSearchResult', () => {
               .be.calledWith({
                 index: 'index',
                 collection: 'collection',
-                body: {foo: 'bar'},
+                body: {
+                  query: {
+                    foo: 'bar'
+                  },
+                  sort: ['foo', {bar: 'asc'}, {_uid: 'desc'}],
+                  search_after: ['barbar', 2345, 'collection#document2']
+                },
                 controller: 'document',
                 action: 'search',
-                size: 2,
-                sort: ['foo', {bar: 'asc'}, {_uid: 'desc'}],
-                search_after: ['barbar', 2345, 'collection#document2']
+                size: 2
               }, options);
             should(res).be.equal(searchResult);
           });
@@ -253,7 +261,7 @@ describe('DocumentSearchResult', () => {
               .be.calledWith({
                 index: 'index',
                 collection: 'collection',
-                body: {foo: 'bar'},
+                body: { query: { foo: 'bar' } },
                 controller: 'document',
                 action: 'search',
                 size: 2,

--- a/test/controllers/searchResult/profile.test.js
+++ b/test/controllers/searchResult/profile.test.js
@@ -19,7 +19,7 @@ describe('ProfileSearchResult', () => {
     };
 
     request = {
-      body: {foo: 'bar'},
+      body: { query: { foo: 'bar'} },
       controller: 'security',
       action: 'searchProfiles',
     };
@@ -172,12 +172,28 @@ describe('ProfileSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['foo', {bar: 'asc'}];
+        request.body.sort = ['foo', {bar: 'asc'}];
 
         response = {
           hits: [
-            {_id: 'profile1', _version: 1, _source: {policies: ['foo', 'bar'], foo: 'bar', bar: 1234}},
-            {_id: 'profile2', _version: 3, _source: {policies: ['foo', 'baz'], foo: 'baz', bar: 3456}}
+            {
+              _id: 'profile1',
+              _version: 1,
+              _source: {
+                policies: ['foo', 'bar'],
+                foo: 'bar',
+                bar: 1234
+              }
+            },
+            {
+              _id: 'profile2',
+              _version: 3,
+              _source: {
+                policies: ['foo', 'baz'],
+                foo: 'baz',
+                bar: 3456
+              }
+            }
           ],
           total: 30
         };
@@ -186,18 +202,21 @@ describe('ProfileSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call security/searchProfiles action with search_after parameter and resolve the current object', () => {
+      it('should call security/searchProfiles action with search_after \
+          parameter and resolve the current object', () => {
         return searchResult.next()
           .then(res => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: {
+                  sort: ['foo', {bar: 'asc'}],
+                  search_after: ['baz', 3456],
+                  query: { foo: 'bar' }
+                },
                 controller: 'security',
                 action: 'searchProfiles',
-                size: 2,
-                sort: ['foo', {bar: 'asc'}],
-                search_after: ['baz', 3456]
+                size: 2
               }, options);
             should(res).be.equal(searchResult);
           });
@@ -268,7 +287,7 @@ describe('ProfileSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: { query: { foo: 'bar' } },
                 controller: 'security',
                 action: 'searchProfiles',
                 size: 2,

--- a/test/controllers/searchResult/specifications.test.js
+++ b/test/controllers/searchResult/specifications.test.js
@@ -1,5 +1,6 @@
 const
-  SpecificationsSearchResult = require('../../../src/controllers/searchResult/specifications'),
+  SpecificationsSearchResult = require(
+    '../../../src/controllers/searchResult/specifications'),
   sinon = require('sinon'),
   should = require('should');
 
@@ -18,7 +19,7 @@ describe('SpecificationsSearchResult', () => {
     };
 
     request = {
-      body: {foo: 'bar'},
+      body: { query: { foo: 'bar' } },
       controller: 'collection',
       action: 'searchSpecifications',
     };
@@ -151,7 +152,7 @@ describe('SpecificationsSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['index', {collection: 'asc'}];
+        request.body.sort = ['index', {collection: 'asc'}];
 
         response = {
           hits: [
@@ -171,12 +172,14 @@ describe('SpecificationsSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: {
+                  query: { foo: 'bar' },
+                  sort: ['index', {collection: 'asc'}],
+                  search_after: ['index', 'collection2']
+                },
                 controller: 'collection',
                 action: 'searchSpecifications',
-                size: 2,
-                sort: ['index', {collection: 'asc'}],
-                search_after: ['index', 'collection2']
+                size: 2
               }, options);
             should(res).be.equal(searchResult);
           });
@@ -237,7 +240,7 @@ describe('SpecificationsSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: { query: { foo: 'bar' } },
                 controller: 'collection',
                 action: 'searchSpecifications',
                 size: 2,

--- a/test/controllers/searchResult/user.test.js
+++ b/test/controllers/searchResult/user.test.js
@@ -19,7 +19,7 @@ describe('UserSearchResult', () => {
     };
 
     request = {
-      body: {foo: 'bar'},
+      body: { query: { foo: 'bar' } },
       controller: 'security',
       action: 'searchUsers',
     };
@@ -176,7 +176,7 @@ describe('UserSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['name', {bar: 'asc'}];
+        request.body.sort = ['name', {bar: 'asc'}];
 
         response = {
           hits: [
@@ -196,12 +196,14 @@ describe('UserSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: {
+                  query: { foo: 'bar' },
+                  sort: ['name', {bar: 'asc'}],
+                  search_after: ['Jane Doe', 3456]
+                },
                 controller: 'security',
                 action: 'searchUsers',
-                size: 2,
-                sort: ['name', {bar: 'asc'}],
-                search_after: ['Jane Doe', 3456]
+                size: 2
               }, options);
             should(res).be.equal(searchResult);
           });
@@ -274,7 +276,7 @@ describe('UserSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: { query: { foo: 'bar' } },
                 controller: 'security',
                 action: 'searchUsers',
                 size: 2,


### PR DESCRIPTION
# Description

The `SearchResult` class sends a `search_after` request to Kuzzle upon calling its `next` method, if:
* no scroll_id is available
* a `size` option is provided
* the search query contains a `sort` modifier

The current implementation considers that `sort` must be at the root of the API request, while Kuzzle expects it inside the body part of it.
Same thing goes for the `search_after` argument, which must be put in the request body, not at root level.
