### PR TITLE
Add a "source" option for document:update to retrieve the updated document

### DIFF
--- a/doc/7/controllers/document/update/index.md
+++ b/doc/7/controllers/document/update/index.md
@@ -35,10 +35,11 @@ Additional query options
 | `queuable`        | <pre>boolean</pre><br/>(`true`) | If true, queues the request during downtime, until connected to Kuzzle again       |
 | `refresh`         | <pre>string</pre><br/>(`""`)    | If set to `wait_for`, waits for the change to be reflected for `search` (up to 1s) |
 | `retryOnConflict` | <pre>int</pre><br/>(`0`)        | The number of times the database layer should retry in case of version conflict    |
+| `source`          | <pre>boolean</pre><br/>(`false`)| If true, returns the updated document inside the response
 
 ## Resolves
 
-Resolves to an object containing the the document update result.
+Resolves to an object containing the document update result.
 
 ## Usage
 

--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -213,8 +213,10 @@ class DocumentController extends BaseController {
       _id,
       body,
       action: 'update',
-      retryOnConflict: options.retryOnConflict
+      retryOnConflict: options.retryOnConflict,
+      source: options.source
     };
+    delete options.source;
     delete options.retryOnConflict;
 
     return this.query(request, options)

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -512,7 +512,8 @@ describe('Document Controller', () => {
               collection: 'collection',
               _id: 'document-id',
               body: {foo: 'bar'},
-              retryOnConflict: undefined
+              retryOnConflict: undefined,
+              source: undefined
             }, options);
 
           should(res).be.equal(result);
@@ -539,7 +540,36 @@ describe('Document Controller', () => {
               collection: 'collection',
               _id: 'document-id',
               body: {foo: 'bar'},
-              retryOnConflict: true
+              retryOnConflict: true,
+              source: undefined
+            }, {});
+
+          should(res).be.equal(result);
+        });
+    });
+
+    it('should inject the "source" option into the request', () => {
+      const result = {
+        _id: 'document-id',
+        _version: 1,
+        _source: { foo: 'bar' },
+        created: false
+      };
+      kuzzle.query.resolves({ result });
+
+      return kuzzle.document.update('index', 'collection', 'document-id', { foo: 'bar' }, { source: true })
+        .then(res => {
+          should(kuzzle.query)
+            .be.calledOnce()
+            .be.calledWith({
+              controller: 'document',
+              action: 'update',
+              index: 'index',
+              collection: 'collection',
+              _id: 'document-id',
+              body: { foo: 'bar' },
+              retryOnConflict: undefined,
+              source: true
             }, {});
 
           should(res).be.equal(result);


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?

This PR adds a `source` option. Set to `true` returns the updated document in a `_source` object.

Depends to https://github.com/kuzzleio/kuzzle/pull/1549

<!-- Please fulfill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

### How should this be manually tested?

Run Kuzzle within this branch https://github.com/kuzzleio/kuzzle/pull/1549

`document.update(index, collection, body, {source: true})`

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
