### PR TITLE
Add the rate limit property to Profile objects

### DIFF
--- a/src/controllers/Security.js
+++ b/src/controllers/Security.js
@@ -113,7 +113,10 @@ class SecurityController extends BaseController {
     };
 
     return this.query(request, options)
-      .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
+      .then(response => new Profile(
+        this.kuzzle,
+        response.result._id,
+        response.result._source));
   }
 
   createOrReplaceRole (_id, body, options = {}) {
@@ -135,7 +138,10 @@ class SecurityController extends BaseController {
     };
 
     return this.query(request, options)
-      .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
+      .then(response => new Profile(
+        this.kuzzle,
+        response.result._id,
+        response.result._source));
   }
 
   createRestrictedUser (body, _id = null, options = {}) {
@@ -247,11 +253,11 @@ class SecurityController extends BaseController {
   }
 
   getProfile (_id, options = {}) {
-    return this.query({
-      _id,
-      action: 'getProfile'
-    }, options)
-      .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
+    return this.query({_id, action: 'getProfile'}, options)
+      .then(response => new Profile(
+        this.kuzzle,
+        response.result._id,
+        response.result._source));
   }
 
   getProfileMapping (options = {}) {
@@ -347,11 +353,9 @@ class SecurityController extends BaseController {
   }
 
   mGetProfiles (ids, options = {}) {
-    return this.query({
-      action: 'mGetProfiles',
-      body: {ids}
-    }, options)
-      .then(response => response.result.hits.map(hit => new Profile(this.kuzzle, hit._id , hit._source.policies)));
+    return this.query({action: 'mGetProfiles', body: {ids}}, options)
+      .then(response => response.result.hits.map(
+        hit => new Profile(this.kuzzle, hit._id, hit._source)));
   }
 
   mGetUsers (ids, options = {}) {
@@ -440,8 +444,12 @@ class SecurityController extends BaseController {
       body,
       action: 'updateProfile'
     };
+
     return this.query(request, options)
-      .then(response => new Profile(this.kuzzle, response.result._id, response.result._source.policies));
+      .then(response => new Profile(
+        this.kuzzle,
+        response.result._id,
+        response.result._source));
   }
 
   updateProfileMapping (body, options = {}) {

--- a/src/core/searchResult/Profile.js
+++ b/src/core/searchResult/Profile.js
@@ -2,13 +2,13 @@ const Profile = require('../security/Profile');
 const SearchResultBase = require('./SearchResultBase');
 
 class ProfileSearchResult extends SearchResultBase {
-
   constructor (kuzzle, request, options, response) {
     super(kuzzle, request, options, response);
 
     this._searchAction = 'searchProfiles';
     this._scrollAction = 'scrollProfiles';
-    this.hits = response.hits.map(hit => new Profile(this._kuzzle, hit._id, hit._source.policies));
+    this.hits = response.hits.map(
+      hit => new Profile(this._kuzzle, hit._id, hit._source));
   }
 
   next () {
@@ -18,7 +18,9 @@ class ProfileSearchResult extends SearchResultBase {
           return null;
         }
 
-        nextSearchResult.hits = nextSearchResult._response.hits.map(hit => new Profile(nextSearchResult._kuzzle, hit._id, hit._source.policies));
+        nextSearchResult.hits = nextSearchResult._response.hits.map(
+          hit => new Profile(nextSearchResult._kuzzle, hit._id, hit._source));
+
         return nextSearchResult;
       });
   }

--- a/src/core/security/Profile.js
+++ b/src/core/security/Profile.js
@@ -4,10 +4,11 @@ class Profile {
    * @param {Kuzzle} kuzzle
    * @param {Object} data
    */
-  constructor (kuzzle, _id = null, policies = []) {
+  constructor (kuzzle, _id = null, content = null) {
     this._kuzzle = kuzzle;
     this._id = _id;
-    this.policies = policies;
+    this.rateLimit = content ? content.rateLimit : 0;
+    this.policies = content ? content.policies : [];
   }
 
   get kuzzle () {
@@ -21,7 +22,10 @@ class Profile {
     if (!this.policies || this.policies.length === 0) {
       return Promise.resolve([]);
     }
-    return this.kuzzle.security.mGetRoles(this.policies.map(policy => policy.roleId), options);
+
+    return this.kuzzle.security.mGetRoles(
+      this.policies.map(policy => policy.roleId),
+      options);
   }
 }
 

--- a/src/core/security/Profile.js
+++ b/src/core/security/Profile.js
@@ -7,8 +7,8 @@ class Profile {
   constructor (kuzzle, _id = null, content = null) {
     this._kuzzle = kuzzle;
     this._id = _id;
-    this.rateLimit = content ? content.rateLimit : 0;
-    this.policies = content ? content.policies : [];
+    this.rateLimit = content && content.rateLimit ? content.rateLimit : 0;
+    this.policies = content && content.policies ? content.policies : [];
   }
 
   get kuzzle () {

--- a/test/controllers/security.test.js
+++ b/test/controllers/security.test.js
@@ -1,13 +1,12 @@
-const
-  SecurityController = require('../../src/controllers/Security'),
-  Profile = require('../../src/core/security/Profile'),
-  Role = require('../../src/core/security/Role'),
-  User = require('../../src/core/security/User'),
-  ProfileSearchResult = require('../../src/core/searchResult/Profile'),
-  RoleSearchResult = require('../../src/core/searchResult/Role'),
-  UserSearchResult = require('../../src/core/searchResult/User'),
-  sinon = require('sinon'),
-  should = require('should');
+const SecurityController = require('../../src/controllers/Security');
+const Profile = require('../../src/core/security/Profile');
+const Role = require('../../src/core/security/Role');
+const User = require('../../src/core/security/User');
+const ProfileSearchResult = require('../../src/core/searchResult/Profile');
+const RoleSearchResult = require('../../src/core/searchResult/Role');
+const UserSearchResult = require('../../src/core/searchResult/User');
+const sinon = require('sinon');
+const should = require('should');
 
 describe('Security Controller', () => {
   const options = {opt: 'in'};

--- a/test/core/security/profile.test.js
+++ b/test/core/security/profile.test.js
@@ -1,23 +1,53 @@
-const
-  Profile = require('../../../src/core/security/Profile'),
-  sinon = require('sinon'),
-  should = require('should');
+const Profile = require('../../../src/core/security/Profile');
+const sinon = require('sinon');
+const should = require('should');
 
 describe('Profile', () => {
-  let profile;
+  let kuzzleMock;
 
   beforeEach(() => {
-    profile = new Profile({
+    kuzzleMock = {
       security: {
         mGetRoles: sinon.stub().resolves([
           {_id: 'role1', controllers: ['foo', 'bar']},
           {_id: 'role2', controllers: ['foo', 'baz']}
         ])
       }
+    };
+  });
+
+  describe('profile class', () => {
+    it('should initialize empty profile with the correct default values', () => {
+      const profile = new Profile(kuzzleMock);
+
+      should(profile._id).be.null();
+      should(profile.policies).be.Array().and.be.empty();
+      should(profile.rateLimit).eql(0);
+    });
+
+    it('should initialize itself properly from a Kuzzle profile document', () => {
+      const policies = [
+        { oh: 'noes' },
+        { foo: 'bar' },
+      ];
+      const profile = new Profile(kuzzleMock, 'foo', {
+        policies,
+        rateLimit: 123,
+      });
+
+      should(profile._id).eql('foo');
+      should(profile.policies).eql(policies);
+      should(profile.rateLimit).eql(123);
     });
   });
 
   describe('getRoles', () => {
+    let profile;
+
+    beforeEach(() => {
+      profile = new Profile(kuzzleMock);
+    });
+
     it('should return a Promise which resolves to an empty array if no profile is attached', () => {
       return profile.getRoles()
         .then(roles => {

--- a/test/core/security/profile.test.js
+++ b/test/core/security/profile.test.js
@@ -17,10 +17,18 @@ describe('Profile', () => {
   });
 
   describe('profile class', () => {
-    it('should initialize empty profile with the correct default values', () => {
+    it('should initialize a null profile with the correct default values', () => {
       const profile = new Profile(kuzzleMock);
 
       should(profile._id).be.null();
+      should(profile.policies).be.Array().and.be.empty();
+      should(profile.rateLimit).eql(0);
+    });
+
+    it('should initialize an empty profile with the correct default values', () => {
+      const profile = new Profile(kuzzleMock, 'foo', {});
+
+      should(profile._id).eql('foo');
       should(profile.policies).be.Array().and.be.empty();
       should(profile.rateLimit).eql(0);
     });


### PR DESCRIPTION
# Description

Profile contents returned by Kuzzle now have a `rateLimit` property which was missing from Profile objects returned by this SDK.

This PR adds that missing property to Profile objects.

# Boyscout

* code wrap
* one var per const/let