### PR TITLE
SearchResult.next returns a new instance

### DIFF
--- a/src/controllers/searchResult/base.js
+++ b/src/controllers/searchResult/base.js
@@ -45,15 +45,16 @@ class SearchResultBase {
           return this;
         });
     }
-    else if (this._request.size && this._request.sort) {
+    else if (this._request.size && this._request.body.sort) {
       const
         request = Object.assign({}, this._request, {
-          action: this._searchAction,
-          search_after: []
+          action: this._searchAction
         }),
-        hit = this._response.hits && this._response.hits[this._response.hits.length -1];
+        hit = this._response.hits[this._response.hits.length -1];
 
-      for (const sort of this._request.sort) {
+      request.body.search_after = [];
+
+      for (const sort of this._request.body.sort) {
         const key = typeof sort === 'string'
           ? sort
           : Object.keys(sort)[0];
@@ -61,7 +62,7 @@ class SearchResultBase {
           ? this._request.collection + '#' + hit._id
           : this._get(hit._source, key.split('.'));
 
-        request.search_after.push(value);
+        request.body.search_after.push(value);
       }
 
       return _kuzzle.query(request, this._options)

--- a/src/controllers/searchResult/base.js
+++ b/src/controllers/searchResult/base.js
@@ -36,14 +36,7 @@ class SearchResultBase {
         action: this._scrollAction,
         scrollId: this._response.scrollId
       }, this._options)
-        .then(response => {
-          const result = response.result;
-          this.fetched += result.hits.length;
-          this._response = result;
-          this.aggregations = result.aggregations;
-          this.hits = result.hits;
-          return this;
-        });
+        .then(response => this._buildNextSearchResult(response));
     }
     else if (this._request.size && this._request.body.sort) {
       const
@@ -66,14 +59,7 @@ class SearchResultBase {
       }
 
       return _kuzzle.query(request, this._options)
-        .then(response => {
-          const result = response.result;
-          this.fetched += result.hits.length;
-          this._response = result;
-          this.aggregations = result.aggregations;
-          this.hits = result.hits;
-          return this;
-        });
+        .then(response => this._buildNextSearchResult(response));
     }
     else if (this._request.size) {
       if (this._request.from >= this._response.total) {
@@ -84,14 +70,7 @@ class SearchResultBase {
         action: this._searchAction,
         from: this.fetched
       }), this._options)
-        .then(response => {
-          const result = response.result;
-          this.fetched += result.hits.length;
-          this._response = result;
-          this.aggregations = result.aggregations;
-          this.hits = result.hits;
-          return this;
-        });
+        .then(response => this._buildNextSearchResult(response));
     }
 
     throw new Error('Unable to retrieve next results from search: missing scrollId, from/sort, or from/size params');
@@ -108,6 +87,13 @@ class SearchResultBase {
 
     const key = path.shift();
     return this._get(object[key], path);
+  }
+
+  _buildNextSearchResult(response) {
+    const nextSearchResult = new this.constructor(this.kuzzle, this._request, this._options, response.result);
+    nextSearchResult.fetched = this.fetched + response.result.hits.length;
+
+    return nextSearchResult;
   }
 
 }

--- a/src/controllers/searchResult/base.js
+++ b/src/controllers/searchResult/base.js
@@ -1,5 +1,3 @@
-let _kuzzle;
-
 class SearchResultBase {
 
   /**
@@ -10,7 +8,7 @@ class SearchResultBase {
    * @param {object} response
    */
   constructor (kuzzle, request = {}, options = {}, response = {}) {
-    _kuzzle = kuzzle;
+    this._kuzzle = kuzzle;
     this._request = request;
     this._response = response;
     this._options = options;
@@ -31,7 +29,7 @@ class SearchResultBase {
     }
 
     if (this._request.scroll) {
-      return _kuzzle.query({
+      return this._kuzzle.query({
         controller: this._request.controller,
         action: this._scrollAction,
         scrollId: this._response.scrollId
@@ -43,7 +41,7 @@ class SearchResultBase {
         request = Object.assign({}, this._request, {
           action: this._searchAction
         }),
-        hit = this._response.hits[this._response.hits.length -1];
+        hit = this._response.hits[this._response.hits.length - 1];
 
       request.body.search_after = [];
 
@@ -58,7 +56,7 @@ class SearchResultBase {
         request.body.search_after.push(value);
       }
 
-      return _kuzzle.query(request, this._options)
+      return this._kuzzle.query(request, this._options)
         .then(response => this._buildNextSearchResult(response));
     }
     else if (this._request.size) {
@@ -66,7 +64,7 @@ class SearchResultBase {
         return Promise.resolve(null);
       }
 
-      return _kuzzle.query(Object.assign({}, this._request, {
+      return this._kuzzle.query(Object.assign({}, this._request, {
         action: this._searchAction,
         from: this.fetched
       }), this._options)
@@ -89,9 +87,9 @@ class SearchResultBase {
     return this._get(object[key], path);
   }
 
-  _buildNextSearchResult(response) {
-    const nextSearchResult = new this.constructor(this.kuzzle, this._request, this._options, response.result);
-    nextSearchResult.fetched = this.fetched + response.result.hits.length;
+  _buildNextSearchResult (response) {
+    const nextSearchResult = new this.constructor(this._kuzzle, this._request, this._options, response.result);
+    nextSearchResult.fetched += this.fetched;
 
     return nextSearchResult;
   }

--- a/src/controllers/searchResult/profile.js
+++ b/src/controllers/searchResult/profile.js
@@ -14,13 +14,13 @@ class ProfileSearchResult extends SearchResultBase {
 
   next () {
     return super.next()
-      .then(result => {
-        if (! result) {
-          return result;
+      .then(nextSearchResult => {
+        if (! nextSearchResult) {
+          return null;
         }
 
-        this.hits = this._response.hits.map(hit => new Profile(this._kuzzle, hit._id, hit._source.policies));
-        return this;
+        nextSearchResult.hits = nextSearchResult._response.hits.map(hit => new Profile(nextSearchResult._kuzzle, hit._id, hit._source.policies));
+        return nextSearchResult;
       });
   }
 }

--- a/src/controllers/searchResult/role.js
+++ b/src/controllers/searchResult/role.js
@@ -21,14 +21,14 @@ class RoleSearchResult extends SearchResultBase {
     }
 
     return super.next()
-      .then(result => {
-        if (!result) {
-          return result;
+      .then(nextSearchResult => {
+        if (! nextSearchResult) {
+          return null;
         }
 
-        this.hits = this._response.hits.map(hit => new Role(this._kuzzle, hit._id, hit._source.controllers));
+        nextSearchResult.hits = nextSearchResult._response.hits.map(hit => new Role(nextSearchResult._kuzzle, hit._id, hit._source.controllers));
 
-        return this;
+        return nextSearchResult;
       });
   }
 }

--- a/src/controllers/searchResult/user.js
+++ b/src/controllers/searchResult/user.js
@@ -14,13 +14,13 @@ class UserSearchResult extends SearchResultBase {
 
   next () {
     return super.next()
-      .then(result => {
-        if (!result) {
-          return result;
+      .then(nextSearchResult => {
+        if (! nextSearchResult) {
+          return null;
         }
 
-        this.hits = this._response.hits.map(hit => new User(this._kuzzle, hit._id, hit._source, hit._meta));
-        return this;
+        nextSearchResult.hits = nextSearchResult._response.hits.map(hit => new User(nextSearchResult._kuzzle, hit._id, hit._source, hit._meta));
+        return nextSearchResult;
       });
   }
 }

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -122,9 +122,9 @@ describe('DocumentSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call document/scroll action with scrollId parameter and resolve the current object', () => {
+      it('should call document/scroll action with scrollId parameter and resolve to a new DocumentSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -132,7 +132,8 @@ describe('DocumentSearchResult', () => {
                 action: 'scroll',
                 scrollId: 'scroll-id'
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(DocumentSearchResult);
           });
       });
 
@@ -141,11 +142,11 @@ describe('DocumentSearchResult', () => {
         should(searchResult._response).be.equal(response);
         should(searchResult.aggregations).equal(response.aggregations);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
-            should(searchResult.hits).be.equal(nextResponse.hits);
-            should(searchResult.aggregations).equal(nextResponse.aggregations);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
+            should(nextSearchResult.hits).be.equal(nextResponse.hits);
+            should(nextSearchResult.aggregations).equal(nextResponse.aggregations);
           });
       });
     });
@@ -177,9 +178,9 @@ describe('DocumentSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call document/search action with search_after parameter and resolve the current object', () => {
+      it('should call document/search action with search_after parameter and resolve to a new DocumentSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -196,7 +197,8 @@ describe('DocumentSearchResult', () => {
                 action: 'search',
                 size: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(DocumentSearchResult);
           });
       });
 
@@ -205,11 +207,11 @@ describe('DocumentSearchResult', () => {
         should(searchResult._response).be.equal(response);
         should(searchResult.aggregations).equal(response.aggregations);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
-            should(searchResult.hits).be.equal(nextResponse.hits);
-            should(searchResult.aggregations).equal(nextResponse.aggregations);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
+            should(nextSearchResult.hits).be.equal(nextResponse.hits);
+            should(nextSearchResult.aggregations).equal(nextResponse.aggregations);
           });
       });
     });
@@ -253,9 +255,9 @@ describe('DocumentSearchResult', () => {
       });
 
 
-      it('should call document/search action with from/size parameters and resolve the current object', () => {
+      it('should call document/search action with from/size parameters and resolve to a new DocumentSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -267,7 +269,8 @@ describe('DocumentSearchResult', () => {
                 size: 2,
                 from: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(DocumentSearchResult);
           });
       });
 
@@ -276,11 +279,11 @@ describe('DocumentSearchResult', () => {
         should(searchResult._response).be.equal(response);
         should(searchResult.aggregations).be.equal(response.aggregations);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
-            should(searchResult.hits).be.equal(nextResponse.hits);
-            should(searchResult.aggregations).equal(nextResponse.aggregations);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
+            should(nextSearchResult.hits).be.equal(nextResponse.hits);
+            should(nextSearchResult.aggregations).equal(nextResponse.aggregations);
           });
       });
     });

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -20,7 +20,11 @@ describe('DocumentSearchResult', () => {
     request = {
       index: 'index',
       collection: 'collection',
-      body: {foo: 'bar'},
+      body: {
+        query: {
+          foo: 'bar'
+        }
+      },
       controller: 'document',
       action: 'search',
     };
@@ -158,7 +162,7 @@ describe('DocumentSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['foo', {bar: 'asc'}, {_uid: 'desc'}];
+        request.body.sort = ['foo', {bar: 'asc'}, {_uid: 'desc'}];
 
         response = {
           hits: [
@@ -181,12 +185,16 @@ describe('DocumentSearchResult', () => {
               .be.calledWith({
                 index: 'index',
                 collection: 'collection',
-                body: {foo: 'bar'},
+                body: {
+                  query: {
+                    foo: 'bar'
+                  },
+                  sort: ['foo', {bar: 'asc'}, {_uid: 'desc'}],
+                  search_after: ['barbar', 2345, 'collection#document2']
+                },
                 controller: 'document',
                 action: 'search',
-                size: 2,
-                sort: ['foo', {bar: 'asc'}, {_uid: 'desc'}],
-                search_after: ['barbar', 2345, 'collection#document2']
+                size: 2
               }, options);
             should(res).be.equal(searchResult);
           });
@@ -253,7 +261,7 @@ describe('DocumentSearchResult', () => {
               .be.calledWith({
                 index: 'index',
                 collection: 'collection',
-                body: {foo: 'bar'},
+                body: { query: { foo: 'bar' } },
                 controller: 'document',
                 action: 'search',
                 size: 2,

--- a/test/controllers/searchResult/profile.test.js
+++ b/test/controllers/searchResult/profile.test.js
@@ -125,9 +125,9 @@ describe('ProfileSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call security/scrollProfiles action with scrollId parameter and resolve the current object', () => {
+      it('should call security/scrollProfiles action with scrollId parameter and resolve to a new ProfileSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -135,7 +135,8 @@ describe('ProfileSearchResult', () => {
                 action: 'scrollProfiles',
                 scrollId: 'scroll-id'
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(ProfileSearchResult);
           });
       });
 
@@ -143,20 +144,20 @@ describe('ProfileSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
 
-            should(searchResult.hits).be.an.Array();
-            should(searchResult.hits.length).be.equal(2);
+            should(nextSearchResult.hits).be.an.Array();
+            should(nextSearchResult.hits.length).be.equal(2);
 
-            should(searchResult.hits[0]).be.an.instanceOf(Profile);
-            should(searchResult.hits[0]._id).be.eql('profile3');
-            should(searchResult.hits[0].policies).be.eql(['baz']);
+            should(nextSearchResult.hits[0]).be.an.instanceOf(Profile);
+            should(nextSearchResult.hits[0]._id).be.eql('profile3');
+            should(nextSearchResult.hits[0].policies).be.eql(['baz']);
 
-            should(searchResult.hits[1]).be.an.instanceOf(Profile);
-            should(searchResult.hits[1]._id).be.eql('profile4');
-            should(searchResult.hits[1].policies).be.eql(['foo', 'bar', 'baz']);
+            should(nextSearchResult.hits[1]).be.an.instanceOf(Profile);
+            should(nextSearchResult.hits[1]._id).be.eql('profile4');
+            should(nextSearchResult.hits[1].policies).be.eql(['foo', 'bar', 'baz']);
           });
       });
     });
@@ -203,9 +204,9 @@ describe('ProfileSearchResult', () => {
       });
 
       it('should call security/searchProfiles action with search_after \
-          parameter and resolve the current object', () => {
+          parameter and resolve to a new ProfileSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -218,7 +219,8 @@ describe('ProfileSearchResult', () => {
                 action: 'searchProfiles',
                 size: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(ProfileSearchResult);
           });
       });
 
@@ -226,20 +228,20 @@ describe('ProfileSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
 
-            should(searchResult.hits).be.an.Array();
-            should(searchResult.hits.length).be.equal(2);
+            should(nextSearchResult.hits).be.an.Array();
+            should(nextSearchResult.hits.length).be.equal(2);
 
-            should(searchResult.hits[0]).be.an.instanceOf(Profile);
-            should(searchResult.hits[0]._id).be.eql('profile3');
-            should(searchResult.hits[0].policies).be.eql(['baz']);
+            should(nextSearchResult.hits[0]).be.an.instanceOf(Profile);
+            should(nextSearchResult.hits[0]._id).be.eql('profile3');
+            should(nextSearchResult.hits[0].policies).be.eql(['baz']);
 
-            should(searchResult.hits[1]).be.an.instanceOf(Profile);
-            should(searchResult.hits[1]._id).be.eql('profile4');
-            should(searchResult.hits[1].policies).be.eql(['foo', 'bar', 'baz']);
+            should(nextSearchResult.hits[1]).be.an.instanceOf(Profile);
+            should(nextSearchResult.hits[1]._id).be.eql('profile4');
+            should(nextSearchResult.hits[1].policies).be.eql(['foo', 'bar', 'baz']);
           });
       });
     });
@@ -281,9 +283,9 @@ describe('ProfileSearchResult', () => {
       });
 
 
-      it('should call security/searchProfiles action with from/size parameters and resolve the current object', () => {
+      it('should call security/searchProfiles action with from/size parameters and resolve to a new ProfileSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -293,7 +295,8 @@ describe('ProfileSearchResult', () => {
                 size: 2,
                 from: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(ProfileSearchResult);
           });
       });
 
@@ -301,20 +304,20 @@ describe('ProfileSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
 
-            should(searchResult.hits).be.an.Array();
-            should(searchResult.hits.length).be.equal(2);
+            should(nextSearchResult.hits).be.an.Array();
+            should(nextSearchResult.hits.length).be.equal(2);
 
-            should(searchResult.hits[0]).be.an.instanceOf(Profile);
-            should(searchResult.hits[0]._id).be.eql('profile3');
-            should(searchResult.hits[0].policies).be.eql(['baz']);
+            should(nextSearchResult.hits[0]).be.an.instanceOf(Profile);
+            should(nextSearchResult.hits[0]._id).be.eql('profile3');
+            should(nextSearchResult.hits[0].policies).be.eql(['baz']);
 
-            should(searchResult.hits[1]).be.an.instanceOf(Profile);
-            should(searchResult.hits[1]._id).be.eql('profile4');
-            should(searchResult.hits[1].policies).be.eql(['foo', 'bar', 'baz']);
+            should(nextSearchResult.hits[1]).be.an.instanceOf(Profile);
+            should(nextSearchResult.hits[1]._id).be.eql('profile4');
+            should(nextSearchResult.hits[1].policies).be.eql(['foo', 'bar', 'baz']);
           });
       });
     });

--- a/test/controllers/searchResult/profile.test.js
+++ b/test/controllers/searchResult/profile.test.js
@@ -19,7 +19,7 @@ describe('ProfileSearchResult', () => {
     };
 
     request = {
-      body: {foo: 'bar'},
+      body: { query: { foo: 'bar'} },
       controller: 'security',
       action: 'searchProfiles',
     };
@@ -172,12 +172,28 @@ describe('ProfileSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['foo', {bar: 'asc'}];
+        request.body.sort = ['foo', {bar: 'asc'}];
 
         response = {
           hits: [
-            {_id: 'profile1', _version: 1, _source: {policies: ['foo', 'bar'], foo: 'bar', bar: 1234}},
-            {_id: 'profile2', _version: 3, _source: {policies: ['foo', 'baz'], foo: 'baz', bar: 3456}}
+            {
+              _id: 'profile1',
+              _version: 1,
+              _source: {
+                policies: ['foo', 'bar'],
+                foo: 'bar',
+                bar: 1234
+              }
+            },
+            {
+              _id: 'profile2',
+              _version: 3,
+              _source: {
+                policies: ['foo', 'baz'],
+                foo: 'baz',
+                bar: 3456
+              }
+            }
           ],
           total: 30
         };
@@ -186,18 +202,21 @@ describe('ProfileSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call security/searchProfiles action with search_after parameter and resolve the current object', () => {
+      it('should call security/searchProfiles action with search_after \
+          parameter and resolve the current object', () => {
         return searchResult.next()
           .then(res => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: {
+                  sort: ['foo', {bar: 'asc'}],
+                  search_after: ['baz', 3456],
+                  query: { foo: 'bar' }
+                },
                 controller: 'security',
                 action: 'searchProfiles',
-                size: 2,
-                sort: ['foo', {bar: 'asc'}],
-                search_after: ['baz', 3456]
+                size: 2
               }, options);
             should(res).be.equal(searchResult);
           });
@@ -268,7 +287,7 @@ describe('ProfileSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: { query: { foo: 'bar' } },
                 controller: 'security',
                 action: 'searchProfiles',
                 size: 2,

--- a/test/controllers/searchResult/role.test.js
+++ b/test/controllers/searchResult/role.test.js
@@ -139,9 +139,9 @@ describe('RoleSearchResult', () => {
       });
 
 
-      it('should call security/searchRoles action with from/size parameters and resolve the current object', () => {
+      it('should call security/searchRoles action with from/size parameters and resolve to a new RoleSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -151,7 +151,8 @@ describe('RoleSearchResult', () => {
                 size: 2,
                 from: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(RoleSearchResult);
           });
       });
 
@@ -159,20 +160,20 @@ describe('RoleSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
 
-            should(searchResult.hits).be.an.Array();
-            should(searchResult.hits.length).be.equal(2);
+            should(nextSearchResult.hits).be.an.Array();
+            should(nextSearchResult.hits.length).be.equal(2);
 
-            should(searchResult.hits[0]).be.an.instanceOf(Role);
-            should(searchResult.hits[0]._id).be.eql('role3');
-            should(searchResult.hits[0].controllers).be.eql({foo: {actions: {baz: true}}});
+            should(nextSearchResult.hits[0]).be.an.instanceOf(Role);
+            should(nextSearchResult.hits[0]._id).be.eql('role3');
+            should(nextSearchResult.hits[0].controllers).be.eql({foo: {actions: {baz: true}}});
 
-            should(searchResult.hits[1]).be.an.instanceOf(Role);
-            should(searchResult.hits[1]._id).be.eql('role4');
-            should(searchResult.hits[1].controllers).be.eql({baz: {actions: {foo: true}}});
+            should(nextSearchResult.hits[1]).be.an.instanceOf(Role);
+            should(nextSearchResult.hits[1]._id).be.eql('role4');
+            should(nextSearchResult.hits[1].controllers).be.eql({baz: {actions: {foo: true}}});
           });
       });
     });

--- a/test/controllers/searchResult/specifications.test.js
+++ b/test/controllers/searchResult/specifications.test.js
@@ -115,9 +115,9 @@ describe('SpecificationsSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call collection/scrollSpecifications action with scrollId parameter and resolve the current object', () => {
+      it('should call collection/scrollSpecifications action with scrollId parameter and resolve to a new SpecificationSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -125,7 +125,8 @@ describe('SpecificationsSearchResult', () => {
                 action: 'scrollSpecifications',
                 scrollId: 'scroll-id'
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(SpecificationsSearchResult);
           });
       });
 
@@ -133,10 +134,10 @@ describe('SpecificationsSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
-            should(searchResult.hits).be.equal(nextResponse.hits);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
+            should(nextSearchResult.hits).be.equal(nextResponse.hits);
           });
       });
     });
@@ -166,9 +167,9 @@ describe('SpecificationsSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call collection/searchSpecifications action with search_after parameter and resolve the current object', () => {
+      it('should call collection/searchSpecifications action with search_after parameter and resolve to a new SpecificationSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -181,7 +182,8 @@ describe('SpecificationsSearchResult', () => {
                 action: 'searchSpecifications',
                 size: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(SpecificationsSearchResult);
           });
       });
 
@@ -189,10 +191,10 @@ describe('SpecificationsSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
-            should(searchResult.hits).be.equal(nextResponse.hits);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
+            should(nextSearchResult.hits).be.equal(nextResponse.hits);
           });
       });
     });
@@ -234,9 +236,9 @@ describe('SpecificationsSearchResult', () => {
       });
 
 
-      it('should call collection/searchSpecifications action with from/size parameters and resolve the current object', () => {
+      it('should call collection/searchSpecifications action with from/size parameters and resolve to a new SpecificationSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -246,7 +248,8 @@ describe('SpecificationsSearchResult', () => {
                 size: 2,
                 from: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(SpecificationsSearchResult);
           });
       });
 
@@ -254,10 +257,10 @@ describe('SpecificationsSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
-            should(searchResult.hits).be.equal(nextResponse.hits);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
+            should(nextSearchResult.hits).be.equal(nextResponse.hits);
           });
       });
     });

--- a/test/controllers/searchResult/specifications.test.js
+++ b/test/controllers/searchResult/specifications.test.js
@@ -1,5 +1,6 @@
 const
-  SpecificationsSearchResult = require('../../../src/controllers/searchResult/specifications'),
+  SpecificationsSearchResult = require(
+    '../../../src/controllers/searchResult/specifications'),
   sinon = require('sinon'),
   should = require('should');
 
@@ -18,7 +19,7 @@ describe('SpecificationsSearchResult', () => {
     };
 
     request = {
-      body: {foo: 'bar'},
+      body: { query: { foo: 'bar' } },
       controller: 'collection',
       action: 'searchSpecifications',
     };
@@ -151,7 +152,7 @@ describe('SpecificationsSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['index', {collection: 'asc'}];
+        request.body.sort = ['index', {collection: 'asc'}];
 
         response = {
           hits: [
@@ -171,12 +172,14 @@ describe('SpecificationsSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: {
+                  query: { foo: 'bar' },
+                  sort: ['index', {collection: 'asc'}],
+                  search_after: ['index', 'collection2']
+                },
                 controller: 'collection',
                 action: 'searchSpecifications',
-                size: 2,
-                sort: ['index', {collection: 'asc'}],
-                search_after: ['index', 'collection2']
+                size: 2
               }, options);
             should(res).be.equal(searchResult);
           });
@@ -237,7 +240,7 @@ describe('SpecificationsSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: { query: { foo: 'bar' } },
                 controller: 'collection',
                 action: 'searchSpecifications',
                 size: 2,

--- a/test/controllers/searchResult/user.test.js
+++ b/test/controllers/searchResult/user.test.js
@@ -127,9 +127,9 @@ describe('UserSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call security/scrollUsers action with scrollId parameter and resolve the current object', () => {
+      it('should call security/scrollUsers action with scrollnextSearchResultparameter and resolve to a new UserSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -137,7 +137,8 @@ describe('UserSearchResult', () => {
                 action: 'scrollUsers',
                 scrollId: 'scroll-id'
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(UserSearchResult);
           });
       });
 
@@ -145,22 +146,22 @@ describe('UserSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
 
-            should(searchResult.hits).be.an.Array();
-            should(searchResult.hits.length).be.equal(2);
+            should(nextSearchResult.hits).be.an.Array();
+            should(nextSearchResult.hits.length).be.equal(2);
 
-            should(searchResult.hits[0]).be.an.instanceOf(User);
-            should(searchResult.hits[0]._id).be.eql('uid3');
-            should(searchResult.hits[0].content).be.eql({name: 'Sarah Connor', profileIds: ['profile1', 'admin']});
-            should(searchResult.hits[0].profileIds).be.eql(['profile1', 'admin']);
+            should(nextSearchResult.hits[0]).be.an.instanceOf(User);
+            should(nextSearchResult.hits[0]._id).be.eql('uid3');
+            should(nextSearchResult.hits[0].content).be.eql({name: 'Sarah Connor', profileIds: ['profile1', 'admin']});
+            should(nextSearchResult.hits[0].profileIds).be.eql(['profile1', 'admin']);
 
-            should(searchResult.hits[1]).be.an.instanceOf(User);
-            should(searchResult.hits[1]._id).be.eql('uid4');
-            should(searchResult.hits[1].content).be.eql({name: 'Obiwan Kenobi', profileIds: ['profile2', 'guest']});
-            should(searchResult.hits[1].profileIds).be.eql(['profile2', 'guest']);
+            should(nextSearchResult.hits[1]).be.an.instanceOf(User);
+            should(nextSearchResult.hits[1]._id).be.eql('uid4');
+            should(nextSearchResult.hits[1].content).be.eql({name: 'Obiwan Kenobi', profileIds: ['profile2', 'guest']});
+            should(nextSearchResult.hits[1].profileIds).be.eql(['profile2', 'guest']);
           });
       });
     });
@@ -190,9 +191,9 @@ describe('UserSearchResult', () => {
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call security/searchUsers action with search_after parameter and resolve the current object', () => {
+      it('should call security/searchUsers action with search_after parameter and resolve to a new UserSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -205,7 +206,8 @@ describe('UserSearchResult', () => {
                 action: 'searchUsers',
                 size: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(UserSearchResult);
           });
       });
 
@@ -213,22 +215,22 @@ describe('UserSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
 
-            should(searchResult.hits).be.an.Array();
-            should(searchResult.hits.length).be.equal(2);
+            should(nextSearchResult.hits).be.an.Array();
+            should(nextSearchResult.hits.length).be.equal(2);
 
-            should(searchResult.hits[0]).be.an.instanceOf(User);
-            should(searchResult.hits[0]._id).be.eql('uid3');
-            should(searchResult.hits[0].content).be.eql({name: 'Sarah Connor', profileIds: ['profile1', 'admin'], bar: 5678});
-            should(searchResult.hits[0].profileIds).be.eql(['profile1', 'admin']);
+            should(nextSearchResult.hits[0]).be.an.instanceOf(User);
+            should(nextSearchResult.hits[0]._id).be.eql('uid3');
+            should(nextSearchResult.hits[0].content).be.eql({name: 'Sarah Connor', profileIds: ['profile1', 'admin'], bar: 5678});
+            should(nextSearchResult.hits[0].profileIds).be.eql(['profile1', 'admin']);
 
-            should(searchResult.hits[1]).be.an.instanceOf(User);
-            should(searchResult.hits[1]._id).be.eql('uid4');
-            should(searchResult.hits[1].content).be.eql({name: 'Obiwan Kenobi', profileIds: ['profile2', 'guest'], bar: 6789});
-            should(searchResult.hits[1].profileIds).be.eql(['profile2', 'guest']);
+            should(nextSearchResult.hits[1]).be.an.instanceOf(User);
+            should(nextSearchResult.hits[1]._id).be.eql('uid4');
+            should(nextSearchResult.hits[1].content).be.eql({name: 'Obiwan Kenobi', profileIds: ['profile2', 'guest'], bar: 6789});
+            should(nextSearchResult.hits[1].profileIds).be.eql(['profile2', 'guest']);
           });
       });
     });
@@ -270,9 +272,9 @@ describe('UserSearchResult', () => {
       });
 
 
-      it('should call security/searchUsers action with from/size parameters and resolve the current object', () => {
+      it('should call security/searchUsers action with from/size parameters and resolve to a new UserSearchResult', () => {
         return searchResult.next()
-          .then(res => {
+          .then(nextSearchResult => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
@@ -282,7 +284,8 @@ describe('UserSearchResult', () => {
                 size: 2,
                 from: 2
               }, options);
-            should(res).be.equal(searchResult);
+            should(nextSearchResult).not.be.equal(searchResult);
+            should(nextSearchResult).be.instanceOf(UserSearchResult);
           });
       });
 
@@ -290,22 +293,22 @@ describe('UserSearchResult', () => {
         should(searchResult.fetched).be.equal(2);
         should(searchResult._response).be.equal(response);
         return searchResult.next()
-          .then(() => {
-            should(searchResult.fetched).be.equal(4);
-            should(searchResult._response).be.equal(nextResponse);
+          .then(nextSearchResult => {
+            should(nextSearchResult.fetched).be.equal(4);
+            should(nextSearchResult._response).be.equal(nextResponse);
 
-            should(searchResult.hits).be.an.Array();
-            should(searchResult.hits.length).be.equal(2);
+            should(nextSearchResult.hits).be.an.Array();
+            should(nextSearchResult.hits.length).be.equal(2);
 
-            should(searchResult.hits[0]).be.an.instanceOf(User);
-            should(searchResult.hits[0]._id).be.eql('uid3');
-            should(searchResult.hits[0].content).be.eql({name: 'Sarah Connor', profileIds: ['profile1', 'admin']});
-            should(searchResult.hits[0].profileIds).be.eql(['profile1', 'admin']);
+            should(nextSearchResult.hits[0]).be.an.instanceOf(User);
+            should(nextSearchResult.hits[0]._id).be.eql('uid3');
+            should(nextSearchResult.hits[0].content).be.eql({name: 'Sarah Connor', profileIds: ['profile1', 'admin']});
+            should(nextSearchResult.hits[0].profileIds).be.eql(['profile1', 'admin']);
 
-            should(searchResult.hits[1]).be.an.instanceOf(User);
-            should(searchResult.hits[1]._id).be.eql('uid4');
-            should(searchResult.hits[1].content).be.eql({name: 'Obiwan Kenobi', profileIds: ['profile2', 'guest']});
-            should(searchResult.hits[1].profileIds).be.eql(['profile2', 'guest']);
+            should(nextSearchResult.hits[1]).be.an.instanceOf(User);
+            should(nextSearchResult.hits[1]._id).be.eql('uid4');
+            should(nextSearchResult.hits[1].content).be.eql({name: 'Obiwan Kenobi', profileIds: ['profile2', 'guest']});
+            should(nextSearchResult.hits[1].profileIds).be.eql(['profile2', 'guest']);
           });
       });
     });

--- a/test/controllers/searchResult/user.test.js
+++ b/test/controllers/searchResult/user.test.js
@@ -19,7 +19,7 @@ describe('UserSearchResult', () => {
     };
 
     request = {
-      body: {foo: 'bar'},
+      body: { query: { foo: 'bar' } },
       controller: 'security',
       action: 'searchUsers',
     };
@@ -176,7 +176,7 @@ describe('UserSearchResult', () => {
 
       beforeEach(() => {
         request.size = 2;
-        request.sort = ['name', {bar: 'asc'}];
+        request.body.sort = ['name', {bar: 'asc'}];
 
         response = {
           hits: [
@@ -196,12 +196,14 @@ describe('UserSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: {
+                  query: { foo: 'bar' },
+                  sort: ['name', {bar: 'asc'}],
+                  search_after: ['Jane Doe', 3456]
+                },
                 controller: 'security',
                 action: 'searchUsers',
-                size: 2,
-                sort: ['name', {bar: 'asc'}],
-                search_after: ['Jane Doe', 3456]
+                size: 2
               }, options);
             should(res).be.equal(searchResult);
           });
@@ -274,7 +276,7 @@ describe('UserSearchResult', () => {
             should(kuzzle.query)
               .be.calledOnce()
               .be.calledWith({
-                body: {foo: 'bar'},
+                body: { query: { foo: 'bar' } },
                 controller: 'security',
                 action: 'searchUsers',
                 size: 2,


### PR DESCRIPTION
## What does this PR do?

Returns a new instance of `SearchResult` instead of mutating the existing object.

### How should this be manually tested?

  - Step 1 : Get a search result
  - Step 2 : Use the `next` method to get the next search result
  - Step 3 : The 2 objects are not the same