### PR TITLE
Fix search with size=0

### DIFF
--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -194,7 +194,10 @@ class DocumentController extends BaseController {
       delete options[opt];
     }
 
-    request.size = request.size || 10;
+    if (request.size === undefined) {
+      request.size = 10;
+    }
+
     if (!request.scroll && !request.body.sort && !request.from) {
       request.from = 0;
     }

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -449,6 +449,23 @@ describe('Document Controller', () => {
         });
     });
 
+    it.only('should allow to set value of 0 for size', () => {
+      const result = {
+        hits: [],
+        total: 0
+      };
+      kuzzle.document.query = sinon.stub().resolves({result});
+
+      return kuzzle.document.search('index', 'collection', {}, { size: 0 })
+        .then(() => {
+          should(kuzzle.document.query).be.calledOnce();
+
+          const request = kuzzle.document.query.getCall(0).args[0];
+          should(request.from).be.eql(0);
+          should(request.size).be.eql(0);
+        });
+    });
+
     it('should not set default value for from if scroll or sort are specified', () => {
       const result = {
         hits: [],

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -449,7 +449,7 @@ describe('Document Controller', () => {
         });
     });
 
-    it.only('should allow to set value of 0 for size', () => {
+    it('should allow to set value of 0 for size', () => {
       const result = {
         hits: [],
         total: 0


### PR DESCRIPTION
## What does this PR do?

Fix a bug that prevent user of setting a `size` of `0` on `document.search`.
