### PR TITLE
Make createUser id parameter optional

### DIFF
--- a/src/controllers/security/index.js
+++ b/src/controllers/security/index.js
@@ -156,9 +156,6 @@ class SecurityController extends BaseController {
   }
 
   createUser (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.createUser: _id is required');
-    }
     if (!body) {
       throw new Error('Kuzzle.security.createUser: body is required');
     }

--- a/test/controllers/security.test.js
+++ b/test/controllers/security.test.js
@@ -429,18 +429,6 @@ describe('Security Controller', () => {
   });
 
   describe('createUser', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      const body = {
-        content: {foo: 'bar'},
-        credentials: {
-          strategy: {foo: 'bar'}
-        }
-      };
-      should(function () {
-        kuzzle.security.createUser(undefined, body, options);
-      }).throw('Kuzzle.security.createUser: _id is required');
-    });
-
     it('should throw an error if the "body" argument is not provided', () => {
       should(function () {
         kuzzle.security.createUser('userId', undefined, options);


### PR DESCRIPTION
## What does this PR do?

Make createUser id parametre optional as it is in the API.

### How should this be manually tested?

```js
kuzzle.security.createUser(null, {
    content: {
      profileIds: ['default']
    },
    credentials: {
      local: {
        username: 'auto',
        password: 'auto'
      }
    }
  });
```
It should create a user with a generated id.