### PR TITLE
[ci] Separate latest from stable deploy

### DIFF
--- a/.ci/test-docs.sh
+++ b/.ci/test-docs.sh
@@ -20,11 +20,19 @@ done
 cd ${here}/../doc/7/getting-started/.react
 npm install
 SKIP_PREFLIGHT_CHECK=true npm run start &
+until $(curl --output /dev/null --silent --head --fail http://localhost:3000); do
+  printf '.'
+  sleep 5
+done
 npm run test
 
 cd ${here}/../doc/7/getting-started/.vuejs
 npm ci
 npm run serve-standalone &
+until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do
+  printf '.'
+  sleep 5
+done
 npm run test
 
 cd ${here}

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,6 @@ jobs:
         - gem install typhoeus
         - HYDRA_MAX_CONCURRENCY=20 npm run --prefix doc/framework dead-links
 
-
     - stage: Deployment Doc Dev
       name: Deploy next-docs.kuzzle.io
       if: type = push AND branch =~ /^[0-9]+-dev$/
@@ -154,8 +153,42 @@ jobs:
       after_deploy:
         - npm run doc-cloudfront
 
+    - stage: Deploy latest release on NPM
+      if: type = push AND branch =~ /^master$/
+      sudo: false
+      language: node_js
+      node_js: 10
+
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - g++-4.9
+
+      before_install:
+        - export CC="gcc-4.9" CXX="g++-4.9"
+
+      install:
+        - npm install
+
+      script:
+        - npm run build
+
+      deploy:
+        provider: npm
+        skip_cleanup: true
+        email: support@kuzzle.io
+        tag: latest
+        api_key:
+          secure: "oZG8eiOGQxH5sEvTI6sNcSL8+RnE/qOs1TMOn1eB0GvRB/pQ9Oylzunjntp7WzHpEm23+3Cfj898sgQ6uNBeKm/bEYOxN+kYbzpY0kSiwaW+dDneFzVIa+r1dF8+/oCvH720VIu+92KYK/8+A6jJGlevMezL+w5ggD6I2j0i+QBPyplvh5qjyd7OayGPCPUq22Om9U9QPux4FFYmpX6TDn/l0iVYat0T8B5+tyUKjsY7XV/Ad4ob8y52kQ1gmxtK09FXkR8im5sEmEaC3QWKQKqWc0XpZ7wwgw/cojVShQvEp25ZgVNxG0cPynIbIu0Y3yCO3c0WVq1QpmMx41ekMb61kBjQ4UYmSKcHODMt3MdP6VgFJOlAVCrP5KgIwAro2vqM+vSWEI8kNMBi/Zivve8hp4TQEAuhHjl9naQnrsoKsw9+CMatMVbDS56O+fmy8H0fnDtvW8SyZThjzhTK2Cee8KbbRF65LlXU9OpR6XOkfsTEseyVlaGm5C+engXl/YKnH8SNgzZNjE45ptYldOhKGlYrMqBv/Nivljsl3K9+yyLrTOE3qG5TxwEOPGoIOBjGGfvur91yP5pZnmefSMnryPEPlAQEzIBh21vqXvG+wYZh6U6YUPKDN3aZgBt4fjLWfcQbBZF95JixG/5CBOEExdrMfVJIbpoVeljcITw="
+        on:
+          repo: kuzzleio/sdk-javascript
+          all_branches: true
+
     - stage: Deploy Stable release on NPM
-      if: type = push AND branch =~ /^master|[0-9]+-stable$/
+      if: type = push AND branch =~ /^[0-9]+-stable$/
       sudo: false
       language: node_js
       node_js: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ jobs:
         - npm run doc-cloudfront
 
     - stage: Deploy latest release on NPM
-      if: type = push AND branch =~ /^master$/
+      if: type = push AND branch = master
       sudo: false
       language: node_js
       node_js: 10

--- a/doc/7/controllers/security/create-or-replace-profile/snippets/create-or-replace-profile.js
+++ b/doc/7/controllers/security/create-or-replace-profile/snippets/create-or-replace-profile.js
@@ -10,7 +10,7 @@ try {
           roleId: 'admin',
           restrictedTo: [
             {
-              index: 'someIndex',
+              index: 'someindex',
               collections: [
                 'collection1',
                 'collection2'

--- a/doc/7/controllers/security/create-or-replace-profile/snippets/create-or-replace-profile.test.yml
+++ b/doc/7/controllers/security/create-or-replace-profile/snippets/create-or-replace-profile.test.yml
@@ -1,6 +1,7 @@
 name: security#createOrReplaceProfile
 description: Creates or replaces a profile
 hooks:
+  before: curl -XPOST kuzzle:7512/someindex/_create
   after: curl -XDELETE kuzzle:7512/profiles/myProfile?refresh=wait_for
 template: default
 expected: Profile successfully updated

--- a/doc/7/controllers/security/create-profile/snippets/create-profile.js
+++ b/doc/7/controllers/security/create-profile/snippets/create-profile.js
@@ -10,7 +10,7 @@ try {
           roleId: 'admin',
           restrictedTo: [
             {
-              index: 'someIndex',
+              index: 'someindex',
               collections: [
                 'collection1',
                 'collection2'

--- a/doc/7/controllers/security/get-profile-rights/snippets/get-profile-rights.test.yml
+++ b/doc/7/controllers/security/get-profile-rights/snippets/get-profile-rights.test.yml
@@ -7,11 +7,11 @@ hooks:
         {
           "roleId": "admin",
           "restrictedTo": [
-            { "index": "someIndex" },
+            { "index": "someindex" },
             {
-              "index": "anotherIndex",
+              "index": "anotherindex",
               "collections": [
-                "someCollection"
+                "somecollection"
               ]
             }
           ]
@@ -23,4 +23,4 @@ hooks:
     }' kuzzle:7512/profiles/myProfile/_create
   after: curl -XDELETE kuzzle:7512/profiles/myProfile
 template: default
-expected: '^    value: ''allowed'' },$'
+expected: "^    value: 'allowed' },$"

--- a/doc/7/controllers/security/get-profile/snippets/get-profile.test.yml
+++ b/doc/7/controllers/security/get-profile/snippets/get-profile.test.yml
@@ -7,11 +7,11 @@ hooks:
         {
           "roleId": "admin",
           "restrictedTo": [
-            { "index": "someIndex" },
+            { "index": "someindex" },
             {
-              "index": "anotherIndex",
+              "index": "anotherindex",
               "collections": [
-                "someCollection"
+                "somecollection"
               ]
             }
           ]

--- a/doc/7/controllers/security/update-profile/snippets/update-profile.js
+++ b/doc/7/controllers/security/update-profile/snippets/update-profile.js
@@ -10,10 +10,10 @@ try {
           roleId: 'privileged',
           restrictedTo: [
             {
-              index: 'someIndex'
+              index: 'someindex'
             },
             {
-              index: 'anotherIndex',
+              index: 'anotherindex',
               collections: [
                 'coll1',
                 'coll2'


### PR DESCRIPTION
## What does this PR do?
Adds a CI job only for the `master` branch, where the `deployments` section adds the `latest` tag to the published package. This way we have
* the `master` branch, published with the `latest` dist-tag
* the `*-stable` branches, published with no dist-tag
* the `*-beta` branches, published with the `beta` dist tag

### How should this be manually tested?
Merge on `master` and ensure the next NPM release from the `master` branch has the `latest` tag.

## Other changes
* Fixed the tests that were failing because now Kuzzle V2 doesn't accept index and collection names containing uppercase letters.
* Added time to wait the dev server of the how-to