### PR TITLE
Fix http protocol unresolved promise on connection error

### DIFF
--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -173,7 +173,7 @@ class HttpWrapper extends KuzzleAbstractProtocol {
 
       xhr.onreadystatechange = () => {
         if (xhr.readyState === 4 && xhr.status === 0) {
-          reject(new Error('Cannot send the request. Is the host online?'));
+          reject(new Error('Cannot connect to host. Is the host online?'));
         }
       };
 

--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -171,6 +171,12 @@ class HttpWrapper extends KuzzleAbstractProtocol {
         xhr = new XMLHttpRequest(),
         url = `${this.protocol}://${this.host}:${this.port}${path}`;
 
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState === 4 && xhr.status === 0) {
+          reject(new Error('Cannot send the request. Is the host online?'));
+        }
+      };
+
       xhr.open(method, url);
 
       for (const header of Object.keys(payload.headers || {})) {

--- a/test/protocol/http.test.js
+++ b/test/protocol/http.test.js
@@ -465,7 +465,8 @@ describe('HTTP networking module', () => {
       xhrStub = {
         open: sinon.stub(),
         send: sinon.stub(),
-        setRequestHeader: sinon.stub()
+        setRequestHeader: sinon.stub(),
+        onreadystatechange: sinon.stub()
       };
       // eslint-disable-next-line no-native-reassign, no-global-assign
       XMLHttpRequest = function() {
@@ -533,6 +534,16 @@ describe('HTTP networking module', () => {
           should(res.status).be.exactly(200);
           should(res.result).be.exactly('Kuzzle Result');
         });
+    });
+
+    it.only('should reject if the xhr ready state is done and the status is 0', () => {
+      xhrStub.readyState = 4;
+      xhrStub.status = 0;
+
+      setTimeout(() => xhrStub.onreadystatechange(), 20);
+
+      return should(protocol._sendHttpRequest('VERB', '/foo/bar', { body: 'foobar' }))
+        .be.rejectedWith({ message: 'Cannot send the request. Is the host online?' });
     });
   });
 

--- a/test/protocol/http.test.js
+++ b/test/protocol/http.test.js
@@ -536,14 +536,14 @@ describe('HTTP networking module', () => {
         });
     });
 
-    it.only('should reject if the xhr ready state is done and the status is 0', () => {
+    it('should reject if the xhr ready state is done and the status is 0', () => {
       xhrStub.readyState = 4;
       xhrStub.status = 0;
 
       setTimeout(() => xhrStub.onreadystatechange(), 20);
 
       return should(protocol._sendHttpRequest('VERB', '/foo/bar', { body: 'foobar' }))
-        .be.rejectedWith({ message: 'Cannot send the request. Is the host online?' });
+        .be.rejectedWith({ message: 'Cannot connect to host. Is the host online?' });
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

When the `XmlHttpRequest` fail, the associated promise is never resolved nor rejected.  
It appear that the `XmlHttpRequest` fail in another thread so the `try ... catch` block fail to catch the associated error.  

This PR add a listener on `onreadystatechange` to reject the promise when the `XmlHttpRequest` is `done` and the status is `fail` .

Fix https://github.com/kuzzleio/sdk-javascript/issues/418

### How should this be manually tested?

  - Step 1 : Build the SDK `npm run build`
  - Step 2 : Create the following webpage at the sdk repo root:
```
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <title>Kuzzle SDK Embedded</title>
    <script type="text/javascript" src="dist/kuzzle.js"></script>
  </head>
  <body>
    <button id="start" onclick="start()">Start</button>
    <script type="text/javascript">
      async function start() {
        window.kuzzle = new KuzzleSDK.Kuzzle(new KuzzleSDK.Http('localhost', { port: 7512}))
        window.kuzzle.on('networkError', () => console.log('Catched by listener'))

        try {
          await window.kuzzle.connect()
        } catch (error) {
          console.log("Catched by try ... catch")
          console.log(error)
        }
      }

    </script>
  </body>
</html>
```
  - Step 3 :  Open the file in your browser and then click "start"
  - Step 4 : You should see the following messages
![image](https://user-images.githubusercontent.com/4447392/61137600-1556ca00-a4c6-11e9-9196-bfc62592e7f3.png)
