### PR TITLE
Fix base64 decoding for the JWT in React Native

### DIFF
--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -36,6 +36,7 @@ async function clean () {
   }
   catch (error) {
     // rethrow to get a readable error
+    console.error(error); // eslint-disable-line no-console
     throw error;
   }
 

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -36,7 +36,6 @@ async function clean () {
   }
   catch (error) {
     // rethrow to get a readable error
-    console.error(error);
     throw error;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/core/Jwt.js
+++ b/src/core/Jwt.js
@@ -10,7 +10,7 @@ const decodeBase64 = input => {
   let output = '';
 
   if (str.length % 4 === 1) {
-    throw new Error('Malformated base64 string.');
+    throw new Error('Malformed base64 string.');
   }
 
   for (let bc = 0, bs = 0, buffer, i = 0;

--- a/src/core/Jwt.js
+++ b/src/core/Jwt.js
@@ -1,15 +1,29 @@
 'use strict';
 
-// used for unit tests
-const browserAtob = base64 => atob(base64);
-const bufferAvailable = () => typeof Buffer !== 'undefined';
+// atob is not available in React Native
+// https://stackoverflow.com/questions/42829838/react-native-atob-btoa-not-working-without-remote-js-debugging
 
-const decodeBase64 = base64 => {
-  if (bufferAvailable()) {
-    return Buffer.from(base64, 'base64').toString();
+const base64Charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+const decodeBase64 = input => {
+  const str = input.replace(/=+$/, '');
+  let output = '';
+
+  if (str.length % 4 === 1) {
+    throw new Error('Malformated base64 string.');
   }
 
-  return browserAtob(base64);
+  for (let bc = 0, bs = 0, buffer, i = 0;
+    buffer = str.charAt(i++); // eslint-disable-line no-cond-assign
+
+    ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer, bc++ % 4)
+      ? output += String.fromCharCode(255 & bs >> (-2 * bc & 6))
+      : 0
+  ) {
+    buffer = base64Charset.indexOf(buffer);
+  }
+
+  return output;
 };
 
 class Jwt {

--- a/test/core/Jwt.test.js
+++ b/test/core/Jwt.test.js
@@ -37,23 +37,6 @@ describe('Jwt', () => {
         new Jwt('this-is.not-json-payload.for-sure');
       }).throwError('Invalid JSON payload for JWT');
     });
-
-    it('should be able to decode the payload when Buffer is not available (browser)', () => {
-      Jwt.__set__('browserAtob', base64 => Buffer.from(base64, 'base64').toString());
-      Jwt.__set__('bufferAvailable', () => false);
-
-      const
-        expiresAt = Date.now() + 3600 * 1000,
-        encodedJwt = generateJwt('user-gordon', expiresAt);
-
-
-      authenticationToken = new Jwt(encodedJwt);
-
-      should(authenticationToken.encodedJwt).be.eql(encodedJwt);
-      should(authenticationToken.userId).be.eql('user-gordon');
-      should(authenticationToken.expiresAt).be.eql(expiresAt);
-      should(authenticationToken.expired).be.eql(false);
-    });
   });
 
   describe('#get expired', () => {


### PR DESCRIPTION
## What does this PR do?

React Native does not have the `Buffer` class or the `atob` function to decode base64 payload.  
This PR add a standalone base64 decoding function to ensure portability across platforms.

### How should this be manually tested?

  - Step 1 : Run unit tests