### PR TITLE
Fix token expired

### DIFF
--- a/src/Kuzzle.js
+++ b/src/Kuzzle.js
@@ -501,9 +501,6 @@ Discarded request: ${JSON.stringify(request)}`));
 
     this._lastTokenExpired = now;
 
-    this.auth.authenticationToken = null;
-    this.realtime.tokenExpired();
-
     this.emit('tokenExpired');
   }
 

--- a/src/controllers/Auth.js
+++ b/src/controllers/Auth.js
@@ -18,6 +18,10 @@ class AuthController extends BaseController {
     super(kuzzle, 'auth');
 
     this._authenticationToken = null;
+
+    this.kuzzle.on('tokenExpired', () => {
+      this._authenticationToken = null;
+    });
   }
 
   get authenticationToken () {
@@ -27,9 +31,11 @@ class AuthController extends BaseController {
   set authenticationToken (encodedJwt) {
     if (encodedJwt === undefined || encodedJwt === null) {
       this._authenticationToken = null;
-    } else if (typeof encodedJwt === 'string') {
+    }
+    else if (typeof encodedJwt === 'string') {
       this._authenticationToken = new Jwt(encodedJwt);
-    } else {
+    }
+    else {
       throw new Error(`Invalid token argument: ${encodedJwt}`);
     }
   }

--- a/src/controllers/Realtime.js
+++ b/src/controllers/Realtime.js
@@ -11,6 +11,8 @@ class RealTimeController extends BaseController {
 
     this.subscriptions = {};
     this.subscriptionsOff = {};
+
+    this.kuzzle.on('tokenExpired', () => this.tokenExpired());
   }
 
   count (roomId, options = {}) {

--- a/src/protocols/abstract/Base.js
+++ b/src/protocols/abstract/Base.js
@@ -98,7 +98,7 @@ Discarded request: ${JSON.stringify(request)}`));
 
         this.emit('queryError', error, request);
 
-        if (request.action !== 'logout' && error.message === 'Token expired') {
+        if (request.action !== 'logout' && error.id === 'security.token.invalid') {
           this.emit('tokenExpired');
         }
 

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -119,7 +119,7 @@ describe('Common Protocol', () => {
         eventStub = sinon.stub(),
         response = {
           error: {
-            message: 'Token expired'
+            id: 'security.token.invalid'
           }
         };
 


### PR DESCRIPTION
## What does this PR do?

Since we use the error code it's better to rely on the error `id` instead of the message.  
The error message when the token has expired has changed and so the corresponding event was not trigger anymore.

This PR fix this by using the error `id` instead.

### How should this be manually tested?

```js
const {
  Kuzzle,
  Http
} = require('./index')

const kuzzle = new Kuzzle(new Http('localhost'))

kuzzle.on('networkError', console.error);

kuzzle.on('tokenExpired', () => {
  console.log('Expired')
});
(async () => {
  await kuzzle.connect()

  await kuzzle.security.createUser('admin', {
    content: { profileIds: [ 'default' ] },
    credentials: { local: { username: 'admin', password: 'admin' } }
  });
  await kuzzle.auth.login('local', { username: 'admin', password: 'admin' }, '2s')

  setTimeout(async () => {
    try {
      await kuzzle.server.now()

    }
    catch (error) {
      console.log(error)
    }
  }, 3000)
})();

```

### Other changes

 - use `tokenExpired` event in Realtime and Auth controller instead of directly calling the methods from Kuzzle object
