### PR TITLE
Remove local checks for arguments 

### DIFF
--- a/src/KuzzleError.js
+++ b/src/KuzzleError.js
@@ -6,6 +6,8 @@ class KuzzleError extends Error {
 
     this.status = apiError.status;
     this.stack = apiError.stack;
+    this.id = apiError.id;
+    this.code = apiError.code;
 
     // PartialError
     if (this.status === 206) {

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -38,11 +38,11 @@ class AuthController extends BaseController {
   /**
    * Do not add the token for the checkToken route, to avoid getting a token error when
    * a developer simply wish to verify his token
-   * 
-   * @param {object} request 
+   *
+   * @param {object} request
    */
   authenticateRequest (request) {
-    if (!this.authenticationToken
+    if ( !this.authenticationToken
       || (request.controller === 'auth'
       && (request.action === 'checkToken' || request.action === 'login'))
     ) {
@@ -178,10 +178,6 @@ class AuthController extends BaseController {
    * @returns {Promise|*|PromiseLike<T>|Promise<T>}
    */
   login (strategy, credentials = {}, expiresIn = null) {
-    if (typeof strategy !== 'string' || strategy === '') {
-      throw new Error('Kuzzle.auth.login: strategy is required');
-    }
-
     const request = {
       strategy,
       expiresIn,

--- a/src/controllers/collection.js
+++ b/src/controllers/collection.js
@@ -11,31 +11,17 @@ class CollectionController extends BaseController {
     super(kuzzle, 'collection');
   }
 
-  create (index, collection, body = {}, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.create: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.create: collection is required');
-    }
-
+  create (index, collection, mappings = {}, options = {}) {
     return this.query({
       index,
       collection,
-      body,
+      body: mappings,
       action: 'create'
     }, options)
       .then(response => response.result);
   }
 
   deleteSpecifications (index, collection, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.deleteSpecifications: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.deleteSpecifications: collection is required');
-    }
-
     return this.query({
       index,
       collection,
@@ -45,13 +31,6 @@ class CollectionController extends BaseController {
   }
 
   exists (index, collection, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.exists: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.exists: collection is required');
-    }
-
     return this.query({
       index,
       collection,
@@ -61,13 +40,6 @@ class CollectionController extends BaseController {
   }
 
   getMapping (index, collection, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.getMapping: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.getMapping: collection is required');
-    }
-
     return this.query({
       index,
       collection,
@@ -77,13 +49,6 @@ class CollectionController extends BaseController {
   }
 
   getSpecifications (index, collection, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.getSpecifications: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.getSpecifications: collection is required');
-    }
-
     return this.query({
       index,
       collection,
@@ -93,10 +58,6 @@ class CollectionController extends BaseController {
   }
 
   list (index, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.list: index is required');
-    }
-
     const request = {
       index,
       action: 'list',
@@ -115,8 +76,10 @@ class CollectionController extends BaseController {
       body,
       action: 'searchSpecifications'
     };
+
     for (const opt of ['from', 'size', 'scroll']) {
       request[opt] = options[opt];
+
       delete options[opt];
     }
 
@@ -125,13 +88,6 @@ class CollectionController extends BaseController {
   }
 
   truncate (index, collection, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.truncate: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.truncate: collection is required');
-    }
-
     return this.query({
       index,
       collection,
@@ -142,13 +98,6 @@ class CollectionController extends BaseController {
   }
 
   updateMapping (index, collection, body, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.updateMapping: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.updateMapping: collection is required');
-    }
-
     return this.query({
       index,
       collection,
@@ -159,16 +108,6 @@ class CollectionController extends BaseController {
   }
 
   updateSpecifications (index, collection, specifications, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.updateSpecifications: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.updateSpecifications: collection is required');
-    }
-    if (!specifications) {
-      throw new Error('Kuzzle.collection.updateSpecifications: specifications are required');
-    }
-
     const body = {
       [index]: {
         [collection]: specifications
@@ -183,16 +122,6 @@ class CollectionController extends BaseController {
   }
 
   validateSpecifications (index, collection, specifications, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.collection.validateSpecifications: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.collection.validateSpecifications: collection is required');
-    }
-    if (!specifications) {
-      throw new Error('Kuzzle.collection.updateSpecifications: specifications are required');
-    }
-
     const body = {
       [index]: {
         [collection]: specifications

--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -12,13 +12,6 @@ class DocumentController extends BaseController {
   }
 
   count (index, collection, body, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.count: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.count: collection is required');
-    }
-
     const request = {
       index,
       collection,
@@ -33,16 +26,6 @@ class DocumentController extends BaseController {
   }
 
   create (index, collection, document, _id = null, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.create: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.create: collection is required');
-    }
-    if (!document) {
-      throw new Error('Kuzzle.document.create: document is required');
-    }
-
     const request = {
       index,
       collection,
@@ -58,19 +41,6 @@ class DocumentController extends BaseController {
   }
 
   createOrReplace (index, collection, _id, body, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.createOrReplace: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.createOrReplace: collection is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.document.createOrReplace: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.document.createOrReplace: body is required');
-    }
-
     const request = {
       index,
       collection,
@@ -86,16 +56,6 @@ class DocumentController extends BaseController {
   }
 
   delete (index, collection, _id, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.delete: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.delete: collection is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.document.delete: _id is required');
-    }
-
     const request = {
       index,
       collection,
@@ -110,13 +70,6 @@ class DocumentController extends BaseController {
   }
 
   deleteByQuery(index, collection, body = {}, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.deleteByQuery: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.deleteByQuery: collection is required');
-    }
-
     const request = {
       index,
       collection,
@@ -131,16 +84,6 @@ class DocumentController extends BaseController {
   }
 
   exists (index, collection, _id, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.get: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.get: collection is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.document.get: _id is required');
-    }
-
     const request = {
       index,
       collection,
@@ -153,16 +96,6 @@ class DocumentController extends BaseController {
   }
 
   get (index, collection, _id, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.get: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.get: collection is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.document.get: _id is required');
-    }
-
     const request = {
       index,
       collection,
@@ -177,16 +110,6 @@ class DocumentController extends BaseController {
   }
 
   mCreate (index, collection, documents, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.mCreate: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.mCreate: collection is required');
-    }
-    if (!Array.isArray(documents)) {
-      throw new Error('Kuzzle.document.mCreate: documents must be an array');
-    }
-
     const request = {
       index,
       collection,
@@ -201,16 +124,6 @@ class DocumentController extends BaseController {
   }
 
   mCreateOrReplace (index, collection, documents, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.mCreateOrReplace: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.mCreateOrReplace: collection is required');
-    }
-    if (!Array.isArray(documents)) {
-      throw new Error('Kuzzle.document.mCreateOrReplace: documents must be an array');
-    }
-
     const request = {
       index,
       collection,
@@ -225,16 +138,6 @@ class DocumentController extends BaseController {
   }
 
   mDelete (index, collection, ids, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.mDelete: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.mDelete: collection is required');
-    }
-    if (!Array.isArray(ids)) {
-      throw new Error('Kuzzle.document.mDelete: ids must be an array');
-    }
-
     const request = {
       index,
       collection,
@@ -249,16 +152,6 @@ class DocumentController extends BaseController {
   }
 
   mGet (index, collection, ids, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.mGet: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.mGet: collection is required');
-    }
-    if (!Array.isArray(ids)) {
-      throw new Error('Kuzzle.document.mGet: ids must be an array');
-    }
-
     const request = {
       index,
       collection,
@@ -273,16 +166,6 @@ class DocumentController extends BaseController {
   }
 
   mReplace (index, collection, documents, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.mReplace: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.mReplace: collection is required');
-    }
-    if (!Array.isArray(documents)) {
-      throw new Error('Kuzzle.document.mReplace: documents must be an array');
-    }
-
     const request = {
       index,
       collection,
@@ -296,16 +179,6 @@ class DocumentController extends BaseController {
   }
 
   mUpdate (index, collection, documents, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.mUpdate: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.mUpdate: collection is required');
-    }
-    if (!Array.isArray(documents)) {
-      throw new Error('Kuzzle.document.mUpdate: documents must be an array');
-    }
-
     const request = {
       index,
       collection,
@@ -320,19 +193,6 @@ class DocumentController extends BaseController {
   }
 
   replace (index, collection, _id, body, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.replace: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.replace: collection is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.document.replace: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.document.replace: body is required');
-    }
-
     const request = {
       index,
       collection,
@@ -348,13 +208,6 @@ class DocumentController extends BaseController {
   }
 
   search (index, collection, body = {}, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.search: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.search: collection is required');
-    }
-
     const request = {
       index,
       collection,
@@ -377,19 +230,6 @@ class DocumentController extends BaseController {
   }
 
   update (index, collection, _id, body, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.update: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.update: collection is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.document.update: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.document.update: body is required');
-    }
-
     const request = {
       index,
       collection,
@@ -407,16 +247,6 @@ class DocumentController extends BaseController {
   }
 
   validate (index, collection, body, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.document.validate: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.document.validate: collection is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.document.validate: body is required');
-    }
-
     return this.query({
       index,
       collection,

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -10,10 +10,6 @@ class IndexController extends BaseController {
   }
 
   create (index, options) {
-    if (!index) {
-      throw new Error('Kuzzle.index.create: index is required');
-    }
-
     return this.query({
       index,
       action : 'create'
@@ -22,10 +18,6 @@ class IndexController extends BaseController {
   }
 
   delete (index, options) {
-    if (!index) {
-      throw new Error('Kuzzle.index.delete: index is required');
-    }
-
     return this.query({
       index,
       action : 'delete'
@@ -34,10 +26,6 @@ class IndexController extends BaseController {
   }
 
   exists (index, options) {
-    if (!index) {
-      throw new Error('Kuzzle.index.exists: index is required');
-    }
-
     return this.query({
       index,
       action : 'exists'
@@ -46,10 +34,6 @@ class IndexController extends BaseController {
   }
 
   getAutoRefresh (index, options) {
-    if (!index) {
-      throw new Error('Kuzzle.index.getAutoRefresh: index is required');
-    }
-
     return this.query({
       index,
       action: 'getAutoRefresh'
@@ -65,10 +49,6 @@ class IndexController extends BaseController {
   }
 
   mDelete (indexes, options) {
-    if (!Array.isArray(indexes)) {
-      throw new Error('Kuzzle.index.mDelete: indexes must be an array');
-    }
-
     return this.query({
       action: 'mDelete',
       body: {
@@ -79,10 +59,6 @@ class IndexController extends BaseController {
   }
 
   refresh (index, options) {
-    if (!index || index === '') {
-      throw new Error('Kuzzle.index.refresh: index is required');
-    }
-
     return this.query({
       index,
       action: 'refresh'
@@ -98,14 +74,6 @@ class IndexController extends BaseController {
   }
 
   setAutoRefresh (index, autoRefresh, options) {
-    if (!index || index === '') {
-      throw new Error('Kuzzle.index.setAutoRefresh: index is required');
-    }
-
-    if (typeof autoRefresh !== 'boolean') {
-      throw new Error('Kuzzle.index.setAutoRefresh: autoRefresh must be a boolean');
-    }
-
     return this.query({
       index,
       action: 'setAutoRefresh',

--- a/src/controllers/realtime/index.js
+++ b/src/controllers/realtime/index.js
@@ -15,10 +15,6 @@ class RealTimeController extends BaseController {
   }
 
   count (roomId, options = {}) {
-    if (!roomId) {
-      throw new Error('Kuzzle.realtime.count: roomId is required');
-    }
-
     return this.query({
       action: 'count',
       body: {roomId}
@@ -27,16 +23,6 @@ class RealTimeController extends BaseController {
   }
 
   publish (index, collection, message, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.realtime.publish: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.realtime.publish: collection is required');
-    }
-    if (!message) {
-      throw new Error('Kuzzle.realtime.publish: message is required');
-    }
-
     const request = {
       index,
       collection,
@@ -49,19 +35,6 @@ class RealTimeController extends BaseController {
   }
 
   subscribe (index, collection, filters, callback, options = {}) {
-    if (!index) {
-      throw new Error('Kuzzle.realtime.subscribe: index is required');
-    }
-    if (!collection) {
-      throw new Error('Kuzzle.realtime.subscribe: collection is required');
-    }
-    if (!filters) {
-      throw new Error('Kuzzle.realtime.subscribe: filters is required');
-    }
-    if (!callback || typeof callback !== 'function') {
-      throw new Error('Kuzzle.realtime.subscribe: a callback function is required');
-    }
-
     const room = new Room(this, index, collection, filters, callback, options);
 
     return room.subscribe()
@@ -75,10 +48,6 @@ class RealTimeController extends BaseController {
   }
 
   unsubscribe (roomId, options = {}) {
-    if (!roomId) {
-      throw new Error('Kuzzle.realtime.unsubscribe: roomId is required');
-    }
-
     const rooms = this.subscriptions[roomId];
 
     if (!rooms) {

--- a/src/controllers/security/index.js
+++ b/src/controllers/security/index.js
@@ -16,16 +16,6 @@ class SecurityController extends BaseController {
   }
 
   createCredentials (strategy, _id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.createCredentials: _id is required');
-    }
-    if (!strategy) {
-      throw new Error('Kuzzle.security.createCredentials: strategy is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.createCredentials: body is required');
-    }
-
     return this.query({
       _id,
       strategy,
@@ -36,13 +26,6 @@ class SecurityController extends BaseController {
   }
 
   createFirstAdmin (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.createFirstAdmin: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.createFirstAdmin: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -56,13 +39,6 @@ class SecurityController extends BaseController {
   }
 
   createOrReplaceProfile (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.createOrReplaceProfile: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.createOrReplaceProfile: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -76,13 +52,6 @@ class SecurityController extends BaseController {
   }
 
   createOrReplaceRole (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.createOrReplaceRole: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.createOrReplaceRole: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -96,13 +65,6 @@ class SecurityController extends BaseController {
   }
 
   createProfile (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.createProfile: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.createProfile: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -116,9 +78,6 @@ class SecurityController extends BaseController {
   }
 
   createRestrictedUser (body, _id = null, options = {}) {
-    if (!body.credentials) {
-      throw new Error('Kuzzle.security.createRestrictedUser: body.credentials is required');
-    }
     if (!body.content) {
       body.content = {};
     }
@@ -136,13 +95,6 @@ class SecurityController extends BaseController {
   }
 
   createRole (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.createRole: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.createRole: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -156,16 +108,6 @@ class SecurityController extends BaseController {
   }
 
   createUser (_id, body, options = {}) {
-    if (!body) {
-      throw new Error('Kuzzle.security.createUser: body is required');
-    }
-    if (!body.content) {
-      throw new Error('Kuzzle.security.createUser: body.content is required');
-    }
-    if (!body.credentials) {
-      throw new Error('Kuzzle.security.createUser: body.credentials is required');
-    }
-
     const request = {
       _id,
       body,
@@ -179,13 +121,6 @@ class SecurityController extends BaseController {
   }
 
   deleteCredentials (strategy, _id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.deleteCredentials: _id is required');
-    }
-    if (!strategy) {
-      throw new Error('Kuzzle.security.deleteCredentials: strategy is required');
-    }
-
     return this.query({
       strategy,
       _id,
@@ -195,10 +130,6 @@ class SecurityController extends BaseController {
   }
 
   deleteProfile (_id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.deleteProfile: _id is required');
-    }
-
     return this.query({
       _id,
       action: 'deleteProfile'
@@ -207,10 +138,6 @@ class SecurityController extends BaseController {
   }
 
   deleteRole (_id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.deleteRole: _id is required');
-    }
-
     return this.query({
       _id,
       action: 'deleteRole'
@@ -219,10 +146,6 @@ class SecurityController extends BaseController {
   }
 
   deleteUser (_id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.deleteUser: _id is required');
-    }
-
     return this.query({
       _id,
       action: 'deleteUser'
@@ -238,10 +161,6 @@ class SecurityController extends BaseController {
   }
 
   getCredentialFields (strategy, options = {}) {
-    if (!strategy) {
-      throw new Error('Kuzzle.security.getCredentialFields: strategy is required');
-    }
-
     return this.query({
       strategy,
       action: 'getCredentialFields'
@@ -250,13 +169,6 @@ class SecurityController extends BaseController {
   }
 
   getCredentials (strategy, _id, options = {}) {
-    if (!strategy) {
-      throw new Error('Kuzzle.security.getCredentials: strategy is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.security.getCredentials: _id is required');
-    }
-
     return this.query({
       strategy,
       _id,
@@ -266,13 +178,6 @@ class SecurityController extends BaseController {
   }
 
   getCredentialsById (strategy, _id, options = {}) {
-    if (!strategy) {
-      throw new Error('Kuzzle.security.getCredentialsById: strategy is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.security.getCredentialsById: _id is required');
-    }
-
     return this.query({
       strategy,
       _id,
@@ -282,10 +187,6 @@ class SecurityController extends BaseController {
   }
 
   getProfile (_id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.getProfile: _id is required');
-    }
-
     return this.query({
       _id,
       action: 'getProfile'
@@ -301,10 +202,6 @@ class SecurityController extends BaseController {
   }
 
   getProfileRights (_id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.getProfileRights: _id is required');
-    }
-
     return this.query({
       _id,
       action: 'getProfileRights'
@@ -313,10 +210,6 @@ class SecurityController extends BaseController {
   }
 
   getRole (_id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.getRole: _id is required');
-    }
-
     return this.query({
       _id,
       action: 'getRole'
@@ -332,10 +225,6 @@ class SecurityController extends BaseController {
   }
 
   getUser (_id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.getUser: _id is required');
-    }
-
     return this.query({
       _id,
       action: 'getUser'
@@ -351,10 +240,6 @@ class SecurityController extends BaseController {
   }
 
   getUserRights (_id, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.getUserRights: _id is required');
-    }
-
     return this.query({
       _id,
       action: 'getUserRights'
@@ -363,13 +248,6 @@ class SecurityController extends BaseController {
   }
 
   hasCredentials (strategy, _id, options = {}) {
-    if (!strategy) {
-      throw new Error('Kuzzle.security.hasCredentials: strategy is required');
-    }
-    if (!_id) {
-      throw new Error('Kuzzle.security.hasCredentials: _id is required');
-    }
-
     return this.query({
       strategy,
       _id,
@@ -379,10 +257,6 @@ class SecurityController extends BaseController {
   }
 
   mDeleteProfiles (ids, options = {}) {
-    if (!Array.isArray(ids)) {
-      throw new Error('Kuzzle.security.mDeleteProfiles: ids must be an array');
-    }
-
     const request = {
       action: 'mDeleteProfiles',
       body: {ids},
@@ -395,10 +269,6 @@ class SecurityController extends BaseController {
   }
 
   mDeleteRoles (ids, options = {}) {
-    if (!Array.isArray(ids)) {
-      throw new Error('Kuzzle.security.mDeleteRoles: ids must be an array');
-    }
-
     const request = {
       action: 'mDeleteRoles',
       body: {ids},
@@ -411,10 +281,6 @@ class SecurityController extends BaseController {
   }
 
   mDeleteUsers (ids, options = {}) {
-    if (!Array.isArray(ids)) {
-      throw new Error('Kuzzle.security.mDeleteUsers: ids must be an array');
-    }
-
     const request = {
       action: 'mDeleteUsers',
       body: {ids},
@@ -427,10 +293,6 @@ class SecurityController extends BaseController {
   }
 
   mGetProfiles (ids, options = {}) {
-    if (!Array.isArray(ids)) {
-      throw new Error('Kuzzle.security.mGetProfiles: ids must be an array');
-    }
-
     return this.query({
       action: 'mGetProfiles',
       body: {ids}
@@ -439,10 +301,6 @@ class SecurityController extends BaseController {
   }
 
   mGetRoles (ids, options = {}) {
-    if (!Array.isArray(ids)) {
-      throw new Error('Kuzzle.security.mGetRoles: ids must be an array');
-    }
-
     return this.query({
       action: 'mGetRoles',
       body: {ids}
@@ -451,13 +309,6 @@ class SecurityController extends BaseController {
   }
 
   replaceUser (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.replaceUser: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.replaceUser: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -513,16 +364,6 @@ class SecurityController extends BaseController {
   }
 
   updateCredentials (strategy, _id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.updateCredentials: _id is required');
-    }
-    if (!strategy) {
-      throw new Error('Kuzzle.security.updateCredentials: strategy is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.updateCredentials: body is required');
-    }
-
     return this.query({
       strategy,
       _id,
@@ -533,13 +374,6 @@ class SecurityController extends BaseController {
   }
 
   updateProfile (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.updateProfile: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.updateProfile: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -561,13 +395,6 @@ class SecurityController extends BaseController {
   }
 
   updateRole (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.updateRole: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.updateRole: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -589,13 +416,6 @@ class SecurityController extends BaseController {
   }
 
   updateUser (_id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.updateUser: _id is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.updateUser: body is required');
-    }
-
     const request = {
       _id,
       body,
@@ -617,16 +437,6 @@ class SecurityController extends BaseController {
   }
 
   validateCredentials (strategy, _id, body, options = {}) {
-    if (!_id) {
-      throw new Error('Kuzzle.security.validateCredentials: _id is required');
-    }
-    if (!strategy) {
-      throw new Error('Kuzzle.security.validateCredentials: strategy is required');
-    }
-    if (!body) {
-      throw new Error('Kuzzle.security.validateCredentials: body is required');
-    }
-
     return this.query({
       _id,
       strategy,

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -9,7 +9,7 @@ const
 describe('Auth Controller', () => {
   const options = {opt: 'in'};
   let
-    jwt, 
+    jwt,
     kuzzle;
 
   beforeEach(() => {
@@ -221,18 +221,6 @@ describe('Auth Controller', () => {
       });
     });
 
-    it('should throw an error if the "strategy" argument is not set', () => {
-      should(function () {
-        kuzzle.auth.login(undefined, {}, options);
-      }).throw('Kuzzle.auth.login: strategy is required');
-    });
-
-    it('should throw an error if the "strategy" argument is empty', () => {
-      should(function () {
-        kuzzle.auth.login('', {}, options);
-      }).throw('Kuzzle.auth.login: strategy is required');
-    });
-
     it('should call auth/login query and return a Promise which resolves a JWT', () => {
       return kuzzle.auth.login('strategy', credentials, 'expiresIn')
         .then(res => {
@@ -419,7 +407,7 @@ describe('Auth Controller', () => {
   describe('#set authenticationToken', () => {
     beforeEach(() => {
       jwt = generateJwt();
-    }); 
+    });
 
     it('should unset the authenticationToken property if parameter is null', () => {
       kuzzle.auth.authenticationToken = jwt;

--- a/test/controllers/collection.test.js
+++ b/test/controllers/collection.test.js
@@ -16,18 +16,6 @@ describe('Collection Controller', () => {
   });
 
   describe('create', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.create(null, 'collection', null, options);
-      }).throw('Kuzzle.collection.create: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.create('index', null, null, options);
-      }).throw('Kuzzle.collection.create: collection is required');
-    });
-
     it('should call collection/create query and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({result: {acknowledged: true}});
 
@@ -67,19 +55,7 @@ describe('Collection Controller', () => {
     });
   });
 
-  describe('deleteSpecificationss', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.deleteSpecifications(undefined, 'collection', options);
-      }).throw('Kuzzle.collection.deleteSpecifications: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.deleteSpecifications('index', undefined, options);
-      }).throw('Kuzzle.collection.deleteSpecifications: collection is required');
-    });
-
+  describe('deleteSpecifications', () => {
     it('should call collection/deleteSpecifications query and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({result: {acknowledged: true}});
 
@@ -100,18 +76,6 @@ describe('Collection Controller', () => {
   });
 
   describe('exists', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.exists(undefined, 'collection', options);
-      }).throw('Kuzzle.collection.exists: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.exists('index', undefined, options);
-      }).throw('Kuzzle.collection.exists: collection is required');
-    });
-
     it('should call collection/exists query names and return a Promise which resolves a boolean', () => {
       kuzzle.query.resolves({result: true});
 
@@ -132,18 +96,6 @@ describe('Collection Controller', () => {
   });
 
   describe('getMapping', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.getMapping(undefined, 'collection', options);
-      }).throw('Kuzzle.collection.getMapping: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.getMapping('index', undefined, options);
-      }).throw('Kuzzle.collection.getMapping: collection is required');
-    });
-
     it('should call collection/getMapping query and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({
         result: {
@@ -188,18 +140,6 @@ describe('Collection Controller', () => {
   });
 
   describe('getSpecifications', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.getSpecifications(undefined, 'collection', options);
-      }).throw('Kuzzle.collection.getSpecifications: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.getSpecifications('index', undefined, options);
-      }).throw('Kuzzle.collection.getSpecifications: collection is required');
-    });
-
     it('should call collection/getSpecifications query and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({
         result: {
@@ -240,12 +180,6 @@ describe('Collection Controller', () => {
   });
 
   describe('list', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.list(undefined, options);
-      }).throw('Kuzzle.collection.list: index is required');
-    });
-
     it('should call collection/list query and return a Promise which resolves collection list', () => {
       kuzzle.query.resolves({
         result: {
@@ -330,18 +264,6 @@ describe('Collection Controller', () => {
   });
 
   describe('truncate', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.truncate(undefined, 'collection', options);
-      }).throw('Kuzzle.collection.truncate: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.truncate('index', undefined, options);
-      }).throw('Kuzzle.collection.truncate: collection is required');
-    });
-
     it('should call collection/truncate query and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({result: {acknowledged: true}});
 
@@ -363,18 +285,6 @@ describe('Collection Controller', () => {
   });
 
   describe('updateMapping', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.updateMapping(undefined, 'collection', options);
-      }).throw('Kuzzle.collection.updateMapping: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.updateMapping('index', undefined, options);
-      }).throw('Kuzzle.collection.updateMapping: collection is required');
-    });
-
     it('should call collection/updateMapping query with the new mapping and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({result: {foo: 'bar'}});
 
@@ -397,18 +307,6 @@ describe('Collection Controller', () => {
   });
 
   describe('updateSpecifications', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.updateSpecifications(undefined, 'collection', options);
-      }).throw('Kuzzle.collection.updateSpecifications: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.collection.updateSpecifications('index', undefined, options);
-      }).throw('Kuzzle.collection.updateSpecifications: collection is required');
-    });
-
     it('should call collection/updateSpecifications query with the new specifications and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({result: { index: { collection: {foo: 'bar'}}}});
 

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -16,18 +16,6 @@ describe('Document Controller', () => {
   });
 
   describe('count', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.count(undefined, 'collection', {}, options);
-      }).throw('Kuzzle.document.count: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.count('index', undefined, {}, options);
-      }).throw('Kuzzle.document.count: collection is required');
-    });
-
     it('should call document/count query and return a Promise which resolves a numeric value', () => {
       kuzzle.query.resolves({result: {count: 1234}});
 
@@ -70,24 +58,6 @@ describe('Document Controller', () => {
   });
 
   describe('create', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.create(undefined, 'collection', {foo: 'bar'}, 'document-id', options);
-      }).throw('Kuzzle.document.create: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.create('index', undefined, {foo: 'bar'}, 'document-id', options);
-      }).throw('Kuzzle.document.create: collection is required');
-    });
-
-    it('should throw an error if the "document" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.create('index', 'collection', undefined, 'document-id', options);
-      }).throw('Kuzzle.document.create: document is required');
-    });
-
     it('should call document/create query and return a Promise which resolves the created document', () => {
       const result = {
         _id: 'document-id',
@@ -142,30 +112,6 @@ describe('Document Controller', () => {
   });
 
   describe('createOrReplace', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.createOrReplace(undefined, 'collection', 'document-id', {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.createOrReplace: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.createOrReplace('index', undefined, 'document-id', {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.createOrReplace: collection is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.createOrReplace('index', 'collection', 'document-id', undefined, options);
-      }).throw('Kuzzle.document.createOrReplace: body is required');
-    });
-
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.createOrReplace('index', 'collection', undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.createOrReplace: _id is required');
-    });
-
     it('should call document/createOrReplace query and return a Promise which resolves an acknowledgement', () => {
       const result = {
         _id: 'document-id',
@@ -222,24 +168,6 @@ describe('Document Controller', () => {
   });
 
   describe('delete', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.delete(undefined, 'collection', 'document-id', options);
-      }).throw('Kuzzle.document.delete: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.delete('index', undefined, 'document-id', options);
-      }).throw('Kuzzle.document.delete: collection is required');
-    });
-
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.delete('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.delete: _id is required');
-    });
-
     it('should call document/delete query and return a Promise which resolves the id of the deleted document', () => {
       kuzzle.query.resolves({result: {_id: 'document-id'}});
 
@@ -282,18 +210,6 @@ describe('Document Controller', () => {
   });
 
   describe('deleteByQuery', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.deleteByQuery(undefined, 'collection', {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.deleteByQuery: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.deleteByQuery('index', undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.deleteByQuery: collection is required');
-    });
-
     it('should call document/deleteByQuery query and return a Promise which resolves the list of deleted document ids', () => {
       kuzzle.query.resolves({result: {ids: ['foo', 'bar', 'baz']}});
 
@@ -344,24 +260,6 @@ describe('Document Controller', () => {
   });
 
   describe('get', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.get(undefined, 'collection', 'document-id', options);
-      }).throw('Kuzzle.document.get: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.get('index', undefined, 'document-id', options);
-      }).throw('Kuzzle.document.get: collection is required');
-    });
-
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.get('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.get: _id is required');
-    });
-
     it('should call document/get query and return a Promise which resolves the document', () => {
       kuzzle.query.resolves({
         result: {
@@ -424,30 +322,6 @@ describe('Document Controller', () => {
   });
 
   describe('mCreate', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mCreate(undefined, 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options);
-      }).throw('Kuzzle.document.mCreate: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mCreate('index', undefined, [{_id: 'document-id', body: {foo: 'bar'}}], options);
-      }).throw('Kuzzle.document.mCreate: collection is required');
-    });
-
-    it('should throw an error if the "documents" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mCreate('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.mCreate: documents must be an array');
-    });
-
-    it('should throw an error if the "documents" argument is not an array', () => {
-      should(function () {
-        kuzzle.document.mCreate('index', 'collection', {_id: 'document-id', body: {foo: 'bar'}}, options);
-      }).throw('Kuzzle.document.mCreate: documents must be an array');
-    });
-
     it('should call document/mCreate query and return a Promise which resolves the created documents', () => {
       const result = {
         hits: [{
@@ -506,30 +380,6 @@ describe('Document Controller', () => {
   });
 
   describe('mCreateOrReplace', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mCreateOrReplace(undefined, 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options);
-      }).throw('Kuzzle.document.mCreateOrReplace: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mCreateOrReplace('index', undefined, [{_id: 'document-id', body: {foo: 'bar'}}], options);
-      }).throw('Kuzzle.document.mCreateOrReplace: collection is required');
-    });
-
-    it('should throw an error if the "documents" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mCreateOrReplace('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.mCreateOrReplace: documents must be an array');
-    });
-
-    it('should throw an error if the "documents" argument is not an array', () => {
-      should(function () {
-        kuzzle.document.mCreateOrReplace('index', 'collection', {_id: 'document-id', body: {foo: 'bar'}}, options);
-      }).throw('Kuzzle.document.mCreateOrReplace: documents must be an array');
-    });
-
     it('should call document/mCreateOrReplace query and return a Promise which resolves the created documents', () => {
       const result = {
         hits: [{
@@ -588,30 +438,6 @@ describe('Document Controller', () => {
   });
 
   describe('mDelete', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mDelete(undefined, 'collection', ['document1', 'document2'], options);
-      }).throw('Kuzzle.document.mDelete: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mDelete('index', undefined, ['document1', 'document2'], options);
-      }).throw('Kuzzle.document.mDelete: collection is required');
-    });
-
-    it('should throw an error if the "ids" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mDelete('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.mDelete: ids must be an array');
-    });
-
-    it('should throw an error if the "ids" argument is not an array', () => {
-      should(function () {
-        kuzzle.document.mDelete('index', 'collection', 'document1', options);
-      }).throw('Kuzzle.document.mDelete: ids must be an array');
-    });
-
     it('should call document/mDelete query and return a Promise which resolves the list of deleted documents ids', () => {
       const result = ['document1', 'document2'];
       kuzzle.query.resolves({result});
@@ -656,30 +482,6 @@ describe('Document Controller', () => {
   });
 
   describe('mGet', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mGet(undefined, 'collection', ['document1', 'document2'], options);
-      }).throw('Kuzzle.document.mGet: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mGet('index', undefined, ['document1', 'document2'], options);
-      }).throw('Kuzzle.document.mGet: collection is required');
-    });
-
-    it('should throw an error if the "ids" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mGet('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.mGet: ids must be an array');
-    });
-
-    it('should throw an error if the "ids" argument is not an array', () => {
-      should(function () {
-        kuzzle.document.mGet('index', 'collection', 'document1', options);
-      }).throw('Kuzzle.document.mGet: ids must be an array');
-    });
-
     it('should call document/mGet query and return a Promise which resolves the list of documents', () => {
       const result = {
         hits: [
@@ -736,30 +538,6 @@ describe('Document Controller', () => {
   });
 
   describe('mReplace', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mReplace(undefined, 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options);
-      }).throw('Kuzzle.document.mReplace: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mReplace('index', undefined, [{_id: 'document-id', body: {foo: 'bar'}}], options);
-      }).throw('Kuzzle.document.mReplace: collection is required');
-    });
-
-    it('should throw an error if the "documents" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mReplace('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.mReplace: documents must be an array');
-    });
-
-    it('should throw an error if the "documents" argument is not an array', () => {
-      should(function () {
-        kuzzle.document.mReplace('index', 'collection', {_id: 'document-id', body: {foo: 'bar'}}, options);
-      }).throw('Kuzzle.document.mReplace: documents must be an array');
-    });
-
     it('should call document/mReplace query and return a Promise which resolves the replaced documents', () => {
       const result = {
         hits: [{
@@ -818,30 +596,6 @@ describe('Document Controller', () => {
   });
 
   describe('mUpdate', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mUpdate(undefined, 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options);
-      }).throw('Kuzzle.document.mUpdate: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mUpdate('index', undefined, [{_id: 'document-id', body: {foo: 'bar'}}], options);
-      }).throw('Kuzzle.document.mUpdate: collection is required');
-    });
-
-    it('should throw an error if the "documents" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.mUpdate('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.mUpdate: documents must be an array');
-    });
-
-    it('should throw an error if the "documents" argument is not an array', () => {
-      should(function () {
-        kuzzle.document.mUpdate('index', 'collection', {_id: 'document-id', body: {foo: 'bar'}}, options);
-      }).throw('Kuzzle.document.mUpdate: documents must be an array');
-    });
-
     it('should call document/mUpdate query and return a Promise which resolves the updated documents', () => {
       const result = {
         hits: [{
@@ -900,30 +654,6 @@ describe('Document Controller', () => {
   });
 
   describe('replace', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.replace(undefined, 'collection', 'document-id', {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.replace: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.replace('index', undefined, 'document-id', {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.replace: collection is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.replace('index', 'collection', 'document-id', undefined, options);
-      }).throw('Kuzzle.document.replace: body is required');
-    });
-
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.replace('index', 'collection', undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.replace: _id is required');
-    });
-
     it('should call document/replace query and return a Promise which resolves the updated document', () => {
       const result = {
         _id: 'document-id',
@@ -980,18 +710,6 @@ describe('Document Controller', () => {
   });
 
   describe('search', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.search(undefined, 'collection', {}, options);
-      }).throw('Kuzzle.document.search: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.search('index', undefined, {}, options);
-      }).throw('Kuzzle.document.search: collection is required');
-    });
-
     it('should call document/search query and return a Promise which resolves a DocumentSearchResult instance', () => {
       const result = {
         scrollId: 'scroll-id',
@@ -1112,7 +830,7 @@ describe('Document Controller', () => {
 
           const request = kuzzle.document.query.getCall(0).args[0];
           should(request.from).be.eql(0);
-          should(request.size).be.eql(10);          
+          should(request.size).be.eql(10);
         });
     });
 
@@ -1128,7 +846,7 @@ describe('Document Controller', () => {
           should(kuzzle.document.query).be.calledOnce();
 
           const request = kuzzle.document.query.getCall(0).args[0];
-          should(request.from).be.undefined();         
+          should(request.from).be.undefined();
 
           return kuzzle.document.search('index', 'collection', { sort: { some: 'thing' }});
         })
@@ -1136,36 +854,12 @@ describe('Document Controller', () => {
           should(kuzzle.document.query).be.calledTwice();
 
           const request = kuzzle.document.query.getCall(1).args[0];
-          should(request.from).be.undefined();         
+          should(request.from).be.undefined();
         });
     });
   });
 
   describe('update', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.update(undefined, 'collection', 'document-id', {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.update: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.update('index', undefined, 'document-id', {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.update: collection is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.update('index', 'collection', 'document-id', undefined, options);
-      }).throw('Kuzzle.document.update: body is required');
-    });
-
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.update('index', 'collection', undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.update: _id is required');
-    });
-
     it('should call document/update query and return a Promise which resolves the updated document', () => {
       const result = {
         _id: 'document-id',
@@ -1252,24 +946,6 @@ describe('Document Controller', () => {
   });
 
   describe('validate', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.validate(undefined, 'collection', {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.validate: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.validate('index', undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.document.validate: collection is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.document.validate('index', 'collection', undefined, options);
-      }).throw('Kuzzle.document.validate: body is required');
-    });
-
     it('should call document/validate query and return a Promise which resolves the validation result', () => {
       const result = {
         errorMessages: {},

--- a/test/controllers/index.test.js
+++ b/test/controllers/index.test.js
@@ -15,12 +15,6 @@ describe('Index Controller', () => {
   });
 
   describe('create', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.index.create(undefined, options);
-      }).throw('Kuzzle.index.create: index is required');
-    });
-
     it('should call index/create query and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({
         result: {
@@ -46,12 +40,6 @@ describe('Index Controller', () => {
   });
 
   describe('delete', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.index.delete(undefined, options);
-      }).throw('Kuzzle.index.delete: index is required');
-    });
-
     it('should call index/delete query and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({
         result: {acknowledged: true}
@@ -73,12 +61,6 @@ describe('Index Controller', () => {
   });
 
   describe('exists', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.index.exists(undefined, options);
-      }).throw('Kuzzle.index.exists: index is required');
-    });
-
     it('should call index/exists query and return a Promise which resolves a boolean', () => {
       kuzzle.query.resolves({result: true});
 
@@ -98,12 +80,6 @@ describe('Index Controller', () => {
   });
 
   describe('getAutoRefresh', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.index.getAutoRefresh(undefined, options);
-      }).throw('Kuzzle.index.getAutoRefresh: index is required');
-    });
-
     it('should call index/getAutoRefresh query and return a Promise which resolves a boolean', () => {
       kuzzle.query.resolves({result: true});
 
@@ -144,18 +120,6 @@ describe('Index Controller', () => {
   });
 
   describe('mDelete', () => {
-    it('should throw an error if the "indexes" argument is not provided', () => {
-      should(function () {
-        kuzzle.index.mDelete(undefined, options);
-      }).throw('Kuzzle.index.mDelete: indexes must be an array');
-    });
-
-    it('should throw an error if the "indexes" argument is not an array', () => {
-      should(function () {
-        kuzzle.index.mDelete('foo', options);
-      }).throw('Kuzzle.index.mDelete: indexes must be an array');
-    });
-
     it('should call index/mDelete query and return a Promise which resolves the list of deleted indexes', () => {
       const result = {
         deleted: ['foo', 'bar']
@@ -178,12 +142,6 @@ describe('Index Controller', () => {
   });
 
   describe('refresh', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.index.refresh(undefined, options);
-      }).throw('Kuzzle.index.refresh: index is required');
-    });
-
     it('should call index/refresh query and return a Promise which resolves an acknowledgement', () => {
       const result = {
         _shards: {
@@ -230,12 +188,6 @@ describe('Index Controller', () => {
   });
 
   describe('setAutoRefresh', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.index.setAutoRefresh(undefined, true, options);
-      }).throw('Kuzzle.index.setAutoRefresh: index is required');
-    });
-
     it('should call index/setAutoRefresh query to enable autorefresh and return a Promise which resolves true', () => {
       kuzzle.query.resolves({result: { response: true }});
 

--- a/test/controllers/realtime.test.js
+++ b/test/controllers/realtime.test.js
@@ -27,12 +27,6 @@ describe('Realtime Controller', () => {
   });
 
   describe('#count', () => {
-    it('should throw an error if the "roomId" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.count(undefined, options);
-      }).throw('Kuzzle.realtime.count: roomId is required');
-    });
-
     it('should call realtime/count query with the roomId and return a Promise which resolves a number', () => {
       kuzzle.query.resolves({result: {roomId: 'roomId', count: 1234}});
 
@@ -52,24 +46,6 @@ describe('Realtime Controller', () => {
   });
 
   describe('#publish', () => {
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.publish(undefined, 'collection', {}, options);
-      }).throw('Kuzzle.realtime.publish: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.publish('index', undefined, {}, options);
-      }).throw('Kuzzle.realtime.publish: collection is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.publish('index', 'collection', undefined, options);
-      }).throw('Kuzzle.realtime.publish: message is required');
-    });
-
     it('should call realtime/publish query with the index, collection and body and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({result: {published: true}});
 
@@ -123,36 +99,6 @@ describe('Realtime Controller', () => {
       const MockRealtimeController =
         mockrequire.reRequire('../../src/controllers/realtime/index');
       kuzzle.realtime = new MockRealtimeController(kuzzle);
-    });
-
-    it('should throw an error if the "index" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.subscribe(undefined, 'collection', {}, sinon.stub(), options);
-      }).throw('Kuzzle.realtime.subscribe: index is required');
-    });
-
-    it('should throw an error if the "collection" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.subscribe('index', undefined, {}, sinon.stub(), options);
-      }).throw('Kuzzle.realtime.subscribe: collection is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.subscribe('index', 'collection', undefined, sinon.stub(), options);
-      }).throw('Kuzzle.realtime.subscribe: filters is required');
-    });
-
-    it('should throw an error if the "callback" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.subscribe('index', 'collection', {}, undefined, options);
-      }).throw('Kuzzle.realtime.subscribe: a callback function is required');
-    });
-
-    it('should throw an error if the "callback" argument is not a function', () => {
-      should(function () {
-        kuzzle.realtime.subscribe('index', 'collection', {}, 'foobar', options);
-      }).throw('Kuzzle.realtime.subscribe: a callback function is required');
     });
 
     it('should create a Room object with the propataged arguments and bind subscribe() method to it', () => {
@@ -217,12 +163,6 @@ describe('Realtime Controller', () => {
       kuzzle.realtime.subscriptions.foo = [room3];
 
       kuzzle.query.resolves({result: roomId});
-    });
-
-    it('should throw an error if the "roomId" argument is not provided', () => {
-      should(function () {
-        kuzzle.realtime.unsubscribe(undefined, options);
-      }).throw('Kuzzle.realtime.unsubscribe: roomId is required');
     });
 
     it('should reject the promise if the room is not found', () => {

--- a/test/controllers/security.test.js
+++ b/test/controllers/security.test.js
@@ -22,24 +22,6 @@ describe('Security Controller', () => {
   });
 
   describe('createCredentials', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createCredentials('strategy', undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.createCredentials: _id is required');
-    });
-
-    it('should throw an error if the "strategy" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createCredentials(undefined, 'kuid', {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.createCredentials: strategy is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createCredentials('strategy', 'kuid', undefined, options);
-      }).throw('Kuzzle.security.createCredentials: body is required');
-    });
-
     it('should call security/createCredentials query with the user credentials and return a Promise which resolves a json object', () => {
       const result = {
         username: 'foo',
@@ -65,18 +47,6 @@ describe('Security Controller', () => {
   });
 
   describe('createFirstAdmin', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createFirstAdmin(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.createFirstAdmin: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createFirstAdmin('kuid', undefined, options);
-      }).throw('Kuzzle.security.createFirstAdmin: body is required');
-    });
-
     it('should call security/createFirstAdmin query with the first admin content and credentials and return a Promise which resolves the created user object', () => {
       kuzzle.query.resolves({
         result: {
@@ -133,18 +103,6 @@ describe('Security Controller', () => {
   });
 
   describe('createOrReplaceProfile', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createOrReplaceProfile(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.createOrReplaceProfile: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createOrReplaceProfile('profileId', undefined, options);
-      }).throw('Kuzzle.security.createOrReplaceProfile: body is required');
-    });
-
     it('should call security/createOrReplaceProfile query with the profile content and return a Promise which resolves a Profile object', () => {
       kuzzle.query.resolves({
         result: {
@@ -207,18 +165,6 @@ describe('Security Controller', () => {
   });
 
   describe('createOrReplaceRole', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createOrReplaceRole(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.createOrReplaceRole: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createOrReplaceRole('roleId', undefined, options);
-      }).throw('Kuzzle.security.createOrReplaceRole: body is required');
-    });
-
     it('should call security/createOrReplaceRole query with the role content and return a Promise which resolves a Role object', () => {
       kuzzle.query.resolves({
         result: {
@@ -281,18 +227,6 @@ describe('Security Controller', () => {
   });
 
   describe('createProfile', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createProfile(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.createProfile: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createProfile('profileId', undefined, options);
-      }).throw('Kuzzle.security.createProfile: body is required');
-    });
-
     it('should call security/createProfile query with the profile content and return a Promise which resolves a Profile object', () => {
       kuzzle.query.resolves({
         result: {
@@ -355,18 +289,6 @@ describe('Security Controller', () => {
   });
 
   describe('createRole', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createRole(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.createRole: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createRole('roleId', undefined, options);
-      }).throw('Kuzzle.security.createRole: body is required');
-    });
-
     it('should call security/createRole query with the role content and return a Promise which resolves a Role object', () => {
       kuzzle.query.resolves({
         result: {
@@ -429,32 +351,6 @@ describe('Security Controller', () => {
   });
 
   describe('createUser', () => {
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.createUser('userId', undefined, options);
-      }).throw('Kuzzle.security.createUser: body is required');
-    });
-
-    it('should throw an error if "body.content" is not provided', () => {
-      const body = {
-        credentials: {
-          strategy: {foo: 'bar'}
-        }
-      };
-      should(function () {
-        kuzzle.security.createUser('userId', body, options);
-      }).throw('Kuzzle.security.createUser: body.content is required');
-    });
-
-    it('should throw an error if "body.credentials" is not provided', () => {
-      const body = {
-        content: {foo: 'bar'}
-      };
-      should(function () {
-        kuzzle.security.createUser('userId', body, options);
-      }).throw('Kuzzle.security.createUser: body.credentials is required');
-    });
-
     it('should call security/createUser query with the user content and credentials and return a Promise which resolves a User object', () => {
       const body = {
         content: {foo: 'bar'},
@@ -533,14 +429,6 @@ describe('Security Controller', () => {
   });
 
   describe('createRestrictedUser', () => {
-    it('should throw an error if "body.credentials" is not provided', () => {
-      const content = {foo: 'bar'};
-
-      should(function () {
-        kuzzle.security.createRestrictedUser(content);
-      }).throw('Kuzzle.security.createRestrictedUser: body.credentials is required');
-    });
-
     it('should call security/createRestrictedUser query with the user content and credentials and return a Promise which resolves a User object', () => {
       const body = {
         content: {foo: 'bar'},
@@ -619,18 +507,6 @@ describe('Security Controller', () => {
   });
 
   describe('deleteCredentials', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.deleteCredentials('strategy', undefined, options);
-      }).throw('Kuzzle.security.deleteCredentials: _id is required');
-    });
-
-    it('should throw an error if the "strategy" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.deleteCredentials(undefined, 'kuid', {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.deleteCredentials: strategy is required');
-    });
-
     it('should call security/deleteCredentials query and return a Promise which resolves an acknowledgement', () => {
       const result = {
         acknowledged: true
@@ -654,12 +530,6 @@ describe('Security Controller', () => {
   });
 
   describe('deleteProfile', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.deleteProfile(undefined, options);
-      }).throw('Kuzzle.security.deleteProfile: _id is required');
-    });
-
     it('should call security/deleteProfile query and return a Promise which resolves the deleted profile id', () => {
       const result = {
         _id: 'profileId'
@@ -682,12 +552,6 @@ describe('Security Controller', () => {
   });
 
   describe('deleteRole', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.deleteRole(undefined, options);
-      }).throw('Kuzzle.security.deleteRole: _id is required');
-    });
-
     it('should call security/deleteRole query and return a Promise which resolves the deleted role id', () => {
       const result = {
         _id: 'roleId'
@@ -710,12 +574,6 @@ describe('Security Controller', () => {
   });
 
   describe('deleteUser', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.deleteUser(undefined, options);
-      }).throw('Kuzzle.security.deleteUser: _id is required');
-    });
-
     it('should call security/deleteUser query and return a Promise which resolves the deleted user id', () => {
       const result = {
         _id: 'kuid'
@@ -760,12 +618,6 @@ describe('Security Controller', () => {
   });
 
   describe('getCredentialFields', () => {
-    it('should throw an error if the "strategy" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getCredentialFields(undefined, options);
-      }).throw('Kuzzle.security.getCredentialFields: strategy is required');
-    });
-
     it('should call security/getCredentialFields query and return a Promise which resolves the list of credendial fields', () => {
       const result = ['username', 'password'];
       kuzzle.query.resolves({result});
@@ -786,18 +638,6 @@ describe('Security Controller', () => {
   });
 
   describe('getCredentials', () => {
-    it('should throw an error if the "strategy" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getCredentials(undefined, 'kuid', options);
-      }).throw('Kuzzle.security.getCredentials: strategy is required');
-    });
-
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getCredentials('strategy', undefined, options);
-      }).throw('Kuzzle.security.getCredentials: _id is required');
-    });
-
     it('should call security/getCredentials query and return a Promise which resolves the user credentials', () => {
       const result = {
         username: 'foo',
@@ -822,18 +662,6 @@ describe('Security Controller', () => {
   });
 
   describe('getCredentialsById', () => {
-    it('should throw an error if the "strategy" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getCredentialsById(undefined, 'kuid', options);
-      }).throw('Kuzzle.security.getCredentialsById: strategy is required');
-    });
-
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getCredentialsById('strategy', undefined, options);
-      }).throw('Kuzzle.security.getCredentialsById: _id is required');
-    });
-
     it('should call security/getCredentialsById query and return a Promise which resolves the user credentials', () => {
       const result = {
         username: 'foo',
@@ -858,12 +686,6 @@ describe('Security Controller', () => {
   });
 
   describe('getProfile', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getProfile(undefined, options);
-      }).throw('Kuzzle.security.getProfile: _id is required');
-    });
-
     it('should call security/getProfile query with the profile id a Promise which resolves a Profile object', () => {
       kuzzle.query.resolves({
         result: {
@@ -914,12 +736,6 @@ describe('Security Controller', () => {
   });
 
   describe('getProfileRights', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getProfileRights(undefined, options);
-      }).throw('Kuzzle.security.getProfileRights: _id is required');
-    });
-
     it('should call security/getProfileRights query with the profile id return a Promise which resolves the list of rights', () => {
       const result = {
         hits: [
@@ -945,12 +761,6 @@ describe('Security Controller', () => {
   });
 
   describe('getRole', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getRole(undefined, options);
-      }).throw('Kuzzle.security.getRole: _id is required');
-    });
-
     it('should call security/getRole query with the role id a Promise which resolves a Role object', () => {
       kuzzle.query.resolves({
         result: {
@@ -1001,12 +811,6 @@ describe('Security Controller', () => {
   });
 
   describe('getUser', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getUser(undefined, options);
-      }).throw('Kuzzle.security.getUser: _id is required');
-    });
-
     it('should call security/getUser query with the user id a Promise which resolves a User object', () => {
       kuzzle.query.resolves({
         result: {
@@ -1058,12 +862,6 @@ describe('Security Controller', () => {
   });
 
   describe('getUserRights', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.getUserRights(undefined, options);
-      }).throw('Kuzzle.security.getUserRights: _id is required');
-    });
-
     it('should call security/getUserRights query with the user id return a Promise which resolves the list of rights', () => {
       const result = {
         hits: [
@@ -1089,18 +887,6 @@ describe('Security Controller', () => {
   });
 
   describe('hasCredentials', () => {
-    it('should throw an error if the "strategy" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.hasCredentials(undefined, 'kuid', options);
-      }).throw('Kuzzle.security.hasCredentials: strategy is required');
-    });
-
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.hasCredentials('strategy', undefined, options);
-      }).throw('Kuzzle.security.hasCredentials: _id is required');
-    });
-
     it('should call security/hasCredentials query and return a Promise which resolves a boolean', () => {
       kuzzle.query.resolves({result: true});
 
@@ -1121,18 +907,6 @@ describe('Security Controller', () => {
   });
 
   describe('mDeleteProfiles', () => {
-    it('should throw an error if the "ids" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.mDeleteProfiles(undefined, options);
-      }).throw('Kuzzle.security.mDeleteProfiles: ids must be an array');
-    });
-
-    it('should throw an error if the "ids" argument is not an array', () => {
-      should(function () {
-        kuzzle.security.mDeleteProfiles('profile1', options);
-      }).throw('Kuzzle.security.mDeleteProfiles: ids must be an array');
-    });
-
     it('should call security/mDeleteProfiles query and return a Promise which resolves the list of deleted profiles ids', () => {
       const result = ['profile1', 'profile2'];
       kuzzle.query.resolves({result});
@@ -1173,18 +947,6 @@ describe('Security Controller', () => {
   });
 
   describe('mDeleteRoles', () => {
-    it('should throw an error if the "ids" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.mDeleteRoles(undefined, options);
-      }).throw('Kuzzle.security.mDeleteRoles: ids must be an array');
-    });
-
-    it('should throw an error if the "ids" argument is not an array', () => {
-      should(function () {
-        kuzzle.security.mDeleteRoles('role1', options);
-      }).throw('Kuzzle.security.mDeleteRoles: ids must be an array');
-    });
-
     it('should call security/mDeleteRoles query and return a Promise which resolves the list of deleted roles ids', () => {
       const result = ['role1', 'role2'];
       kuzzle.query.resolves({result});
@@ -1225,18 +987,6 @@ describe('Security Controller', () => {
   });
 
   describe('mDeleteUsers', () => {
-    it('should throw an error if the "ids" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.mDeleteUsers(undefined, options);
-      }).throw('Kuzzle.security.mDeleteUsers: ids must be an array');
-    });
-
-    it('should throw an error if the "ids" argument is not an array', () => {
-      should(function () {
-        kuzzle.security.mDeleteUsers('user1', options);
-      }).throw('Kuzzle.security.mDeleteUsers: ids must be an array');
-    });
-
     it('should call security/mDeleteUsers query and return a Promise which resolves the list of deleted users ids', () => {
       const result = ['user1', 'user2'];
       kuzzle.query.resolves({result});
@@ -1277,18 +1027,6 @@ describe('Security Controller', () => {
   });
 
   describe('mGetProfiles', () => {
-    it('should throw an error if the "ids" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.mGetProfiles(undefined, options);
-      }).throw('Kuzzle.security.mGetProfiles: ids must be an array');
-    });
-
-    it('should throw an error if the "ids" argument is not an array', () => {
-      should(function () {
-        kuzzle.security.mGetProfiles('profile1', options);
-      }).throw('Kuzzle.security.mGetProfiles: ids must be an array');
-    });
-
     it('should call security/mGetProfiles query and return a Promise which resolves the list of profiles', () => {
       const result = {
         hits: [
@@ -1324,18 +1062,6 @@ describe('Security Controller', () => {
   });
 
   describe('mGetRoles', () => {
-    it('should throw an error if the "ids" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.mGetRoles(undefined, options);
-      }).throw('Kuzzle.security.mGetRoles: ids must be an array');
-    });
-
-    it('should throw an error if the "ids" argument is not an array', () => {
-      should(function () {
-        kuzzle.security.mGetRoles('role1', options);
-      }).throw('Kuzzle.security.mGetRoles: ids must be an array');
-    });
-
     it('should call security/mGetRoles query and return a Promise which resolves the list of roles', () => {
       const result = {
         hits: [
@@ -1371,18 +1097,6 @@ describe('Security Controller', () => {
   });
 
   describe('replaceUser', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.replaceUser(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.replaceUser: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.replaceUser('userId', undefined, options);
-      }).throw('Kuzzle.security.replaceUser: body is required');
-    });
-
     it('should call security/replaceUser query with the user content and return a Promise which resolves a User object', () => {
       kuzzle.query.resolves({
         result: {
@@ -1640,24 +1354,6 @@ describe('Security Controller', () => {
   });
 
   describe('updateCredentials', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateCredentials('strategy', undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.updateCredentials: _id is required');
-    });
-
-    it('should throw an error if the "strategy" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateCredentials(undefined, 'kuid', {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.updateCredentials: strategy is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateCredentials('strategy', 'kuid', undefined, options);
-      }).throw('Kuzzle.security.updateCredentials: body is required');
-    });
-
     it('should call security/updateCredentials query with the user credentials and return a Promise which resolves a json object', () => {
       const result = {
         username: 'foo',
@@ -1683,18 +1379,6 @@ describe('Security Controller', () => {
   });
 
   describe('updateProfile', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateProfile(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.updateProfile: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateProfile('profileId', undefined, options);
-      }).throw('Kuzzle.security.updateProfile: body is required');
-    });
-
     it('should call security/updateProfile query with the profile content and return a Promise which resolves a Profile object', () => {
       kuzzle.query.resolves({
         result: {
@@ -1776,18 +1460,6 @@ describe('Security Controller', () => {
   });
 
   describe('updateRole', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateRole(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.updateRole: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateRole('roleId', undefined, options);
-      }).throw('Kuzzle.security.updateRole: body is required');
-    });
-
     it('should call security/updateRole query with the role content and return a Promise which resolves a Role object', () => {
       kuzzle.query.resolves({
         result: {
@@ -1869,18 +1541,6 @@ describe('Security Controller', () => {
   });
 
   describe('updateUser', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateUser(undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.updateUser: _id is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.updateUser('userId', undefined, options);
-      }).throw('Kuzzle.security.updateUser: body is required');
-    });
-
     it('should call security/updateUser query with the user content to update and return a Promise which resolves a User object', () => {
       kuzzle.query.resolves({
         result: {
@@ -1964,24 +1624,6 @@ describe('Security Controller', () => {
   });
 
   describe('validateCredentials', () => {
-    it('should throw an error if the "_id" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.validateCredentials('strategy', undefined, {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.validateCredentials: _id is required');
-    });
-
-    it('should throw an error if the "strategy" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.validateCredentials(undefined, 'kuid', {foo: 'bar'}, options);
-      }).throw('Kuzzle.security.validateCredentials: strategy is required');
-    });
-
-    it('should throw an error if the "body" argument is not provided', () => {
-      should(function () {
-        kuzzle.security.validateCredentials('strategy', 'kuid', undefined, options);
-      }).throw('Kuzzle.security.validateCredentials: body is required');
-    });
-
     it('should call security/validateCredentials query with the user credentials and return a Promise which resolves a boolean', () => {
       kuzzle.query.resolves({result: true});
 


### PR DESCRIPTION
## What does this PR do?

`v6` version of #450 

Remove the local check of the arguments since now we have specifics errors code sent by Kuzzle.

### Other changes

 - Add error codes `id` and `code` properties to `KuzzleError`