### PR TITLE
Prevent pending request leak when disconnect the SDK

### DIFF
--- a/doc/6/core-classes/kuzzle/disconnect/index.md
+++ b/doc/6/core-classes/kuzzle/disconnect/index.md
@@ -9,7 +9,9 @@ description: Disconnect the SDK
 
 Closes the current connection to Kuzzle.
 The SDK then enters the `offline` state.
-A call to `disconnect()` will not trigger a `disconnected` event. This event is only triggered on unexpected disconnection.
+A call to `disconnect()` will not trigger a `disconnected` event. This event is only triggered on unexpected disconnection.  
+
+If there are still pending requests during the `disconnect` call, a `discarded` event will be issued for each of them.  
 
 ## Arguments
 

--- a/src/protocols/abstract/common.js
+++ b/src/protocols/abstract/common.js
@@ -23,8 +23,6 @@ class AbstractWrapper extends KuzzleEventEmitter {
         this[opt] = options[opt];
       }
     });
-
-    this.on('disconnected', () => this.clear());
   }
 
   get host () {
@@ -68,6 +66,8 @@ class AbstractWrapper extends KuzzleEventEmitter {
    * Called when the client's connection is established
    */
   clientConnected (state, wasConnected) {
+    this.on('disconnected', () => this.clear());
+
     this.state = state || 'ready';
     this.emit(wasConnected && 'reconnect' || 'connect');
   }

--- a/src/protocols/abstract/common.js
+++ b/src/protocols/abstract/common.js
@@ -5,20 +5,15 @@ const
   uuidv4 = require('../../uuidv4'),
   KuzzleEventEmitter = require('../../eventEmitter');
 
-// read-only properties
-let
-  _host,
-  _port,
-  _ssl;
-
 class AbstractWrapper extends KuzzleEventEmitter {
 
   constructor (host, options = {}) {
     super();
 
-    _host = host;
-    _port = typeof options.port === 'number' ? options.port : 7512;
-    _ssl = typeof options.sslConnection === 'boolean' ? options.sslConnection : false;
+    this._pendingRequests = new Map();
+    this._host = host;
+    this._port = typeof options.port === 'number' ? options.port : 7512;
+    this._ssl = typeof options.sslConnection === 'boolean' ? options.sslConnection : false;
 
     this.id = uuidv4();
     this.state = 'offline';
@@ -44,6 +39,10 @@ class AbstractWrapper extends KuzzleEventEmitter {
 
   get connected () {
     return this.state === 'online';
+  }
+
+  get pendingRequests () {
+    return this._pendingRequests;
   }
 
   /**
@@ -76,6 +75,7 @@ class AbstractWrapper extends KuzzleEventEmitter {
    */
   close () {
     this.state = 'offline';
+    this.clear();
   }
 
   query (request) {
@@ -85,8 +85,12 @@ class AbstractWrapper extends KuzzleEventEmitter {
 Discarded request: ${JSON.stringify(request)}`));
     }
 
+    this._pendingRequests.set(request.requestId, request);
+
     return new Promise((resolve, reject) => {
       this.once(request.requestId, response => {
+        this._pendingRequests.delete(request.requestId);
+
         if (response.error) {
           const error = new KuzzleError(response.error);
 
@@ -108,6 +112,18 @@ Discarded request: ${JSON.stringify(request)}`));
 
   isReady () {
     return this.state === 'ready';
+  }
+
+  /**
+   * Clear pendings requests.
+   * Emits an event for each discarded pending request.
+   */
+  clear () {
+    for (const request of this._pendingRequests.values()) {
+      this.emit('discarded', request);
+    }
+
+    this._pendingRequests.clear();
   }
 
 }

--- a/src/protocols/abstract/common.js
+++ b/src/protocols/abstract/common.js
@@ -28,15 +28,15 @@ class AbstractWrapper extends KuzzleEventEmitter {
   }
 
   get host () {
-    return _host;
+    return this._host;
   }
 
   get port () {
-    return _port;
+    return this._port;
   }
 
   get ssl () {
-    return _ssl;
+    return this._ssl;
   }
 
   get connected () {

--- a/src/protocols/abstract/common.js
+++ b/src/protocols/abstract/common.js
@@ -23,6 +23,8 @@ class AbstractWrapper extends KuzzleEventEmitter {
         this[opt] = options[opt];
       }
     });
+
+    this.on('disconnected', () => this.clear());
   }
 
   get host () {

--- a/test/protocol/common.test.js
+++ b/test/protocol/common.test.js
@@ -46,7 +46,7 @@ describe('Common Protocol', () => {
         .be.calledWith(request);
     });
 
-    it('should adds the requests to pending requests', () => {
+    it('should add the requests to pending requests', () => {
       protocol.send = () => {};
       const request = {requestId: 'bar', response: {}};
 

--- a/test/protocol/common.test.js
+++ b/test/protocol/common.test.js
@@ -6,6 +6,7 @@ const
 
 describe('Common Protocol', () => {
   let
+    sendSpy,
     protocol;
 
   beforeEach(function () {
@@ -17,17 +18,9 @@ describe('Common Protocol', () => {
   });
 
   describe('#query', () => {
-    let
-      sendSpy,
-      protocol;
 
     beforeEach(() => {
-      protocol = new AbstractWrapper('somewhere');
       protocol.isReady = sinon.stub().returns(true);
-      protocol.send = function(request) {
-        protocol.emit(request.requestId, request.response);
-      };
-      sendSpy = sinon.spy(protocol, 'send');
       protocol._emitRequest = sinon.stub().resolves();
     });
 
@@ -54,7 +47,7 @@ describe('Common Protocol', () => {
     });
 
     it('should adds the requests to pending requests', () => {
-      protocol.send = () => {}
+      protocol.send = () => {};
       const request = {requestId: 'bar', response: {}};
 
       protocol.query(request);
@@ -175,7 +168,6 @@ describe('Common Protocol', () => {
 
       protocol.clear();
 
-
       should(listener).be.calledTwice();
       should(listener.getCall(0).args).be.eql([request1]);
       should(listener.getCall(1).args).be.eql([request2]);
@@ -190,6 +182,6 @@ describe('Common Protocol', () => {
 
       should(protocol.state).be.eql('offline');
       should(protocol.clear).be.calledOnce();
-    })
+    });
   });
 });


### PR DESCRIPTION

## What does this PR do?

When a request is made to Kuzzle, we setup a once listener to handle the response. If a disconnection occur (manual with `disconnect()` or not), the listener are never freed.  

This PR save the pending requests in a `Map` and when a disconnection occur, a `discarded` event is triggered for each requests and then the map is cleared.

Fix #356 

### Other changes

  - add .npmignore
