### PR TITLE
Properly handle boolean flags in HTTP querystrings

### DIFF
--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -17,7 +17,9 @@ class HttpWrapper extends KuzzleAbstractProtocol {
     if (options.http && options.http.customRoutes) {
       for (const controller in options.http.customRoutes) {
         if (options.http.customRoutes.hasOwnProperty(controller)) {
-          this.http.routes[controller] = Object.assign(this.http.routes[controller] || {}, options.http.customRoutes[controller]);
+          this.http.routes[controller] = Object.assign(
+            this.http.routes[controller] || {},
+            options.http.customRoutes[controller]);
         }
       }
     }
@@ -129,6 +131,15 @@ class HttpWrapper extends KuzzleAbstractProtocol {
       if (Array.isArray(value)) {
         queryString.push(...value.map(v => `${key}=${v}`));
 
+      }
+      else if (typeof value === 'boolean') {
+        // In Kuzzle, an optional boolean option is set to true if present in
+        // the querystring, and false if absent.
+        // As there is no boolean type in querystrings, encoding a boolean
+        // option "foo=false" in it will make Kuzzle consider it as truthy.
+        if (value === true) {
+          queryString.push(key);
+        }
       }
       else {
         queryString.push(`${key}=${value}`);

--- a/test/protocol/http.test.js
+++ b/test/protocol/http.test.js
@@ -387,6 +387,58 @@ describe('HTTP networking module', () => {
       protocol.send(data);
     });
 
+    it('should properly encode arrays into the querystring', done => {
+      const data = {
+        requestId: 'requestId',
+        action: 'bar',
+        controller: 'foo',
+        foo: ['bar', 'baz', 'qux'],
+        qux: 123
+      };
+
+      protocol.on('requestId', () => {
+        try {
+          should(protocol._sendHttpRequest).be.calledOnce();
+          should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
+          should(protocol._sendHttpRequest.firstCall.args[1])
+            .be.equal('/foo/bar?foo=bar&foo=baz&foo=qux&qux=123');
+        }
+        catch (error) {
+          return done(error);
+        }
+
+        done();
+      });
+
+      protocol.send(data);
+    });
+
+    it('should properly encode boolean flags in the querystring', done => {
+      const data = {
+        requestId: 'requestId',
+        action: 'bar',
+        controller: 'foo',
+        foo: false,
+        bar: true,
+        qux: 123
+      };
+
+      protocol.on('requestId', () => {
+        try {
+          should(protocol._sendHttpRequest).be.calledOnce();
+          should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
+          should(protocol._sendHttpRequest.firstCall.args[1])
+            .be.equal('/foo/bar?bar&qux=123');
+        }
+        catch (error) {
+          return done(error);
+        }
+
+        done();
+      });
+
+      protocol.send(data);
+    });
   });
 
   describe('#sendHttpRequest NodeJS', () => {


### PR DESCRIPTION
# Description

HTTP querystrings do not define how boolean values should be encoded, how they are handled depend on the API parsing the querystring.

Kuzzle's convention is that, for booleans, option values are irrelevant. Instead, a boolean option is truthy if it' set in the querystring, and falsey otherwise.

So this: `url?foo=0` or `url?foo=false` makes Kuzzle interpret the `foo` option as a non-empty string, and thus as "true" when converted to a boolean.

This PR fixes how the SDK passes boolean options to the querystring, only setting one if it's truthy, and skipping it if it's not.

# How to test it

Use Kuzzle's CLI `createFirstAdmin` command: even if you tell it to not reset anonymous rights, it resets it because of that bug. If you apply these changes, the CLI acts as expected.

# Other changes

Add a missing unit test about how arrays are encoded in the querystring.