### PR TITLE
Emit queryError event on malformed request

### DIFF
--- a/doc/6/essentials/events/index.md
+++ b/doc/6/essentials/events/index.md
@@ -86,7 +86,7 @@ Triggered whenever Kuzzle responds with an error
 **Callback arguments:**
 
 `@param {KuzzleError} error - Error details`
-`@param {object} request - Request that causing an error`
+`@param {object} request - Request that caused the error`
 
 ## reconnected
 

--- a/doc/6/essentials/events/index.md
+++ b/doc/6/essentials/events/index.md
@@ -85,12 +85,8 @@ Triggered whenever Kuzzle responds with an error
 
 **Callback arguments:**
 
-`@param {object} data`
-
-| Property  | Type              | Description                   |
-| --------- | ----------------- | ----------------------------- |
-| `request` | <pre>object</pre> | Request that causing an error |
-| `error`   | <pre>Error</pre>  | Error details                 |
+`@param {KuzzleError} error - Error details`
+`@param {object} request - Request that causing an error`
 
 ## reconnected
 

--- a/src/protocols/websocket.js
+++ b/src/protocols/websocket.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const
+  KuzzleError = require('../KuzzleError'),
   RTWrapper = require('./abstract/realtime');
 
 class WSNode extends RTWrapper {
@@ -108,8 +109,11 @@ class WSNode extends RTWrapper {
           this.emit(data.room, data);
         }
         else {
+          // @deprecated
           this.emit('discarded', data);
-          this.emit('discardedResponse', data);
+
+          const error = new KuzzleError(data.error);
+          this.emit('queryError', error, data);
         }
       };
 

--- a/src/protocols/websocket.js
+++ b/src/protocols/websocket.js
@@ -109,6 +109,7 @@ class WSNode extends RTWrapper {
         }
         else {
           this.emit('discarded', data);
+          this.emit('discardedResponse', data);
         }
       };
 

--- a/test/protocol/websocket.test.js
+++ b/test/protocol/websocket.test.js
@@ -247,9 +247,12 @@ describe('WebSocket networking module', () => {
   });
 
   it('should send the message on room "discarded" if no room specified', () => {
-    const cb = sinon.stub();
+    const
+      cb = sinon.stub(),
+      cb2 = sinon.stub();
 
     websocket.on('discarded', cb);
+    websocket.on('discardedResponse', cb2);
     websocket.connect();
 
     const payload = {};
@@ -258,6 +261,8 @@ describe('WebSocket networking module', () => {
     clock.tick(10);
     should(cb).be.calledOnce();
     should(cb.alwaysCalledWithMatch(payload)).be.true();
+    should(cb2).be.calledOnce();
+    should(cb2.alwaysCalledWithMatch(payload)).be.true();
   });
 
   it('should be able to unregister a callback on an event', () => {


### PR DESCRIPTION
## What does this PR do?

Emit a `queryError` when receiving a response from a malformed request

Fix #357
