### PR TITLE
Fix bug when decoding JWT in browser

### DIFF
--- a/src/core/Jwt.js
+++ b/src/core/Jwt.js
@@ -1,11 +1,15 @@
 'use strict';
 
+// used for unit tests
+const browserAtob = base64 => atob(base64);
+const bufferAvailable = () => typeof Buffer !== 'undefined';
+
 const decodeBase64 = base64 => {
-  if (typeof Buffer !== 'undefined') {
+  if (bufferAvailable()) {
     return Buffer.from(base64, 'base64').toString();
   }
 
-  return atob(base64);
+  return browserAtob(base64);
 };
 
 class Jwt {

--- a/src/core/Jwt.js
+++ b/src/core/Jwt.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const decodeBase64 = base64 => {
-  if (Buffer) {
+  if (typeof Buffer !== 'undefined') {
     return Buffer.from(base64, 'base64').toString();
-  } 
+  }
 
   return atob(base64);
 };
@@ -35,19 +35,19 @@ class Jwt {
   }
 
   _decode () {
-    const [, payloadRaw, ] = this._encodedJwt.split('.');
+    const payloadRaw = this._encodedJwt.split('.')[1];
 
     if (!payloadRaw) {
       throw new Error('Invalid JWT format');
     }
-    
+
     let payload;
     try {
       payload = JSON.parse(decodeBase64(payloadRaw));
     } catch (error) {
       throw new Error('Invalid JSON payload for JWT');
     }
-    
+
     this._userId = payload._id;
     this._expiresAt = payload.exp;
   }


### PR DESCRIPTION
## What does this PR do?

Since the SDK is available for Node.js and for browsers, the decoding of the JWT from base64 is done either with `Buffer.from(jwt, 'base64')` for Node.js or `atob(base64)` for browsers.  
The check to know the runtime was `if (Buffer)`, and since this class is undefined in the browsers, this line throw an exception who is catched by the `JSON.parse` `try...catch`.  

This PR fix the check to infer the runtime with `if (typeof Buffer !== 'undefined')` instead.

Fix #407 

### How should this be manually tested?

  - Step 1 : Create an this HTML file at the repository root and open it in your browser:
```
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <title>Kuzzle SDK Embedded</title>
    <script type="text/javascript" src="dist/kuzzle.js"></script>
  </head>
  <body>
    <button id="start" onclick="start()">Start</button>
    <script type="text/javascript">
      async function start() {
        window.kuzzle = new KuzzleSDK.Kuzzle(new KuzzleSDK.Http('localhost', { port: 7512}))
        window.kuzzle.on('networkError', () => console.log('Catched by listener'))

        try {
          await window.kuzzle.connect()

          const jwt = await window.kuzzle.auth.login('local', { username: 'admin', password: 'admin' })
          console.log(jwt)
        } catch (error) {
          console.log("Catched by try ... catch")
          console.log(error)
        }
      }

    </script>
  </body>
</html>
```
