### PR TITLE
Avoid to mutate user options

### DIFF
--- a/src/controllers/Collection.js
+++ b/src/controllers/Collection.js
@@ -77,8 +77,6 @@ class CollectionController extends BaseController {
       size: options.size || 0,
       from: options.from
     };
-    delete options.from;
-    delete options.size;
 
     return this.query(request, options)
       .then(response => response.result);
@@ -92,8 +90,6 @@ class CollectionController extends BaseController {
 
     for (const opt of ['from', 'size', 'scroll']) {
       request[opt] = options[opt];
-
-      delete options[opt];
     }
 
     return this.query(request, options)

--- a/src/controllers/Document.js
+++ b/src/controllers/Document.js
@@ -182,8 +182,8 @@ class DocumentController extends BaseController {
 
   search (index, collection, body = {}, options = {}) {
     return this._search(index, collection, body, options)
-      .then(({ response, request }) => (
-        new DocumentSearchResult(this.kuzzle, request, options, response.result)
+      .then(({ response, request, opts }) => (
+        new DocumentSearchResult(this.kuzzle, request, opts, response.result)
       ));
   }
 
@@ -197,15 +197,12 @@ class DocumentController extends BaseController {
 
     for (const opt of ['from', 'size', 'scroll']) {
       request[opt] = options[opt];
-      delete options[opt];
     }
 
-    if (!options.verb) {
-      options.verb = 'POST';
-    }
+    const opts = { verb: 'POST', ...options };
 
-    return this.query(request, options)
-      .then(response => ({ response, request }));
+    return this.query(request, opts)
+      .then(response => ({ response, request, opts }));
   }
 
   update (index, collection, _id, body, options = {}) {
@@ -218,8 +215,6 @@ class DocumentController extends BaseController {
       retryOnConflict: options.retryOnConflict,
       source: options.source
     };
-    delete options.source;
-    delete options.retryOnConflict;
 
     return this.query(request, options)
       .then(response => response.result);

--- a/src/controllers/Security.js
+++ b/src/controllers/Security.js
@@ -400,7 +400,6 @@ class SecurityController extends BaseController {
     };
     for (const opt of ['from', 'size', 'scroll']) {
       request[opt] = options[opt];
-      delete options[opt];
     }
 
     return this.query(request, options)
@@ -414,7 +413,6 @@ class SecurityController extends BaseController {
     };
     for (const opt of ['from', 'size']) {
       request[opt] = options[opt];
-      delete options[opt];
     }
 
     return this.query(request, options)
@@ -428,7 +426,6 @@ class SecurityController extends BaseController {
     };
     for (const opt of ['from', 'size', 'scroll']) {
       request[opt] = options[opt];
-      delete options[opt];
     }
 
     return this.query(request, options)

--- a/src/controllers/Server.js
+++ b/src/controllers/Server.js
@@ -23,15 +23,7 @@ class ServerController extends BaseControler {
     return this.query({
       action: 'adminExists'
     }, options)
-      .then(response => {
-        if (typeof response.result !== 'object' || typeof response.result.exists !== 'boolean') {
-          const error = new Error('adminExists: bad response format');
-          error.status = 400;
-          error.response = response;
-          return Promise.reject(error);
-        }
-        return response.result.exists;
-      });
+      .then(response => response.result.exists);
   }
 
 
@@ -114,15 +106,7 @@ class ServerController extends BaseControler {
     return this.query({
       action: 'now'
     }, options)
-      .then(response => {
-        if (typeof response.result !== 'object' || typeof response.result.now !== 'number') {
-          const error = new Error('now: bad response format');
-          error.status = 400;
-          error.response = response;
-          return Promise.reject(error);
-        }
-        return response.result.now;
-      });
+      .then(response => response.result.now);
   }
 }
 

--- a/test/controllers/collection.test.js
+++ b/test/controllers/collection.test.js
@@ -263,7 +263,7 @@ describe('Collection Controller', () => {
               from: 3,
               size: 42,
               scroll: 'scroll'
-            }, {foo: 'bar'});
+            }, { foo: 'bar', from: 3, scroll: 'scroll', size: 42 });
 
           should(res).be.an.instanceOf(SpecificationsSearchResult);
           should(res._request).match({

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -394,7 +394,8 @@ describe('Document Controller', () => {
             }, options);
 
           should(res).be.an.instanceOf(DocumentSearchResult);
-          should(res._options).be.equal(options);
+          should(res._options).match(options);
+          should(res._options.verb).be.eql('POST');
           should(res._response).be.equal(result);
           should(res.fetched).be.equal(3);
           should(res.total).be.equal(3);
@@ -527,7 +528,7 @@ describe('Document Controller', () => {
               body: {foo: 'bar'},
               retryOnConflict: true,
               source: undefined
-            }, {});
+            }, { retryOnConflict: true });
 
           should(res).be.equal(result);
         });
@@ -555,7 +556,7 @@ describe('Document Controller', () => {
               body: { foo: 'bar' },
               retryOnConflict: undefined,
               source: true
-            }, {});
+            }, { source: true });
 
           should(res).be.equal(result);
         });

--- a/test/controllers/security.test.js
+++ b/test/controllers/security.test.js
@@ -1014,10 +1014,9 @@ describe('Security Controller', () => {
               from: 1,
               size: 2,
               scroll: '10s'
-            }, {});
+            }, { from: 1, scroll: '10s', size: 2 });
 
           should(res).be.an.instanceOf(ProfileSearchResult);
-          should(res._options).be.empty();
           should(res._response).be.equal(result);
           should(res.fetched).be.equal(2);
           should(res.total).be.equal(3);
@@ -1077,10 +1076,9 @@ describe('Security Controller', () => {
               body: {controllers: ['foo', 'bar']},
               from: 1,
               size: 2
-            }, {});
+            }, { from: 1, size: 2 });
 
           should(res).be.an.instanceOf(RoleSearchResult);
-          should(res._options).be.empty();
           should(res._response).be.equal(result);
           should(res.fetched).be.equal(2);
           should(res.total).be.equal(3);
@@ -1142,10 +1140,9 @@ describe('Security Controller', () => {
               from: 1,
               size: 2,
               scroll: '10s'
-            }, {});
+            }, { from: 1, scroll: '10s', size: 2 });
 
           should(res).be.an.instanceOf(UserSearchResult);
-          should(res._options).be.empty();
           should(res._response).be.equal(result);
           should(res.fetched).be.equal(2);
           should(res.total).be.equal(3);

--- a/test/controllers/server.test.js
+++ b/test/controllers/server.test.js
@@ -47,21 +47,6 @@ describe('Server Controller', () => {
         });
     });
 
-    it('should reject the promise if receiving a response in bad format (missing result)', () => {
-      kuzzle.query.resolves({foo: 'bar'});
-      return should(kuzzle.server.adminExists()).be.rejectedWith({status: 400, message: 'adminExists: bad response format'});
-    });
-
-    it('should reject the promise if receiving a response in bad format (missing "exists" attribute)', () => {
-      kuzzle.query.resolves({result: {foo: 'bar'}});
-      return should(kuzzle.server.adminExists()).be.rejectedWith({status: 400, message: 'adminExists: bad response format'});
-    });
-
-    it('should reject the promise if receiving a response in bad format (bad type of "exists" attribute)', () => {
-      kuzzle.query.resolves({result: {exists: 'foobar'}});
-      return should(kuzzle.server.adminExists()).be.rejectedWith({status: 400, message: 'adminExists: bad response format'});
-    });
-
     it('should reject the promise if an error occurs', () => {
       const error = new Error('foobar error');
       error.status = 412;
@@ -425,21 +410,6 @@ describe('Server Controller', () => {
           should(kuzzle.query).be.calledWith(expectedQuery, {queuable: false});
           should(res).be.exactly(12345);
         });
-    });
-
-    it('should reject the promise if receiving a response in bad format (missing result)', () => {
-      kuzzle.query.resolves({foo: 'bar'});
-      return should(kuzzle.server.now()).be.rejectedWith({status: 400, message: 'now: bad response format'});
-    });
-
-    it('should reject the promise if receiving a response in bad format (missing "now" attribute)', () => {
-      kuzzle.query.resolves({result: {foo: 'bar'}});
-      return should(kuzzle.server.now()).be.rejectedWith({status: 400, message: 'now: bad response format'});
-    });
-
-    it('should reject the promise if receiving a response in bad format (bad type for "now" attribute)', () => {
-      kuzzle.query.resolves({result: {now: 'bar'}});
-      return should(kuzzle.server.now()).be.rejectedWith({status: 400, message: 'now: bad response format'});
     });
 
     it('should reject the promise if an error occurs', () => {


### PR DESCRIPTION
## What does this PR do?

Before this PR we were mutating user options passed to SDK method (eg: `document:search`).  
It could lead to confusion because the user may want to reuse the same options object across different calls.

### How should this be manually tested?

```bash
$ kourou collection:create index collection
```

This code should print `{ from: 0, size: 42 }` two times.

```js
const { Kuzzle, WebSocket } = require('./index')

const kuzzle = new Kuzzle(new WebSocket('localhost'));

(async () => {
  await kuzzle.connect();

  const options = { from: 0, size: 42 }
  console.log(options)
  await kuzzle.document.search('index', 'collection', {}, options)
  console.log(options)

  kuzzle.disconnect();
})();
```

### Other changes

 - remove custom errors when the result of `server:now` or `server:adminExists` is unexpected