### PR TITLE
Fix connected property value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/protocols/abstract/common.js
+++ b/src/protocols/abstract/common.js
@@ -40,7 +40,7 @@ class AbstractWrapper extends KuzzleEventEmitter {
   }
 
   get connected () {
-    return this.state === 'online';
+    return this.state === 'connected';
   }
 
   get pendingRequests () {

--- a/test/protocol/common.test.js
+++ b/test/protocol/common.test.js
@@ -18,6 +18,18 @@ describe('Common Protocol', () => {
     sendSpy = sinon.spy(protocol, 'send');
   });
 
+  describe('#connected', () => {
+    it('should return true if the protocol state is "connected"', () => {
+      protocol.state = 'connected';
+
+      should(protocol.connected).be.True();
+
+      protocol.state = 'disconnected';
+
+      should(protocol.connected).be.False();
+    });
+  });
+
   describe('#query', () => {
 
     beforeEach(() => {


### PR DESCRIPTION
## What does this PR do?

The `kuzzle.connected` property which delegate to the protocol was testing a wrong `protocol.state` value (`'online'` instead of `'connected'`). 

7.x PR: https://github.com/kuzzleio/sdk-javascript/pull/453
