### PR TITLE
Allow to use custom controller in another package

### DIFF
--- a/doc/7/controllers/collection/search-specifications/snippets/search-specifications.js
+++ b/doc/7/controllers/collection/search-specifications/snippets/search-specifications.js
@@ -10,7 +10,7 @@ try {
   const options = {
     size: 50,
     offset: 0,
-    scroll: '10m'
+    scroll: '10s'
   };
 
   const searchResult = await kuzzle.collection.searchSpecifications(body, options);

--- a/doc/7/core-classes/search-result/next/snippets/scroll.js
+++ b/doc/7/core-classes/search-result/next/snippets/scroll.js
@@ -13,7 +13,7 @@ try {
     'nyc-open-data',
     'yellow-taxi',
     { query: { match: { category: 'suv' } } },
-    { scroll: '1m', size: 10 });
+    { scroll: '10s', size: 10 });
 
   // Fetch the matched items by advancing through the result pages
   const matched = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -516,10 +516,6 @@ Discarded request: ${JSON.stringify(request)}`));
    * @returns {Kuzzle}
    */
   useController (ControllerClass, accessor) {
-    if (!(ControllerClass.prototype.__proto__.constructor.name === 'BaseController')) {
-      throw new Error('Controllers must inherits from the BaseController class.');
-    }
-
     if (!(accessor && accessor.length > 0)) {
       throw new Error('You must provide a valid accessor.');
     }

--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -9,7 +9,6 @@ const
   ServerController = require('./controllers/server'),
   SecurityController = require('./controllers/security'),
   MemoryStorageController = require('./controllers/memoryStorage'),
-  BaseController = require('./controllers/base'),
   uuidv4 = require('./uuidv4'),
   proxify = require('./proxify');
 
@@ -517,7 +516,7 @@ Discarded request: ${JSON.stringify(request)}`));
    * @returns {Kuzzle}
    */
   useController (ControllerClass, accessor) {
-    if (!(ControllerClass.prototype instanceof BaseController)) {
+    if (!(ControllerClass.prototype.__proto__.constructor.name === 'BaseController')) {
       throw new Error('Controllers must inherits from the BaseController class.');
     }
 

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -412,7 +412,7 @@ describe('Document Controller', () => {
       };
       kuzzle.query.resolves({result});
 
-      return kuzzle.document.search('index', 'collection', {foo: 'bar'}, {from: 1, size: 2, scroll: '1m'})
+      return kuzzle.document.search('index', 'collection', {foo: 'bar'}, {from: 1, size: 2, scroll: '10s'})
         .then(res => {
           should(kuzzle.query)
             .be.calledOnce()
@@ -424,7 +424,7 @@ describe('Document Controller', () => {
               body: {foo: 'bar'},
               from: 1,
               size: 2,
-              scroll: '1m'
+              scroll: '10s'
             }, {});
 
           should(res).be.an.instanceOf(DocumentSearchResult);

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -106,7 +106,7 @@ describe('DocumentSearchResult', () => {
       };
 
       beforeEach(() => {
-        request.scroll = '1m';
+        request.scroll = '10s';
 
         response = {
           scrollId: 'scroll-id',

--- a/test/controllers/searchResult/document.test.js
+++ b/test/controllers/searchResult/document.test.js
@@ -130,7 +130,7 @@ describe('DocumentSearchResult', () => {
               .be.calledWith({
                 controller: 'document',
                 action: 'scroll',
-                scroll: '1m',
+                scroll: '10s',
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);

--- a/test/controllers/searchResult/profile.test.js
+++ b/test/controllers/searchResult/profile.test.js
@@ -133,7 +133,7 @@ describe('ProfileSearchResult', () => {
               .be.calledWith({
                 controller: 'security',
                 action: 'scrollProfiles',
-                scroll: '1m',
+                scroll: '10s',
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);

--- a/test/controllers/searchResult/profile.test.js
+++ b/test/controllers/searchResult/profile.test.js
@@ -110,7 +110,7 @@ describe('ProfileSearchResult', () => {
       };
 
       beforeEach(() => {
-        request.scroll = '1m';
+        request.scroll = '10s';
 
         response = {
           scrollId: 'scroll-id',

--- a/test/controllers/searchResult/role.test.js
+++ b/test/controllers/searchResult/role.test.js
@@ -84,7 +84,7 @@ describe('RoleSearchResult', () => {
 
 
     it('should throw an error if scrollId parameters is set', () => {
-      request.scroll = '1m';
+      request.scroll = '10s';
       searchResult = new RoleSearchResult(kuzzle, request, options, response);
 
       should(function () {

--- a/test/controllers/searchResult/specifications.test.js
+++ b/test/controllers/searchResult/specifications.test.js
@@ -123,7 +123,7 @@ describe('SpecificationsSearchResult', () => {
               .be.calledWith({
                 controller: 'collection',
                 action: 'scrollSpecifications',
-                scroll: '1m',
+                scroll: '10s',
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);

--- a/test/controllers/searchResult/specifications.test.js
+++ b/test/controllers/searchResult/specifications.test.js
@@ -100,7 +100,7 @@ describe('SpecificationsSearchResult', () => {
       };
 
       beforeEach(() => {
-        request.scroll = '1m';
+        request.scroll = '10s';
 
         response = {
           scrollId: 'scroll-id',

--- a/test/controllers/searchResult/user.test.js
+++ b/test/controllers/searchResult/user.test.js
@@ -112,7 +112,7 @@ describe('UserSearchResult', () => {
       };
 
       beforeEach(() => {
-        request.scroll = '1m';
+        request.scroll = '10s';
 
         response = {
           scrollId: 'scroll-id',

--- a/test/controllers/searchResult/user.test.js
+++ b/test/controllers/searchResult/user.test.js
@@ -135,7 +135,7 @@ describe('UserSearchResult', () => {
               .be.calledWith({
                 controller: 'security',
                 action: 'scrollUsers',
-                scroll: '1m',
+                scroll: '10s',
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);

--- a/test/controllers/security.test.js
+++ b/test/controllers/security.test.js
@@ -985,7 +985,7 @@ describe('Security Controller', () => {
       };
       kuzzle.query.resolves({result});
 
-      return kuzzle.security.searchProfiles({roles: ['foo', 'bar']}, {from: 1, size: 2, scroll: '1m'})
+      return kuzzle.security.searchProfiles({roles: ['foo', 'bar']}, {from: 1, size: 2, scroll: '10s'})
         .then(res => {
           should(kuzzle.query)
             .be.calledOnce()
@@ -995,7 +995,7 @@ describe('Security Controller', () => {
               body: {roles: ['foo', 'bar']},
               from: 1,
               size: 2,
-              scroll: '1m'
+              scroll: '10s'
             }, {});
 
           should(res).be.an.instanceOf(ProfileSearchResult);
@@ -1113,7 +1113,7 @@ describe('Security Controller', () => {
       };
       kuzzle.query.resolves({result});
 
-      return kuzzle.security.searchUsers({foo: 'bar'}, {from: 1, size: 2, scroll: '1m'})
+      return kuzzle.security.searchUsers({foo: 'bar'}, {from: 1, size: 2, scroll: '10s'})
         .then(res => {
           should(kuzzle.query)
             .be.calledOnce()
@@ -1123,7 +1123,7 @@ describe('Security Controller', () => {
               body: {foo: 'bar'},
               from: 1,
               size: 2,
-              scroll: '1m'
+              scroll: '10s'
             }, {});
 
           should(res).be.an.instanceOf(UserSearchResult);

--- a/test/kuzzle/useController.test.js
+++ b/test/kuzzle/useController.test.js
@@ -23,12 +23,6 @@ class CustomController extends BaseController {
   }
 }
 
-class NotInheritingController {
-  constructor (kuzzle) {
-    this._kuzzle = kuzzle;
-  }
-}
-
 class UnamedController extends BaseController {
   constructor (kuzzle) {
     super(kuzzle);

--- a/test/kuzzle/useController.test.js
+++ b/test/kuzzle/useController.test.js
@@ -82,12 +82,6 @@ describe('Kuzzle custom controllers management', () => {
         });
     });
 
-    it('should throw if the controller does not inherits from BaseController', () => {
-      should(() => {
-        kuzzle.useController(NotInheritingController, 'wrong');
-      }).throw('Controllers must inherits from the BaseController class.');
-    });
-
     it('should throw if the controller does not have a name', () => {
       should(() => {
         kuzzle.useController(UnamedController, 'unamed');


### PR DESCRIPTION
## What does this PR do?

Consider the following situation:

I have a custom controller in the package `custom-controller`:
 - this package include `kuzzle-sdk` as peer dependencies
 - this package expose a controller inheriting from `BaseController` class of `kuzzle-sdk`

I have my project including `custom-controller` and `kuzzle-sdk` as dependencies.

I will not be able to use my controller since the SDK checks if the controller is an instanceof `BaseController` but since these class are used in 2 different modules, the check fail.

This PR does not checks anymore if the controller is an instance of `BaseController` but it stills checks that the interface is respected (`kuzzle` and `name` properties present)

### Other changes

 - use scroll of 10s