### PR TITLE
Update updateSpecification & validateSpecification to the latest API specs

### DIFF
--- a/src/controllers/collection.js
+++ b/src/controllers/collection.js
@@ -169,15 +169,11 @@ class CollectionController extends BaseController {
       throw new Error('Kuzzle.collection.updateSpecifications: specifications are required');
     }
 
-    const body = {
-      [index]: {
-        [collection]: specifications
-      }
-    };
-
     return this.query({
-      body,
-      action: 'updateSpecifications'
+      action: 'updateSpecifications',
+      index,
+      collection,
+      body: specifications
     }, options)
       .then(response => response.result[index][collection]);
   }
@@ -193,15 +189,11 @@ class CollectionController extends BaseController {
       throw new Error('Kuzzle.collection.updateSpecifications: specifications are required');
     }
 
-    const body = {
-      [index]: {
-        [collection]: specifications
-      }
-    };
-
     return this.query({
-      body,
-      action: 'validateSpecifications'
+      action: 'validateSpecifications',
+      index,
+      collection,
+      body: specifications
     }, options)
       .then(response => response.result);
   }


### PR DESCRIPTION
## What does this PR do?

- update query updateSpecification & validateSpecification because will be deprecated after https://github.com/kuzzleio/kuzzle/pull/1300

### How should this be manually tested?

`npm test` but this will work only with the right Kuzzle