### PR TITLE
Fix large document search using scroll

### DIFF
--- a/src/controllers/searchResult/base.js
+++ b/src/controllers/searchResult/base.js
@@ -32,6 +32,7 @@ class SearchResultBase {
       return this._kuzzle.query({
         controller: this._request.controller,
         action: this._scrollAction,
+        scroll: this._request.scroll,
         scrollId: this._response.scrollId
       }, this._options)
         .then(response => this._buildNextSearchResult(response));

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -130,6 +130,7 @@ describe('DocumentSearchResult', () => {
               .be.calledWith({
                 controller: 'document',
                 action: 'scroll',
+                scroll: '1m',
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);

--- a/test/controllers/searchResult/profile.test.js
+++ b/test/controllers/searchResult/profile.test.js
@@ -133,6 +133,7 @@ describe('ProfileSearchResult', () => {
               .be.calledWith({
                 controller: 'security',
                 action: 'scrollProfiles',
+                scroll: '1m',
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);

--- a/test/controllers/searchResult/specifications.test.js
+++ b/test/controllers/searchResult/specifications.test.js
@@ -123,6 +123,7 @@ describe('SpecificationsSearchResult', () => {
               .be.calledWith({
                 controller: 'collection',
                 action: 'scrollSpecifications',
+                scroll: '1m',
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);

--- a/test/controllers/searchResult/user.test.js
+++ b/test/controllers/searchResult/user.test.js
@@ -135,6 +135,7 @@ describe('UserSearchResult', () => {
               .be.calledWith({
                 controller: 'security',
                 action: 'scrollUsers',
+                scroll: '1m',
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);


### PR DESCRIPTION
## What does this PR do?
According to ES documentation, `scroll` parameter should be sent again with `_search/scroll` api call, allowing us to choose smallest timeout for scroll to live on.
