### PR TITLE
Add collection:update and deprecate collection:updateMapping

### DIFF
--- a/doc/7/controllers/collection/update-mapping/index.md
+++ b/doc/7/controllers/collection/update-mapping/index.md
@@ -7,8 +7,8 @@ description: Update the collection mapping
 
 # updateMapping
 
-<SinceBadge version="1.7.1" />
-<DeprecatedBadge version="2.1.0"/>
+<SinceBadge version="Kuzzle 1.7.1" />
+<DeprecatedBadge version="Kuzzle 2.1.0"/>
 
 __Use [collection:update](/sdk/js/7/controllers/collection/update/) instead.__
 

--- a/doc/7/controllers/collection/update/index.md
+++ b/doc/7/controllers/collection/update/index.md
@@ -1,16 +1,13 @@
 ---
 code: true
 type: page
-title: updateMapping
+title: update
 description: Update the collection mapping
 ---
 
-# updateMapping
+# update
 
-<SinceBadge version="1.7.1" />
-<DeprecatedBadge version="2.1.0"/>
-
-__Use [collection:update](/sdk/js/7/controllers/collection/update/) instead.__
+<SinceBadge version="Kuzzle 2.1.0" />
 
 You can define the collection [dynamic mapping policy](/core/2/guides/essentials/database-mappings#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
 
@@ -19,7 +16,7 @@ You can define [collection additional metadata](/core/2/guides/essentials/databa
 <br/>
 
 ```js
-updateMapping(index, collection, mapping, [options]);
+update(index, collection, mapping);
 ```
 
 <br/>
@@ -29,7 +26,6 @@ updateMapping(index, collection, mapping, [options]);
 | `index`      | <pre>string</pre> | Index name                                                                                                                                                                    |
 | `collection` | <pre>string</pre> | Collection name                                                                                                                                                               |
 | `mapping`    | <pre>object</pre> | Describes the collection mapping  |
-| `options`    | <pre>object</pre> | Query options                                                                                                                                                                 |
 
 ### mapping
 
@@ -52,18 +48,10 @@ const mapping = {
 
 More informations about database mappings [here](/core/2/guides/essentials/database-mappings).
 
-### options
-
-Additional query options
-
-| Property   | Type<br/>(default)              | Description                                                                  |
-| ---------- | ------------------------------- | ---------------------------------------------------------------------------- |
-| `queuable` | <pre>boolean</pre><br/>(`true`) | If true, queues the request during downtime, until connected to Kuzzle again |
-
 ## Resolves
 
 Resolve if the collection is successfully updated.
 
 ## Usage
 
-<<< ./snippets/update-mapping.js
+<<< ./snippets/update.js

--- a/doc/7/controllers/collection/update/snippets/update.js
+++ b/doc/7/controllers/collection/update/snippets/update.js
@@ -1,0 +1,17 @@
+const mapping = {
+  dynamic: 'false',
+  _meta: {
+    area: 'Panipokhari'
+  },
+  properties: {
+    plate: { type: 'keyword' }
+  }
+};
+
+try {
+  await kuzzle.collection.update('nyc-open-data', 'yellow-taxi', mapping);
+
+  console.log('Success');
+} catch (error) {
+  console.error(error.message);
+}

--- a/doc/7/controllers/collection/update/snippets/update.test.yml
+++ b/doc/7/controllers/collection/update/snippets/update.test.yml
@@ -1,0 +1,10 @@
+name: collection#update
+description: Update the collection mapping
+hooks:
+  before: curl -X POST kuzzle:7512/nyc-open-data/_create && curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
+  after:
+template: default
+expected: Success
+
+sdk: js
+version: 7

--- a/src/controllers/Collection.js
+++ b/src/controllers/Collection.js
@@ -106,6 +106,17 @@ class CollectionController extends BaseController {
       .then(response => response.result);
   }
 
+  update(index, collection, body) {
+    return this.query({
+      index,
+      collection,
+      body,
+      action: 'update'
+    })
+      .then(response => response.result);
+  }
+
+  // @deprecated
   updateMapping (index, collection, body, options = {}) {
     return this.query({
       index,

--- a/src/protocols/routes.json
+++ b/src/protocols/routes.json
@@ -324,6 +324,10 @@
     }
   },
   "collection": {
+    "update": {
+      "url": "/:index/:collection/",
+      "verb": "POST"
+    },
     "updateMapping": {
       "url": "/:index/:collection/_mapping",
       "verb": "PUT"

--- a/test/controllers/collection.test.js
+++ b/test/controllers/collection.test.js
@@ -328,6 +328,28 @@ describe('Collection Controller', () => {
     });
   });
 
+  describe('update', () => {
+    it('should call collection/update query with the new mapping and return a Promise which resolves a json object', () => {
+      kuzzle.query.resolves({ result: { foo: 'bar' } });
+
+      const body = { foo: 'bar' };
+      return kuzzle.collection.update('index', 'collection', body)
+        .then(res => {
+          should(kuzzle.query)
+            .be.calledOnce()
+            .be.calledWith({
+              body,
+              controller: 'collection',
+              action: 'update',
+              index: 'index',
+              collection: 'collection'
+            });
+
+          should(res).match({ foo: 'bar' });
+        });
+    });
+  });
+
   describe('updateSpecifications', () => {
     it('should call collection/updateSpecifications query with the new specifications and return a Promise which resolves a json object', () => {
       kuzzle.query.resolves({ result: { foo: 'bar' } });


### PR DESCRIPTION
## What does this PR do?

This PR adds `collection:update` to the sdk and deprecates the older `collection:updateMapping`.

### How should this be manually tested?

Create an index/collection and update its mapping by calling the `collection:update` method
Tests
