### PR TITLE
Add timeout support to Http protocol

### DIFF
--- a/doc/6/protocols/http/constructor/index.md
+++ b/doc/6/protocols/http/constructor/index.md
@@ -32,7 +32,7 @@ Http protocol connection options.
 | `port`          | <pre>number</pre><br/>(`7512`)   | Kuzzle server port                  |
 | `sslConnection` | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server |
 | `customRoutes` | <pre>object</pre><br/>(`{}`) | Add custom routes <SinceBadge version="6.2.0"/> |
-| `timeout` | <pre>number</pre><br/>(`0`) | Connection timeout <SinceBadge version="6.2.1"/> |
+| `timeout` | <pre>number</pre><br/>(`0`) | Connection timeout in milliseconds (`0` mean never timeout)<SinceBadge version="6.2.1"/> |
 
 **Note:**
 
@@ -46,6 +46,7 @@ They must have the following format:
   }
 }
 ```
+
 
 ## Return
 

--- a/doc/6/protocols/http/constructor/index.md
+++ b/doc/6/protocols/http/constructor/index.md
@@ -32,6 +32,7 @@ Http protocol connection options.
 | `port`          | <pre>number</pre><br/>(`7512`)   | Kuzzle server port                  |
 | `sslConnection` | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server |
 | `customRoutes` | <pre>object</pre><br/>(`{}`) | Add custom routes <SinceBadge version="6.2.0"/> |
+| `timeout` | <pre>number</pre><br/>(`0`) | Connection timeout <SinceBadge version="6.2.1"/> |
 
 **Note:**
 

--- a/doc/6/protocols/http/constructor/index.md
+++ b/doc/6/protocols/http/constructor/index.md
@@ -32,7 +32,7 @@ Http protocol connection options.
 | `port`          | <pre>number</pre><br/>(`7512`)   | Kuzzle server port                  |
 | `sslConnection` | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server |
 | `customRoutes` | <pre>object</pre><br/>(`{}`) | Add custom routes <SinceBadge version="6.2.0"/> |
-| `timeout` | <pre>number</pre><br/>(`0`) | Connection timeout in milliseconds (`0` mean never timeout)<SinceBadge version="6.2.1"/> |
+| `timeout` | <pre>number</pre><br/>(`0`) | Connection timeout in milliseconds (`0` means no timeout)<SinceBadge version="6.2.1"/> |
 
 **Note:**
 

--- a/doc/6/protocols/http/properties/index.md
+++ b/doc/6/protocols/http/properties/index.md
@@ -18,4 +18,8 @@ order: 10
 | `port`  | <pre>number</pre>  | Kuzzle server port | Get |
 | `protocol`  | <pre>string</pre>  | `https` or `http` | Get |
 | `ssl`  | <pre>boolean</pre>  | `true` if ssl is active | Get |
-| `timeout`  | <pre>number</pre>  | Connection timeout <SinceBadge version="6.2.1"/>| Get/Set |
+| `timeout`  | <pre>number</pre>  | Connection timeout in milliseconds <SinceBadge version="6.2.1"/>| Get/Set |
+
+**Note:**
+
+A `timeout` of 0 mean that the connection will never timeout.

--- a/doc/6/protocols/http/properties/index.md
+++ b/doc/6/protocols/http/properties/index.md
@@ -9,12 +9,13 @@ order: 10
 
 # Properties
 
-| Property name        | Type     | Description          |
-| -------------------- | -------- | ---------------------|
-| `connected`  | <pre>boolean</pre>  | Always returns `true` |
-| `host`  | <pre>string</pre>  | Kuzzle server host |
-| `http`  | <pre>object</pre>  | Returns a list of available routes <DeprecatedBadge version="6.2.0"/> |
-| `routes`  | <pre>object</pre>  | Returns a list of available routes <SinceBadge version="6.2.0"/> |
-| `port`  | <pre>number</pre>  | Kuzzle server port |
-| `protocol`  | <pre>string</pre>  | `https` or `http` |
-| `ssl`  | <pre>boolean</pre>  | `true` if ssl is active |
+| Property name        | Type     | Description          |  Get/Set |
+| -------------------- | -------- | ---------------------| ---------|
+| `connected`  | <pre>boolean</pre>  | Always returns `true` | Get |
+| `host`  | <pre>string</pre>  | Kuzzle server host | Get |
+| `http`  | <pre>object</pre>  | Returns a list of available routes <DeprecatedBadge version="6.2.0"/> | Get |
+| `routes`  | <pre>object</pre>  | Returns a list of available routes <SinceBadge version="6.2.0"/> | Get |
+| `port`  | <pre>number</pre>  | Kuzzle server port | Get |
+| `protocol`  | <pre>string</pre>  | `https` or `http` | Get |
+| `ssl`  | <pre>boolean</pre>  | `true` if ssl is active | Get |
+| `timeout`  | <pre>number</pre>  | Connection timeout <SinceBadge version="6.2.1"/>| Get/Set |

--- a/doc/6/protocols/http/properties/index.md
+++ b/doc/6/protocols/http/properties/index.md
@@ -22,4 +22,4 @@ order: 10
 
 **Note:**
 
-A `timeout` of 0 mean that the connection will never timeout.
+A `timeout` of 0 means that the connection will never timeout.

--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -14,6 +14,8 @@ class HttpWrapper extends KuzzleAbstractProtocol {
 
     this._routes = {};
 
+    this._timeout = options.timeout || 0;
+
     this.customRoutes = options.customRoutes || {};
 
     for (const [controller, definition] of Object.entries(this.customRoutes)) {
@@ -45,6 +47,14 @@ class HttpWrapper extends KuzzleAbstractProtocol {
 
   get connected () {
     return true;
+  }
+
+  get timeout () {
+    return this._timeout;
+  }
+
+  set timeout (timeout) {
+    this._timeout = timeout;
   }
 
   /**
@@ -230,7 +240,8 @@ class HttpWrapper extends KuzzleAbstractProtocol {
 
       return httpClient.request(url, method, {
         headers,
-        body: payload.body
+        body: payload.body,
+        timeout: this._timeout
       })
         .then(response => JSON.parse(response.body));
     }
@@ -240,6 +251,8 @@ class HttpWrapper extends KuzzleAbstractProtocol {
       const
         xhr = new XMLHttpRequest(),
         url = `${this.protocol}://${this.host}:${this.port}${path}`;
+
+      xhr.timeout = this._timeout;
 
       xhr.onreadystatechange = () => {
         if (xhr.readyState === 4 && xhr.status === 0) {

--- a/test/protocol/http.test.js
+++ b/test/protocol/http.test.js
@@ -483,7 +483,14 @@ describe('HTTP networking module', () => {
       protocol._sendHttpRequest('VERB', '/foo/bar');
 
       should(httpRequestStub).be.calledOnce();
-      should(httpRequestStub).be.calledWith('http://address:1234/foo/bar', 'VERB', { body: undefined, headers: {'Content-Length': 0} });
+      should(httpRequestStub).be.calledWith(
+        'http://address:1234/foo/bar',
+        'VERB',
+        {
+          body: undefined,
+          headers: { 'Content-Length': 0 },
+          timeout: 0
+        });
     });
 
     it('should call http.request with a body', () => {
@@ -491,7 +498,29 @@ describe('HTTP networking module', () => {
       protocol._sendHttpRequest('VERB', '/foo/bar', {body});
 
       should(httpRequestStub).be.calledOnce();
-      should(httpRequestStub).be.calledWith('http://address:1234/foo/bar', 'VERB', {body: 'http request body', headers: {'Content-Length': body.length}});
+      should(httpRequestStub).be.calledWith(
+        'http://address:1234/foo/bar',
+        'VERB',
+        {
+          body: 'http request body',
+          headers: { 'Content-Length': body.length },
+          timeout: 0
+        });
+    });
+
+    it('should call http.request with configured timeout', () => {
+      protocol.timeout = 42000;
+      protocol._sendHttpRequest('VERB', '/foo/bar');
+
+      should(httpRequestStub).be.calledOnce();
+      should(httpRequestStub).be.calledWith(
+        'http://address:1234/foo/bar',
+        'VERB',
+        {
+          body: undefined,
+          headers: { 'Content-Length': 0 },
+          timeout: 42000
+        });
     });
 
     it('should call http.request with a body and some headers', () => {
@@ -499,10 +528,14 @@ describe('HTTP networking module', () => {
       protocol._sendHttpRequest('VERB', '/foo/bar', {body, headers: {foo: 'bar'}});
 
       should(httpRequestStub).be.calledOnce();
-      should(httpRequestStub).be.calledWith('http://address:1234/foo/bar', 'VERB', {
-        body: 'http request body',
-        headers: {'Content-Length': body.length, foo: 'bar'}
-      });
+      should(httpRequestStub).be.calledWith(
+        'http://address:1234/foo/bar',
+        'VERB',
+        {
+          body: 'http request body',
+          headers: { 'Content-Length': body.length, foo: 'bar' },
+          timeout: 0
+        });
     });
 
     it('should reject the request in case of error', () => {
@@ -537,7 +570,8 @@ describe('HTTP networking module', () => {
         open: sinon.stub(),
         send: sinon.stub(),
         setRequestHeader: sinon.stub(),
-        onreadystatechange: sinon.stub()
+        onreadystatechange: sinon.stub(),
+        timeout: 0
       };
       // eslint-disable-next-line no-native-reassign, no-global-assign
       XMLHttpRequest = function() {
@@ -565,6 +599,16 @@ describe('HTTP networking module', () => {
 
       should(xhrStub.setRequestHeader).not.be.called();
     });
+
+    it('should call XMLHttpRequest with configured timeout', () => {
+      protocol.timeout = 42000;
+
+      protocol._sendHttpRequest('VERB', '/foo/bar');
+
+      should(xhrStub.open).be.calledOnce();
+      should(xhrStub.timeout).be.eql(42000);
+    });
+
 
     it('should call XMLHttpRequest with a body', () => {
       const body = 'http request body';


### PR DESCRIPTION
## What does this PR do?

Adds a connection timeout for http protocol

https://deploy-preview-439--doc-sdk-javascript.netlify.com/protocols/http/properties/

### How should this be manually tested?

  - Step 1 : instantiate the protocol with a timeout `new Http('localhost', { timeout: 1000 })`
  - Step 2 :
  - Step 3 :  
