### PR TITLE
Fix erroneous error message on browser ws error

### DIFF
--- a/src/protocols/websocket.js
+++ b/src/protocols/websocket.js
@@ -90,8 +90,10 @@ class WSNode extends RTWrapper {
         let err = error;
 
         if (!(error instanceof Error)) {
-          err = error ?
-            new Error(error.message || error) : new Error('Unexpected error');
+          // browser-side, the payload sent to this event is a generic "Event"
+          // object bearing no information about the cause of the error
+          err = error && (typeof Event === 'undefined' || !(error instanceof Event)) ?
+            new Error(error.message || error) : new Error('Connection error');
         }
 
         this.clientNetworkError(err);

--- a/test/protocol/websocket.test.js
+++ b/test/protocol/websocket.test.js
@@ -414,6 +414,26 @@ describe('WebSocket networking module', () => {
     should(websocket.wasConnected).be.false();
   });
 
+  it('should reject with a proper error if onerror is called with an event (browser)', () => {
+    const Event = sinon.stub();
+    Object.defineProperty(global, 'Event', {
+      value: Event,
+      enumerable: false,
+      writable: false,
+      configurable: true
+    });
+
+    const promise = websocket.connect();
+    websocket.client.onerror(new Event());
+
+    return should(promise).rejectedWith(Error, {message: 'Connection error'})
+      .then(() => delete global.Event)
+      .catch(e => {
+        delete global.Event;
+        throw e;
+      });
+  });
+
   describe('#constructor', () => {
     it('should throw if an invalid host is provided', () => {
       const invalidHosts = [undefined, null, 123, false, true, [], {}, ''];


### PR DESCRIPTION
# Description

The `onerror` event handler called in browsers' WebSocket API differ from the one exposed by the `ws` module used in Node.js: the handler in browsers receive a generic `Event` object without any error information, while the ws handler receives a proper error.

Result: `kuzzle.connect().catch(e => console.log(e))` prints something like `Error: [object Event]` in a browser's console.

This PR fixes that issue by detecting the case and sending a generic `Connection error` to the connect promise handler.

# How to reproduce

Run the following script in a browser:

```html
<html>
<head>
<script src="node_modules/kuzzle-sdk/dist/kuzzle.js"></script>
</head>
<body>
<script>
const
  // doesn't matter, must not reach any kuzzle server is what is important
  ws = new KuzzleSDK.WebSocket('172.19.0.129', {port: 5555}),
  kuzzle = new KuzzleSDK.Kuzzle(ws);

console.log('Connecting...');

kuzzle
  .connect()
  .catch(err => {
    console.log(err);
    kuzzle.disconnect();
  });

</script>
</body>
```

Without this PR, the console should show the following message:

`Error: [object Event]`

With this PR:

`Error: Connection error`
