### PR TITLE
Use BaseController class for controllers

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -466,6 +466,10 @@ Discarded request: ${JSON.stringify(request)}`));
       throw new Error('Controllers must have a name.');
     }
 
+    if (controller.kuzzle !== this) {
+      throw new Error('You must pass the Kuzzle SDK instance to the parent constructor.');
+    }
+
     this[accessor] = controller;
 
     return this;

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -1,4 +1,6 @@
-const User = require('./security/user');
+const
+  BaseController = require('./base'),
+  User = require('./security/user');
 
 /**
  * Auth controller
@@ -6,18 +8,14 @@ const User = require('./security/user');
  * @param kuzzle
  * @constructor
  */
-class AuthController {
+class AuthController extends BaseController {
 
   /**
    * constructor
    * @param kuzzle
    */
   constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
-
-  get kuzzle () {
-    return this._kuzzle;
+    super(kuzzle, 'auth');
   }
 
   /**
@@ -27,8 +25,7 @@ class AuthController {
    * @return {Promise|*|PromiseLike<T>|Promise<T>}
    */
   checkToken (token) {
-    return this.kuzzle.query({
-      controller: 'auth',
+    return this.query({
       action: 'checkToken',
       body: {token}
     }, {queuable: false})
@@ -44,9 +41,8 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   createMyCredentials (strategy, credentials, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       strategy,
-      controller: 'auth',
       action: 'createMyCredentials',
       body: credentials
     }, options)
@@ -60,9 +56,8 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   credentialsExist (strategy, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       strategy,
-      controller: 'auth',
       action: 'credentialsExist'
     }, options)
       .then(response => response.result);
@@ -76,9 +71,8 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   deleteMyCredentials (strategy, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       strategy,
-      controller: 'auth',
       action: 'deleteMyCredentials'
     }, options)
       .then(response => response.result.acknowledged);
@@ -90,8 +84,7 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   getCurrentUser (options = {}) {
-    return this.kuzzle.query({
-      controller: 'auth',
+    return this.query({
       action: 'getCurrentUser'
     }, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
@@ -104,9 +97,8 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   getMyCredentials(strategy, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       strategy,
-      controller: 'auth',
       action: 'getMyCredentials'
     }, options)
       .then(response => response.result);
@@ -119,8 +111,7 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   getMyRights (options = {}) {
-    return this.kuzzle.query({
-      controller: 'auth',
+    return this.query({
       action: 'getMyRights'
     }, options)
       .then(response => response.result.hits);
@@ -133,8 +124,7 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   getStrategies (options = {}) {
-    return this.kuzzle.query({
-      controller: 'auth',
+    return this.query({
       action: 'getStrategies'
     }, options)
       .then(response => response.result);
@@ -159,11 +149,10 @@ class AuthController {
         strategy,
         expiresIn,
         body: credentials,
-        controller: 'auth',
         action: 'login'
       };
 
-    return this.kuzzle.query(request, {queuable: false})
+    return this.query(request, {queuable: false})
       .then(response => {
         try {
           this.kuzzle.jwt = response.result.jwt;
@@ -186,8 +175,7 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   logout () {
-    return this.kuzzle.query({
-      controller: 'auth',
+    return this.query({
       action: 'logout'
     }, {queuable: false})
       .then(() => {
@@ -204,10 +192,9 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   updateMyCredentials (strategy, credentials, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       strategy,
       body: credentials,
-      controller: 'auth',
       action: 'updateMyCredentials'
     }, options)
       .then(response => response.result);
@@ -221,9 +208,8 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   updateSelf (body, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       body,
-      controller: 'auth',
       action: 'updateSelf'
     }, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
@@ -238,10 +224,9 @@ class AuthController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   validateMyCredentials (strategy, credentials, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       strategy,
       body: credentials,
-      controller: 'auth',
       action: 'validateMyCredentials'
     }, options)
       .then(response => response.result);
@@ -255,12 +240,11 @@ class AuthController {
    */
   refreshToken(options = {}) {
     const query = {
-      controller: 'auth',
       action: 'refreshToken',
       expiresIn: options.expiresIn
     };
 
-    return this.kuzzle.query(query, options)
+    return this.query(query, options)
       .then(response => {
         this.kuzzle.jwt = response.result.jwt;
 

--- a/src/controllers/base.js
+++ b/src/controllers/base.js
@@ -1,20 +1,16 @@
 class BaseController {
 
   /**
+   * @param {Kuzzle} kuzzle - Kuzzle SDK object.
    * @param {string} name - Controller full name for API request.
-   * @param {string} accessor - Controller accessor name on Kuzzle object.
    */
-  constructor (name, accessor) {
+  constructor (kuzzle, name) {
+    this._kuzzle = kuzzle;
     this.name = name;
-    this.accessor = accessor;
   }
 
   get kuzzle () {
     return this._kuzzle;
-  }
-
-  set kuzzle (kuzzle) {
-    this._kuzzle = kuzzle;
   }
 
   /**
@@ -25,7 +21,7 @@ class BaseController {
   query (request = {}, options = {}) {
     request.controller = request.controller || this.name;
 
-    return this.kuzzle.query(request, options);
+    return this._kuzzle.query(request, options);
   }
 }
 

--- a/src/controllers/base.js
+++ b/src/controllers/base.js
@@ -6,11 +6,15 @@ class BaseController {
    */
   constructor (kuzzle, name) {
     this._kuzzle = kuzzle;
-    this.name = name;
+    this._name = name;
   }
 
   get kuzzle () {
     return this._kuzzle;
+  }
+
+  get name () {
+    return this._name;
   }
 
   /**

--- a/src/controllers/bulk.js
+++ b/src/controllers/bulk.js
@@ -1,15 +1,12 @@
-class BulkController {
-  constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
+const BaseController = require('./base');
 
-  get kuzzle () {
-    return this._kuzzle;
+class BulkController extends BaseController {
+  constructor (kuzzle) {
+    super(kuzzle, 'bulk');
   }
 
   import (data, options) {
-    return this.kuzzle.query({
-      controller: 'bulk',
+    return this.query({
       action: 'import',
       body: {
         bulkData: data

--- a/src/controllers/collection.js
+++ b/src/controllers/collection.js
@@ -1,17 +1,14 @@
 const
+  BaseController = require('./base'),
   SpecificationsSearchResult = require('./searchResult/specifications');
 
-class CollectionController {
+class CollectionController extends BaseController {
 
   /**
    * @param {Kuzzle} kuzzle
    */
   constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
-
-  get kuzzle () {
-    return this._kuzzle;
+    super(kuzzle, 'collection');
   }
 
   create (index, collection, body = {}, options = {}) {
@@ -22,11 +19,10 @@ class CollectionController {
       throw new Error('Kuzzle.collection.create: collection is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
       collection,
       body,
-      controller: 'collection',
       action: 'create'
     }, options)
       .then(response => response.result);
@@ -40,10 +36,9 @@ class CollectionController {
       throw new Error('Kuzzle.collection.deleteSpecifications: collection is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
       collection,
-      controller: 'collection',
       action: 'deleteSpecifications'
     }, options)
       .then(response => response.result);
@@ -57,10 +52,9 @@ class CollectionController {
       throw new Error('Kuzzle.collection.exists: collection is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
       collection,
-      controller: 'collection',
       action: 'exists'
     }, options)
       .then(response => response.result);
@@ -74,10 +68,9 @@ class CollectionController {
       throw new Error('Kuzzle.collection.getMapping: collection is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
       collection,
-      controller: 'collection',
       action: 'getMapping'
     }, options)
       .then(response => response.result);
@@ -91,10 +84,9 @@ class CollectionController {
       throw new Error('Kuzzle.collection.getSpecifications: collection is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
       collection,
-      controller: 'collection',
       action: 'getSpecifications'
     }, options)
       .then(response => response.result);
@@ -107,7 +99,6 @@ class CollectionController {
 
     const request = {
       index,
-      controller: 'collection',
       action: 'list',
       from: options.from,
       size: options.size
@@ -115,14 +106,13 @@ class CollectionController {
     delete options.from;
     delete options.size;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
   searchSpecifications (body = {}, options = {}) {
     const request = {
       body,
-      controller: 'collection',
       action: 'searchSpecifications'
     };
     for (const opt of ['from', 'size', 'scroll']) {
@@ -130,7 +120,7 @@ class CollectionController {
       delete options[opt];
     }
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new SpecificationsSearchResult(this.kuzzle, request, options, response.result));
   }
 
@@ -142,10 +132,9 @@ class CollectionController {
       throw new Error('Kuzzle.collection.truncate: collection is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
       collection,
-      controller: 'collection',
       action: 'truncate',
       refresh: options.refresh
     }, options)
@@ -160,11 +149,10 @@ class CollectionController {
       throw new Error('Kuzzle.collection.updateMapping: collection is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
       collection,
       body,
-      controller: 'collection',
       action: 'updateMapping'
     }, options)
       .then(response => response.result);
@@ -187,9 +175,8 @@ class CollectionController {
       }
     };
 
-    return this.kuzzle.query({
+    return this.query({
       body,
-      controller: 'collection',
       action: 'updateSpecifications'
     }, options)
       .then(response => response.result[index][collection]);
@@ -212,9 +199,8 @@ class CollectionController {
       }
     };
 
-    return this.kuzzle.query({
+    return this.query({
       body,
-      controller: 'collection',
       action: 'validateSpecifications'
     }, options)
       .then(response => response.result);

--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -1,17 +1,14 @@
 const
+  BaseController = require('./base'),
   DocumentSearchResult = require('./searchResult/document');
 
-class DocumentController {
+class DocumentController extends BaseController {
 
   /**
    * @param {Kuzzle} kuzzle
    */
   constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
-
-  get kuzzle () {
-    return this._kuzzle;
+    super(kuzzle, 'document');
   }
 
   count (index, collection, body, options = {}) {
@@ -26,13 +23,12 @@ class DocumentController {
       index,
       collection,
       body,
-      controller: 'document',
       action: 'count',
       includeTrash: options.includeTrash
     };
     delete options.includeTrash;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result.count);
   }
 
@@ -52,13 +48,12 @@ class DocumentController {
       collection,
       _id,
       body: document,
-      controller: 'document',
       action: 'create',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -81,13 +76,12 @@ class DocumentController {
       collection,
       _id,
       body,
-      controller: 'document',
       action: 'createOrReplace',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -106,13 +100,12 @@ class DocumentController {
       index,
       collection,
       _id,
-      controller: 'document',
       action: 'delete',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result._id);
   }
 
@@ -128,13 +121,12 @@ class DocumentController {
       index,
       collection,
       body,
-      controller: 'document',
       action: 'deleteByQuery',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result.ids);
   }
 
@@ -153,11 +145,10 @@ class DocumentController {
       index,
       collection,
       _id,
-      controller: 'document',
       action: 'exists'
     };
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -176,13 +167,12 @@ class DocumentController {
       index,
       collection,
       _id,
-      controller: 'document',
       action: 'get',
       includeTrash: options.includeTrash
     };
     delete options.includeTrash;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -201,13 +191,12 @@ class DocumentController {
       index,
       collection,
       body: {documents},
-      controller: 'document',
       action: 'mCreate',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -226,13 +215,12 @@ class DocumentController {
       index,
       collection,
       body: {documents},
-      controller: 'document',
       action: 'mCreateOrReplace',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -251,13 +239,12 @@ class DocumentController {
       index,
       collection,
       body: {ids},
-      controller: 'document',
       action: 'mDelete',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -276,13 +263,12 @@ class DocumentController {
       index,
       collection,
       body: {ids},
-      controller: 'document',
       action: 'mGet',
       includeTrash: options.includeTrash
     };
     delete options.includeTrash;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -301,12 +287,11 @@ class DocumentController {
       index,
       collection,
       body: {documents},
-      controller: 'document',
       action: 'mReplace',
       refresh: options.refresh
     };
     delete options.refresh;
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -325,13 +310,12 @@ class DocumentController {
       index,
       collection,
       body: {documents},
-      controller: 'document',
       action: 'mUpdate',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -354,13 +338,12 @@ class DocumentController {
       collection,
       _id,
       body,
-      controller: 'document',
       action: 'replace',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -376,7 +359,6 @@ class DocumentController {
       index,
       collection,
       body,
-      controller: 'document',
       action: 'search',
     };
     for (const opt of ['from', 'size', 'scroll', 'includeTrash']) {
@@ -384,7 +366,7 @@ class DocumentController {
       delete options[opt];
     }
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new DocumentSearchResult(this.kuzzle, request, options, response.result));
   }
 
@@ -407,7 +389,6 @@ class DocumentController {
       collection,
       _id,
       body,
-      controller: 'document',
       action: 'update',
       refresh: options.refresh,
       retryOnConflict: options.retryOnConflict
@@ -415,7 +396,7 @@ class DocumentController {
     delete options.refresh;
     delete options.retryOnConflict;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -430,11 +411,10 @@ class DocumentController {
       throw new Error('Kuzzle.document.validate: body is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
       collection,
       body,
-      controller: 'document',
       action: 'validate'
     }, options)
       .then(response => response.result);

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,14 +1,12 @@
-class IndexController {
+const BaseController = require('./base');
+
+class IndexController extends BaseController {
 
   /**
    * @param {Kuzzle} kuzzle
    */
   constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
-
-  get kuzzle () {
-    return this._kuzzle;
+    super(kuzzle, 'index');
   }
 
   create (index, options) {
@@ -16,9 +14,8 @@ class IndexController {
       throw new Error('Kuzzle.index.create: index is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
-      controller: 'index',
       action : 'create'
     }, options)
       .then(response => response.result);
@@ -29,9 +26,8 @@ class IndexController {
       throw new Error('Kuzzle.index.delete: index is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
-      controller: 'index',
       action : 'delete'
     }, options)
       .then(response => response.result.acknowledged);
@@ -42,9 +38,8 @@ class IndexController {
       throw new Error('Kuzzle.index.exists: index is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
-      controller: 'index',
       action : 'exists'
     }, options)
       .then(response => response.result);
@@ -55,17 +50,15 @@ class IndexController {
       throw new Error('Kuzzle.index.getAutoRefresh: index is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
-      controller: 'index',
       action: 'getAutoRefresh'
     }, options)
       .then(response => response.result);
   }
 
   list (options) {
-    return this.kuzzle.query({
-      controller: 'index',
+    return this.query({
       action: 'list'
     }, options)
       .then(response => response.result.indexes);
@@ -76,8 +69,7 @@ class IndexController {
       throw new Error('Kuzzle.index.mDelete: indexes must be an array');
     }
 
-    return this.kuzzle.query({
-      controller: 'index',
+    return this.query({
       action: 'mDelete',
       body: {
         indexes
@@ -91,17 +83,15 @@ class IndexController {
       throw new Error('Kuzzle.index.refresh: index is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
-      controller: 'index',
       action: 'refresh'
     }, options)
       .then(response => response.result._shards);
   }
 
   refreshInternal (options) {
-    return this.kuzzle.query({
-      controller: 'index',
+    return this.query({
       action: 'refreshInternal'
     }, options)
       .then(response => response.result.acknowledged);
@@ -116,9 +106,8 @@ class IndexController {
       throw new Error('Kuzzle.index.setAutoRefresh: autoRefresh must be a boolean');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       index,
-      controller: 'index',
       action: 'setAutoRefresh',
       body: {
         autoRefresh

--- a/src/controllers/memoryStorage.js
+++ b/src/controllers/memoryStorage.js
@@ -1,3 +1,5 @@
+const BaseControler = require('./base');
+
 // Parameter mutualization
 const
   getId = {getter: true, required: ['_id']},
@@ -187,14 +189,10 @@ const
  * @param {object} kuzzle - Kuzzle instance to inherit from
  * @constructor
  */
-class MemoryStorageController {
+class MemoryStorageController extends BaseControler {
 
   constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
-
-  get kuzzle () {
-    return this._kuzzle;
+    super(kuzzle, 'ms');
   }
 }
 
@@ -206,8 +204,7 @@ for (const action of Object.keys(commands)) {
     const
       command = commands[action],
       request = {
-        action,
-        controller: 'ms'
+        action
       },
       options = {};
 
@@ -254,7 +251,7 @@ for (const action of Object.keys(commands)) {
       command.opts(request, options);
     }
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => {
         if (command.mapResults) {
           return command.mapResults(response.result);

--- a/src/controllers/realtime/index.js
+++ b/src/controllers/realtime/index.js
@@ -1,21 +1,19 @@
-const Room = require('./room');
+const
+  BaseController = require('../base'),
+  Room = require('./room');
 
 const expirationThrottleDelay = 1000;
 
-class RealTimeController {
+class RealTimeController extends BaseController {
   /**
    * @param {Kuzzle} kuzzle
    */
   constructor (kuzzle) {
-    this._kuzzle = kuzzle;
+    super(kuzzle, 'realtime');
+
     this.lastExpirationTimestamp = 0;
 
-    this.subscriptions = {
-    };
-  }
-
-  get kuzzle () {
-    return this._kuzzle;
+    this.subscriptions = {};
   }
 
   count (roomId, options = {}) {
@@ -23,8 +21,7 @@ class RealTimeController {
       throw new Error('Kuzzle.realtime.count: roomId is required');
     }
 
-    return this.kuzzle.query({
-      controller: 'realtime',
+    return this.query({
       action: 'count',
       body: {roomId}
     }, options)
@@ -46,11 +43,10 @@ class RealTimeController {
       index,
       collection,
       body: message,
-      controller: 'realtime',
       action: 'publish'
     };
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result.published);
   }
 
@@ -96,8 +92,7 @@ class RealTimeController {
     }
     delete this.subscriptions[roomId];
 
-    return this.kuzzle.query({
-      controller: 'realtime',
+    return this.query({
       action: 'unsubscribe',
       body: {roomId}
     }, options)

--- a/src/controllers/security/index.js
+++ b/src/controllers/security/index.js
@@ -1,4 +1,5 @@
 const
+  BaseController = require('../base'),
   Role = require('./role'),
   RoleSearchResult = require('../searchResult/role'),
   Profile = require('./profile'),
@@ -6,16 +7,12 @@ const
   User = require('./user'),
   UserSearchResult = require('../searchResult/user');
 
-class SecurityController {
+class SecurityController extends BaseController {
   /**
    * @param {Kuzzle} kuzzle
    */
   constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
-
-  get kuzzle () {
-    return this._kuzzle;
+    super(kuzzle, 'security');
   }
 
   createCredentials (strategy, _id, body, options = {}) {
@@ -29,11 +26,10 @@ class SecurityController {
       throw new Error('Kuzzle.security.createCredentials: body is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
       strategy,
       body,
-      controller: 'security',
       action: 'createCredentials'
     }, options)
       .then(response => response.result);
@@ -50,13 +46,12 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'createFirstAdmin',
       reset: options.reset
     };
     delete options.reset;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
@@ -71,13 +66,12 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'createOrReplaceProfile',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
   }
 
@@ -92,13 +86,12 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'createOrReplaceRole',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
@@ -113,13 +106,12 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'createProfile',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
   }
 
@@ -134,13 +126,12 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'createRestrictedUser',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
@@ -155,13 +146,12 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'createRole',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
@@ -182,13 +172,12 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'createUser',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
@@ -200,10 +189,9 @@ class SecurityController {
       throw new Error('Kuzzle.security.deleteCredentials: strategy is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       strategy,
       _id,
-      controller: 'security',
       action: 'deleteCredentials'
     }, options)
       .then(response => response.result);
@@ -214,9 +202,8 @@ class SecurityController {
       throw new Error('Kuzzle.security.deleteProfile: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
-      controller: 'security',
       action: 'deleteProfile'
     }, options)
       .then(response => response.result);
@@ -227,9 +214,8 @@ class SecurityController {
       throw new Error('Kuzzle.security.deleteRole: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
-      controller: 'security',
       action: 'deleteRole'
     }, options)
       .then(response => response.result);
@@ -240,17 +226,15 @@ class SecurityController {
       throw new Error('Kuzzle.security.deleteUser: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
-      controller: 'security',
       action: 'deleteUser'
     }, options)
       .then(response => response.result);
   }
 
   getAllCredentialFields (options = {}) {
-    return this.kuzzle.query({
-      controller: 'security',
+    return this.query({
       action: 'getAllCredentialFields'
     }, options)
       .then(response => response.result);
@@ -261,9 +245,8 @@ class SecurityController {
       throw new Error('Kuzzle.security.getCredentialFields: strategy is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       strategy,
-      controller: 'security',
       action: 'getCredentialFields'
     }, options)
       .then(response => response.result);
@@ -277,10 +260,9 @@ class SecurityController {
       throw new Error('Kuzzle.security.getCredentials: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       strategy,
       _id,
-      controller: 'security',
       action: 'getCredentials'
     }, options)
       .then(response => response.result);
@@ -294,10 +276,9 @@ class SecurityController {
       throw new Error('Kuzzle.security.getCredentialsById: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       strategy,
       _id,
-      controller: 'security',
       action: 'getCredentialsById'
     }, options)
       .then(response => response.result);
@@ -308,17 +289,15 @@ class SecurityController {
       throw new Error('Kuzzle.security.getProfile: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
-      controller: 'security',
       action: 'getProfile'
     }, options)
       .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
   }
 
   getProfileMapping (options = {}) {
-    return this.kuzzle.query({
-      controller: 'security',
+    return this.query({
       action: 'getProfileMapping'
     }, options)
       .then(response => response.result);
@@ -329,9 +308,8 @@ class SecurityController {
       throw new Error('Kuzzle.security.getProfileRights: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
-      controller: 'security',
       action: 'getProfileRights'
     }, options)
       .then(response => response.result.hits);
@@ -342,17 +320,15 @@ class SecurityController {
       throw new Error('Kuzzle.security.getRole: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
-      controller: 'security',
       action: 'getRole'
     }, options)
       .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
   getRoleMapping (options = {}) {
-    return this.kuzzle.query({
-      controller: 'security',
+    return this.query({
       action: 'getRoleMapping'
     }, options)
       .then(response => response.result);
@@ -363,17 +339,15 @@ class SecurityController {
       throw new Error('Kuzzle.security.getUser: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
-      controller: 'security',
       action: 'getUser'
     }, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   getUserMapping (options = {}) {
-    return this.kuzzle.query({
-      controller: 'security',
+    return this.query({
       action: 'getUserMapping'
     }, options)
       .then(response => response.result);
@@ -384,9 +358,8 @@ class SecurityController {
       throw new Error('Kuzzle.security.getUserRights: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
-      controller: 'security',
       action: 'getUserRights'
     }, options)
       .then(response => response.result.hits);
@@ -400,10 +373,9 @@ class SecurityController {
       throw new Error('Kuzzle.security.hasCredentials: _id is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       strategy,
       _id,
-      controller: 'security',
       action: 'hasCredentials'
     }, options)
       .then(response => response.result);
@@ -415,14 +387,13 @@ class SecurityController {
     }
 
     const request = {
-      controller: 'security',
       action: 'mDeleteProfiles',
       body: {ids},
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -432,14 +403,13 @@ class SecurityController {
     }
 
     const request = {
-      controller: 'security',
       action: 'mDeleteRoles',
       body: {ids},
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -449,14 +419,13 @@ class SecurityController {
     }
 
     const request = {
-      controller: 'security',
       action: 'mDeleteUsers',
       body: {ids},
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -465,8 +434,7 @@ class SecurityController {
       throw new Error('Kuzzle.security.mGetProfiles: ids must be an array');
     }
 
-    return this.kuzzle.query({
-      controller: 'security',
+    return this.query({
       action: 'mGetProfiles',
       body: {ids}
     }, options)
@@ -478,8 +446,7 @@ class SecurityController {
       throw new Error('Kuzzle.security.mGetRoles: ids must be an array');
     }
 
-    return this.kuzzle.query({
-      controller: 'security',
+    return this.query({
       action: 'mGetRoles',
       body: {ids}
     }, options)
@@ -497,20 +464,18 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'replaceUser',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   searchProfiles (body, options= {}) {
     const request = {
       body,
-      controller: 'security',
       action: 'searchProfiles'
     };
     for (const opt of ['from', 'size', 'scroll']) {
@@ -518,14 +483,13 @@ class SecurityController {
       delete options[opt];
     }
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new ProfileSearchResult(this.kuzzle, request, options, response.result));
   }
 
   searchRoles (body, options = {}) {
     const request = {
       body,
-      controller: 'security',
       action: 'searchRoles'
     };
     for (const opt of ['from', 'size']) {
@@ -533,14 +497,13 @@ class SecurityController {
       delete options[opt];
     }
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new RoleSearchResult(this.kuzzle, request, options, response.result));
   }
 
   searchUsers (body, options = {}) {
     const request = {
       body,
-      controller: 'security',
       action: 'searchUsers'
     };
     for (const opt of ['from', 'size', 'scroll']) {
@@ -548,7 +511,7 @@ class SecurityController {
       delete options[opt];
     }
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new UserSearchResult(this.kuzzle, request, options, response.result));
   }
 
@@ -563,11 +526,10 @@ class SecurityController {
       throw new Error('Kuzzle.security.updateCredentials: body is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       strategy,
       _id,
       body,
-      controller: 'security',
       action: 'updateCredentials'
     }, options)
       .then(response => response.result);
@@ -584,20 +546,18 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'updateProfile',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
   }
 
   updateProfileMapping (body, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       body,
-      controller: 'security',
       action: 'updateProfileMapping'
     }, options)
       .then(response => response.result);
@@ -614,20 +574,18 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'updateRole',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
   updateRoleMapping (body, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       body,
-      controller: 'security',
       action: 'updateRoleMapping'
     }, options)
       .then(response => response.result);
@@ -644,20 +602,18 @@ class SecurityController {
     const request = {
       _id,
       body,
-      controller: 'security',
       action: 'updateUser',
       refresh: options.refresh
     };
     delete options.refresh;
 
-    return this.kuzzle.query(request, options)
+    return this.query(request, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source, response.result._meta));
   }
 
   updateUserMapping (body, options = {}) {
-    return this.kuzzle.query({
+    return this.query({
       body,
-      controller: 'security',
       action: 'updateUserMapping'
     }, options)
       .then(response => response.result);
@@ -674,11 +630,10 @@ class SecurityController {
       throw new Error('Kuzzle.security.validateCredentials: body is required');
     }
 
-    return this.kuzzle.query({
+    return this.query({
       _id,
       strategy,
       body,
-      controller: 'security',
       action: 'validateCredentials'
     }, options)
       .then(response => response.result);

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -1,18 +1,16 @@
+const BaseControler = require('./base');
+
 /**
  * @class ServerController
  * @property {Kuzzle} kuzzle - The Kuzzle SDK Instance
  */
-class ServerController {
+class ServerController extends BaseControler {
 
   /**
    * @param {Kuzzle} kuzzle - The Kuzzle SDK Instance
    */
   constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
-
-  get kuzzle () {
-    return this._kuzzle;
+    super(kuzzle, 'server');
   }
 
   /**
@@ -22,8 +20,7 @@ class ServerController {
    * @returns {Promise<Boolean>}
    */
   adminExists (options) {
-    return this.kuzzle.query({
-      controller: 'server',
+    return this.query({
       action: 'adminExists'
     }, options)
       .then(response => {
@@ -45,8 +42,7 @@ class ServerController {
    * @returns {Promise<Object>}
    */
   getAllStats (options) {
-    return this.kuzzle.query({
-      controller: 'server',
+    return this.query({
       action: 'getAllStats'
     }, options)
       .then(response => response.result);
@@ -59,8 +55,7 @@ class ServerController {
    * @returns {Promise<Object>}
    */
   getConfig (options) {
-    return this.kuzzle.query({
-      controller: 'server',
+    return this.query({
       action: 'getConfig'
     }, options)
       .then(response => response.result);
@@ -73,8 +68,7 @@ class ServerController {
    * @returns {Promise<Object>}
    */
   getLastStats (options) {
-    return this.kuzzle.query({
-      controller: 'server',
+    return this.query({
       action: 'getLastStats'
     }, options)
       .then(response => response.result);
@@ -89,8 +83,7 @@ class ServerController {
    * @returns {Promise<Object>}
    */
   getStats(startTime, stopTime, options) {
-    return this.kuzzle.query({
-      controller: 'server',
+    return this.query({
       action: 'getStats',
       startTime,
       stopTime
@@ -105,8 +98,7 @@ class ServerController {
    * @returns {Promise<Object>}
    */
   info (options) {
-    return this.kuzzle.query({
-      controller: 'server',
+    return this.query({
       action: 'info'
     }, options)
       .then(response => response.result);
@@ -119,8 +111,7 @@ class ServerController {
    * @returns {Promise<Number>}
    */
   now (options) {
-    return this.kuzzle.query({
-      controller: 'server',
+    return this.query({
       action: 'now'
     }, options)
       .then(response => {

--- a/test/controllers/server.test.js
+++ b/test/controllers/server.test.js
@@ -25,7 +25,7 @@ describe('Server Controller', () => {
       return kuzzle.server.adminExists()
         .then(res => {
           should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectedQuery, undefined);
+          should(kuzzle.query).be.calledWith(expectedQuery, {});
           should(res).be.a.Boolean().and.be.true();
 
           kuzzle.query.resetHistory();
@@ -106,7 +106,7 @@ describe('Server Controller', () => {
       return kuzzle.server.getAllStats()
         .then(res => {
           should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectedQuery, undefined);
+          should(kuzzle.query).be.calledWith(expectedQuery, {});
           should(res).match(result);
         })
         .then(() => {
@@ -159,7 +159,7 @@ describe('Server Controller', () => {
       return kuzzle.server.getConfig()
         .then(res => {
           should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectedQuery, undefined);
+          should(kuzzle.query).be.calledWith(expectedQuery, {});
           should(res).match(result);
         })
         .then(() => {
@@ -219,7 +219,7 @@ describe('Server Controller', () => {
       return kuzzle.server.getLastStats()
         .then(res => {
           should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectedQuery, undefined);
+          should(kuzzle.query).be.calledWith(expectedQuery, {});
           should(res).match(result);
         })
         .then(() => {
@@ -280,7 +280,7 @@ describe('Server Controller', () => {
       return kuzzle.server.getStats(1234, 9876)
         .then(res => {
           should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectedQuery, undefined);
+          should(kuzzle.query).be.calledWith(expectedQuery, {});
           should(res).match(result);
         })
         .then(() => {
@@ -300,7 +300,7 @@ describe('Server Controller', () => {
           should(kuzzle.query).be.calledOnce();
           should(kuzzle.query).be.calledWith(
             {controller: 'server', action: 'getStats', startTime: 1234, stopTime: null},
-            undefined
+            {}
           );
           should(res).match(result);
         })
@@ -312,7 +312,7 @@ describe('Server Controller', () => {
           should(kuzzle.query).be.calledOnce();
           should(kuzzle.query).be.calledWith(
             {controller: 'server', action: 'getStats', startTime: null, stopTime: 9876},
-            undefined
+            {}
           );
           should(res).match(result);
         })
@@ -324,7 +324,7 @@ describe('Server Controller', () => {
           should(kuzzle.query).be.calledOnce();
           should(kuzzle.query).be.calledWith(
             {controller: 'server', action: 'getStats', startTime: null, stopTime: null},
-            undefined
+            {}
           );
           should(res).match(result);
         });
@@ -379,7 +379,7 @@ describe('Server Controller', () => {
       return kuzzle.server.info()
         .then(res => {
           should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectedQuery, undefined);
+          should(kuzzle.query).be.calledWith(expectedQuery, {});
           should(res).match(result);
         })
         .then(() => {
@@ -413,7 +413,7 @@ describe('Server Controller', () => {
       return kuzzle.server.now()
         .then(res => {
           should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectedQuery, undefined);
+          should(kuzzle.query).be.calledWith(expectedQuery, {});
           should(res).be.exactly(12345);
         })
         .then(() => {

--- a/test/kuzzle/useController.test.js
+++ b/test/kuzzle/useController.test.js
@@ -23,7 +23,7 @@ class CustomController extends BaseController {
   }
 }
 
-class WrongController {
+class NotInheritingController {
   constructor (kuzzle) {
     this._kuzzle = kuzzle;
   }
@@ -32,6 +32,12 @@ class WrongController {
 class UnamedController extends BaseController {
   constructor (kuzzle) {
     super(kuzzle);
+  }
+}
+
+class WrongConstructorController extends BaseController {
+  constructor (kuzzle) {
+    super({}, 'wrongConstructor', kuzzle);
   }
 }
 
@@ -78,7 +84,7 @@ describe('Kuzzle custom controllers management', () => {
 
     it('should throw if the controller does not inherits from BaseController', () => {
       should(() => {
-        kuzzle.useController(WrongController, 'wrong');
+        kuzzle.useController(NotInheritingController, 'wrong');
       }).throw('Controllers must inherits from the BaseController class.');
     });
 
@@ -86,6 +92,12 @@ describe('Kuzzle custom controllers management', () => {
       should(() => {
         kuzzle.useController(UnamedController, 'unamed');
       }).throw('Controllers must have a name.');
+    });
+
+    it('should throw if the controller does not call the parent with the Kuzzle sdk instance', () => {
+      should(() => {
+        kuzzle.useController(WrongConstructorController, 'unamed');
+      }).throw('You must pass the Kuzzle SDK instance to the parent constructor.');
     });
 
     it('should throw if the controller does not have an accessor', () => {


### PR DESCRIPTION
## What does this PR do?

*I'm not sure if this is a new feature or an enhancement* 

This PR intend to unify the way we add/use controllers with the SDK. In this way we can have the same API when using our core controllers (`document`, `collection`, etc.) and custom controllers made by users.  

All existing controllers are now inheriting from the `BaseController` class and they are added to the SDK with `Kuzzle.useController` instead of been manually instantiated.

Example of custom controller
```
class TaxiController extends BaseController {
  constructor (kuzzle) {
    super(kuzzle, 'my-plugin/taxi');
  }

  startDuty (driver) {
    return this.query({ driver, action: 'startDuty' });
  }
}

kuzzle.useController(TaxiController, 'taxi');

kuzzle.taxi.startDuty('Martin');
```

I know this look like a breaking change but since we never documented this feature by now it is not really one.

Documentation https://github.com/kuzzleio/documentation/pull/284

### How should this be manually tested?

  - Step 1 : Run unit tests
