### PR TITLE
Hotfix document search http

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/controllers/document.js
+++ b/src/controllers/document.js
@@ -194,12 +194,8 @@ class DocumentController extends BaseController {
       delete options[opt];
     }
 
-    if (request.size === undefined) {
-      request.size = 10;
-    }
-
-    if (!request.scroll && !request.body.sort && !request.from) {
-      request.from = 0;
+    if (!options.verb) {
+      options.verb = 'POST';
     }
 
     return this.query(request, options)

--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -339,7 +339,7 @@ class HttpWrapper extends KuzzleAbstractProtocol {
 }
 
 function getPostRoute (routes) {
-  return routes[0].verb === 'POST' ? routes[0] : routes[1]
+  return routes[0].verb === 'POST' ? routes[0] : routes[1];
 }
 
 function getCorrectRoute (routes) {

--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -310,7 +310,7 @@ class HttpWrapper extends KuzzleAbstractProtocol {
           }
           else if (http && http.length > 1) {
             // We need this ugly fix because the document:search route can also
-            // in GET with this url: "/:index/:collection"
+            // be accessed in GET with this url: "/:index/:collection"
             // But to send a query, we need to pass it in the body so we need POST
             // so we can change the verb but then POST on "/:index/:collection"
             // is the collection:update method (document:search is "/:index/:collection/_search")

--- a/src/protocols/http.js
+++ b/src/protocols/http.js
@@ -307,8 +307,19 @@ class HttpWrapper extends KuzzleAbstractProtocol {
 
           if (http && http.length === 1) {
             routes[controller][action] = http[0];
-          } else if (http && http.length > 1) {
-            routes[controller][action] = getCorrectRoute(http);
+          }
+          else if (http && http.length > 1) {
+            // We need this ugly fix because the document:search route can also
+            // in GET with this url: "/:index/:collection"
+            // But to send a query, we need to pass it in the body so we need POST
+            // so we can change the verb but then POST on "/:index/:collection"
+            // is the collection:update method (document:search is "/:index/:collection/_search")
+            if (controller === 'document' && action === 'search') {
+              routes[controller][action] = getPostRoute(http);
+            }
+            else {
+              routes[controller][action] = getCorrectRoute(http);
+            }
           }
         }
 
@@ -325,7 +336,10 @@ class HttpWrapper extends KuzzleAbstractProtocol {
   _warn (message) {
     console.warn(message); // eslint-disable-line no-console
   }
+}
 
+function getPostRoute (routes) {
+  return routes[0].verb === 'POST' ? routes[0] : routes[1]
 }
 
 function getCorrectRoute (routes) {

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -382,14 +382,14 @@ describe('Document Controller', () => {
         .then(res => {
           should(kuzzle.query)
             .be.calledOnce()
-            .be.calledWith({
+            .be.calledWithMatch({
               controller: 'document',
               action: 'search',
               index: 'index',
               collection: 'collection',
               body: {foo: 'bar'},
-              from: 0,
-              size: 10,
+              from: undefined,
+              size: undefined,
               scroll: undefined
             }, options);
 
@@ -416,7 +416,7 @@ describe('Document Controller', () => {
         .then(res => {
           should(kuzzle.query)
             .be.calledOnce()
-            .be.calledWith({
+            .be.calledWithMatch({
               controller: 'document',
               action: 'search',
               index: 'index',
@@ -428,27 +428,10 @@ describe('Document Controller', () => {
             }, {});
 
           should(res).be.an.instanceOf(DocumentSearchResult);
-          should(res._options).be.empty();
+          should(res._options).match({ verb: 'POST' });
           should(res._response).be.equal(result);
           should(res.fetched).be.equal(2);
           should(res.total).be.equal(3);
-        });
-    });
-
-    it('should set default value for from and size', () => {
-      const result = {
-        hits: [],
-        total: 0
-      };
-      kuzzle.document.query = sinon.stub().resolves({result});
-
-      return kuzzle.document.search('index', 'collection', {})
-        .then(() => {
-          should(kuzzle.document.query).be.calledOnce();
-
-          const request = kuzzle.document.query.getCall(0).args[0];
-          should(request.from).be.eql(0);
-          should(request.size).be.eql(10);
         });
     });
 
@@ -464,7 +447,6 @@ describe('Document Controller', () => {
           should(kuzzle.document.query).be.calledOnce();
 
           const request = kuzzle.document.query.getCall(0).args[0];
-          should(request.from).be.eql(0);
           should(request.size).be.eql(0);
         });
     });

--- a/test/protocol/http.test.js
+++ b/test/protocol/http.test.js
@@ -721,6 +721,14 @@ describe('HTTP networking module', () => {
   describe('_constructRoutes', () => {
     it('should construct http routes from server:publicApi', () => {
       const publicApi = {
+        document: {
+          search: {
+            http: [
+              { verb: 'GET', url: '/:index/:collection/' },
+              { verb: 'POST', url: '/:index/:collection/_search' }
+            ]
+          }
+        },
         foo: {
           login: {
             http: [
@@ -766,8 +774,10 @@ describe('HTTP networking module', () => {
       // will be in the query string
       should(routes.foo.create.url).be.eql('/:index/:collection/_create');
 
-      should(routes.foo.subscribe).be.undefined();
+      // we should choose the POST route for document:create
+      should(routes.document.search.url).be.eql('/:index/:collection/_search');
 
+      should(routes.foo.subscribe).be.undefined();
     });
 
     it('should overwrite kuzzle routes with custom routes', () => {


### PR DESCRIPTION
## What does this PR do?

When we have multiple choose for a route, we choose the shortest or the GET route.  
With `document:create` we have the choice between those 2 routes:
```
{ verb: 'GET', url: '/:index/:collection/' },
{ verb: 'POST', url: '/:index/:collection/_search' }
```

The problem is that after even if we want to change the verb by using `options.verb`, the URL is not the good one and `GET /:index/:collection` correspond to the `collection:create` method.

So this PR is just a dirty fix to always use the POST route with `document:search`.  

When we are going to fully support the GET verb with query for `document:search`, maybe we can get ride of this.

See this failing job on Kuzzle: https://travis-ci.org/github/kuzzleio/kuzzle/jobs/667658863