### PR TITLE
Solve promise+event+memory leaks when the network fails

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -205,7 +205,7 @@ class Kuzzle extends KuzzleEventEmitter {
   set jwt (encodedJwt) {
     this.auth.authenticationToken = encodedJwt;
   }
-  
+
   get connected () {
     return this.protocol.connected;
   }
@@ -368,9 +368,13 @@ class Kuzzle extends KuzzleEventEmitter {
 
     if (!request.volatile) {
       request.volatile = this.volatile;
-    } else if (typeof request.volatile !== 'object' || Array.isArray(request.volatile)) {
+    } else if (
+      typeof request.volatile !== 'object'
+      || Array.isArray(request.volatile)
+    ) {
       throw new Error(`Kuzzle.query: Invalid volatile argument received: ${JSON.stringify(request.volatile)}`);
     }
+
     for (const item of Object.keys(this.volatile)) {
       if (request.volatile[item] === undefined) {
         request.volatile[item] = this.volatile[item];
@@ -460,15 +464,15 @@ Discarded request: ${JSON.stringify(request)}`));
     }
 
     const controller = new ControllerClass(this);
-    
+
     if (!(controller.name && controller.name.length > 0)) {
       throw new Error('Controllers must have a name.');
     }
-    
+
     if (controller.kuzzle !== this) {
       throw new Error('You must pass the Kuzzle SDK instance to the parent constructor.');
     }
-    
+
     if (this.__proxy__) {
       this.__proxy__.registerProp(accessor);
     }

--- a/src/protocols/abstract/pendingRequest.js
+++ b/src/protocols/abstract/pendingRequest.js
@@ -1,0 +1,23 @@
+'use strict';
+
+class PendingRequest {
+  constructor(request) {
+    this._resolve = null;
+    this._reject = null;
+    this.request = request;
+    this.promise = new Promise((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+  }
+
+  resolve(...payload) {
+    this._resolve(...payload);
+  }
+
+  reject(error) {
+    this._reject(error);
+  }
+}
+
+module.exports = PendingRequest;

--- a/src/protocols/abstract/realtime.js
+++ b/src/protocols/abstract/realtime.js
@@ -43,6 +43,7 @@ class RTWrapper extends KuzzleAbstractProtocol {
    * Called when the client's connection is closed
    */
   clientDisconnected() {
+    this.clear();
     this.emit('disconnect');
   }
 
@@ -53,6 +54,7 @@ class RTWrapper extends KuzzleAbstractProtocol {
    */
   clientNetworkError(error) {
     this.state = 'offline';
+    this.clear();
 
     const connectionError = new Error(`Unable to connect to kuzzle server at ${this.host}:${this.port}`);
     connectionError.internal = error;

--- a/test/protocol/websocket.test.js
+++ b/test/protocol/websocket.test.js
@@ -159,6 +159,7 @@ describe('WebSocket networking module', () => {
   it('should call listeners on a "disconnect" event', () => {
     const cb = sinon.stub();
 
+    sinon.spy(websocket, 'clear');
     websocket.retrying = false;
     websocket.addListener('disconnect', cb);
     should(websocket.listeners('disconnect').length).be.eql(1);
@@ -169,11 +170,13 @@ describe('WebSocket networking module', () => {
     clock.tick(10);
     should(cb).be.calledOnce();
     should(websocket.listeners('disconnect').length).be.eql(1);
+    websocket.clear.should.be.calledOnce();
   });
 
   it('should call error listeners on a "disconnect" event with an abnormal websocket code', () => {
     const cb = sinon.stub();
 
+    sinon.spy(websocket, 'clear');
     websocket.retrying = false;
     websocket.addListener('networkError', cb);
     should(websocket.listeners('networkError').length).be.eql(1);
@@ -188,8 +191,10 @@ describe('WebSocket networking module', () => {
     should(cb.firstCall.args[0].internal.status).be.equal(4666);
     should(cb.firstCall.args[0].internal.message).be.equal('foobar');
     should(websocket.listeners('networkError').length).be.eql(1);
+    websocket.clear.should.be.calledOnce();
 
     cb.reset();
+    websocket.clear.resetHistory();
     websocket.connect();
     clientStub.onclose({code: 4666, reason: 'foobar'});
 
@@ -199,6 +204,7 @@ describe('WebSocket networking module', () => {
     should(cb.firstCall.args[0].internal.status).be.equal(4666);
     should(cb.firstCall.args[0].internal.message).be.equal('foobar');
     should(websocket.listeners('networkError').length).be.eql(1);
+    websocket.clear.should.be.calledOnce();
   });
 
   it('should be able to register ephemeral callbacks on an event', () => {


### PR DESCRIPTION
# Description

Whenever a request is sent through `AbstractProtocol.query`:
* a one-time listener is registered to the requestId event
* a new entry is created in a map holding pending requests
* a promise is created and returned to the caller

When an API response is received, its requestId is used to invoke the one-time listener which, in turns, remove the entry from the pending requests map, and resolves/rejects the promise.

But nothing was ever done if the network fails, meaning that requests were created with no hope of ever receiving a corresponding response.
This leads to several leaks, and it will also block users awaiting for SDK methods that might never resolve their returned promise.

This PR fixes the problem by making sure that `AbstractProtocol.clear` gets called on network disconnections (expected or not), ensuring that the pending requests map is properly cleared.
This PR also enhances the "clear" method by making it unregister the one-time event, and reject the corresponding promise, to make sure that no trace remains of the pending request.