### PR TITLE
Add default values for from/size to document:search

### DIFF
--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -361,9 +361,15 @@ class DocumentController extends BaseController {
       body,
       action: 'search',
     };
+
     for (const opt of ['from', 'size', 'scroll', 'includeTrash']) {
       request[opt] = options[opt];
       delete options[opt];
+    }
+
+    request.size = request.size || 10;
+    if (!request.scroll && !request.body.sort && !request.from) {
+      request.from = 0;
     }
 
     return this.query(request, options)

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -1113,7 +1113,7 @@ describe('Document Controller', () => {
           const request = kuzzle.document.query.getCall(0).args[0];
           should(request.from).be.eql(0);
           should(request.size).be.eql(10);          
-        })
+        });
     });
 
     it('should not set default value for from if scroll or sort are specified', () => {
@@ -1130,7 +1130,7 @@ describe('Document Controller', () => {
           const request = kuzzle.document.query.getCall(0).args[0];
           should(request.from).be.undefined();         
 
-          return kuzzle.document.search('index', 'collection', { sort: { some: 'thing' }})
+          return kuzzle.document.search('index', 'collection', { sort: { some: 'thing' }});
         })
         .then(() => {
           should(kuzzle.document.query).be.calledTwice();

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -1014,8 +1014,8 @@ describe('Document Controller', () => {
               index: 'index',
               collection: 'collection',
               body: {foo: 'bar'},
-              from: undefined,
-              size: undefined,
+              from: 0,
+              size: 10,
               scroll: undefined,
               includeTrash: undefined
             }, options);
@@ -1050,8 +1050,8 @@ describe('Document Controller', () => {
               index: 'index',
               collection: 'collection',
               body: {foo: 'bar'},
-              from: undefined,
-              size: undefined,
+              from: 0,
+              size: 10,
               scroll: undefined,
               includeTrash: true
             }, {});
@@ -1096,6 +1096,47 @@ describe('Document Controller', () => {
           should(res._response).be.equal(result);
           should(res.fetched).be.equal(2);
           should(res.total).be.equal(3);
+        });
+    });
+
+    it('should set default value for from and size', () => {
+      const result = {
+        hits: [],
+        total: 0
+      };
+      kuzzle.document.query = sinon.stub().resolves({result});
+
+      return kuzzle.document.search('index', 'collection', {})
+        .then(() => {
+          should(kuzzle.document.query).be.calledOnce();
+
+          const request = kuzzle.document.query.getCall(0).args[0];
+          should(request.from).be.eql(0);
+          should(request.size).be.eql(10);          
+        })
+    });
+
+    it('should not set default value for from if scroll or sort are specified', () => {
+      const result = {
+        hits: [],
+        total: 0
+      };
+      kuzzle.document.query = sinon.stub().resolves({result});
+
+      return kuzzle.document.search('index', 'collection', {}, { scroll: '42s' })
+        .then(() => {
+          should(kuzzle.document.query).be.calledOnce();
+
+          const request = kuzzle.document.query.getCall(0).args[0];
+          should(request.from).be.undefined();         
+
+          return kuzzle.document.search('index', 'collection', { sort: { some: 'thing' }})
+        })
+        .then(() => {
+          should(kuzzle.document.query).be.calledTwice();
+
+          const request = kuzzle.document.query.getCall(1).args[0];
+          should(request.from).be.undefined();         
         });
     });
   });


### PR DESCRIPTION
## What does this PR do?

Explicitly declare default value for `from` and `size` in the request as specified in the documentation.  
We have to be explicit otherwise the `SearchResult` returned can not be used as usual with the `next()` method.

```
const result = await this.sdk.document.search(index, collection, { query: 'some query', sort: 'some sort'})
await result.next()
// Unable to retrieve next results from search: missing scrollId, from/sort, or from/size params\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.
```
