### PR TITLE
Hide kuzzle object from console.log

### DIFF
--- a/doc/7/controllers/security/m-get-profiles/snippets/m-get-profiles.test.yml
+++ b/doc/7/controllers/security/m-get-profiles/snippets/m-get-profiles.test.yml
@@ -12,4 +12,4 @@ hooks:
       curl -XDELETE kuzzle:7512/profiles/profile${i}
     done
 template: default
-expected: '^    policies: \[ \[Object\] \] } \]$'
+expected: '^\w+policies:\w+\[\w+\[Object\]\w+\]\w+}\w+\]$'

--- a/doc/7/controllers/security/m-get-profiles/snippets/m-get-profiles.test.yml
+++ b/doc/7/controllers/security/m-get-profiles/snippets/m-get-profiles.test.yml
@@ -12,4 +12,4 @@ hooks:
       curl -XDELETE kuzzle:7512/profiles/profile${i}
     done
 template: default
-expected: '^\w+policies:\w+\[\w+\[Object\]\w+\]\w+}\w+\]$'
+expected: '.*Profile.*_id.*rateLimit.*policies.*'

--- a/doc/7/controllers/security/m-get-roles/snippets/m-get-roles.test.yml
+++ b/doc/7/controllers/security/m-get-roles/snippets/m-get-roles.test.yml
@@ -18,4 +18,4 @@ hooks:
       curl -XDELETE kuzzle:7512/roles/role${i}
     done
 template: default
-expected: '^    _id: ''role3'',$'
+expected: '.*Role.*_id.*controllers.*'

--- a/doc/7/controllers/security/m-get-users/snippets/m-get-users.test.yml
+++ b/doc/7/controllers/security/m-get-users/snippets/m-get-users.test.yml
@@ -21,4 +21,4 @@ hooks:
       curl -XDELETE kuzzle:7512/users/user${i}
     done
 template: default
-expected: '.*User.*_id.*profiles.*'
+expected: '.*User.*_id.*content.*'

--- a/doc/7/controllers/security/m-get-users/snippets/m-get-users.test.yml
+++ b/doc/7/controllers/security/m-get-users/snippets/m-get-users.test.yml
@@ -21,4 +21,4 @@ hooks:
       curl -XDELETE kuzzle:7512/users/user${i}
     done
 template: default
-expected: '.*User.*_id.*content.*'
+expected: '.*User.*'

--- a/doc/7/controllers/security/m-get-users/snippets/m-get-users.test.yml
+++ b/doc/7/controllers/security/m-get-users/snippets/m-get-users.test.yml
@@ -21,4 +21,4 @@ hooks:
       curl -XDELETE kuzzle:7512/users/user${i}
     done
 template: default
-expected: '^    _id: ''user3'',$'
+expected: '.*User.*_id.*profiles.*'

--- a/src/controllers/Base.js
+++ b/src/controllers/Base.js
@@ -5,7 +5,10 @@ class BaseController {
    * @param {string} name - Controller full name for API request.
    */
   constructor (kuzzle, name) {
-    this._kuzzle = kuzzle;
+    Reflect.defineProperty(this, '_kuzzle', {
+      value: kuzzle
+    });
+
     this._name = name;
   }
 

--- a/src/controllers/MemoryStorage.js
+++ b/src/controllers/MemoryStorage.js
@@ -237,7 +237,6 @@ for (const action of Object.keys(commands)) {
         for (const opt of command.opts) {
           if (options[opt] !== null && options[opt] !== undefined) {
             assignParameter(request, command.getter, opt, options[opt]);
-            delete options[opt];
           }
         }
       }
@@ -296,7 +295,6 @@ function assignGeoRadiusOptions(data, options) {
     .forEach(function (opt) {
       if (opt === 'withcoord' || opt === 'withdist') {
         parsed.push(opt);
-        delete options[opt];
       }
       else if (opt === 'count' || opt === 'sort') {
         if (opt === 'count') {
@@ -305,8 +303,6 @@ function assignGeoRadiusOptions(data, options) {
 
         parsed.push(options[opt]);
       }
-
-      delete options[opt];
     });
 
   if (parsed.length > 0) {
@@ -327,7 +323,6 @@ function assignZrangeOptions (data, options) {
 
   if (options.limit) {
     data.limit = options.limit;
-    delete options.limit;
   }
 }
 

--- a/src/controllers/Realtime.js
+++ b/src/controllers/Realtime.js
@@ -49,22 +49,23 @@ class RealTimeController extends BaseController {
   }
 
   unsubscribe (roomId, options = {}) {
-    const rooms = this.subscriptions.get(roomId);
-
-    if (!rooms) {
-      return Promise.reject(new Error(`not subscribed to ${roomId}`));
-    }
-
-    for (const room of rooms) {
-      room.removeListeners();
-    }
-    this.subscriptions.delete(roomId);
-
-    return this.query({
+    const request = {
       action: 'unsubscribe',
-      body: {roomId}
-    }, options)
+      body: { roomId }
+    };
+
+    return this.query(request, options)
       .then(response => {
+        const rooms = this.subscriptions.get(roomId);
+
+        if (rooms) {
+          for (const room of rooms) {
+            room.removeListeners();
+          }
+
+          this.subscriptions.delete(roomId);
+        }
+
         return response.result;
       });
   }

--- a/src/controllers/Realtime.js
+++ b/src/controllers/Realtime.js
@@ -28,7 +28,8 @@ class RealTimeController extends BaseController {
       index,
       collection,
       body: message,
-      action: 'publish'
+      action: 'publish',
+      _id: options._id
     };
 
     return this.query(request, options)

--- a/src/controllers/Security.js
+++ b/src/controllers/Security.js
@@ -99,7 +99,6 @@ class SecurityController extends BaseController {
       action: 'createFirstAdmin',
       reset: options.reset
     };
-    delete options.reset;
 
     return this.query(request, options)
       .then(response => new User(this.kuzzle, response.result._id, response.result._source));

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -25,12 +25,13 @@ class Room {
       collection,
       body,
       controller: 'realtime',
-      action: 'subscribe'
+      action: 'subscribe',
+      state: this.options.state,
+      scope: this.options.scope,
+      users: this.options.users,
+      volatile: this.options.volatile,
+      cluster: this.options.cluster
     };
-    for (const opt of ['state', 'scope', 'users', 'volatile']) {
-      this.request[opt] = this.options[opt];
-      delete this.options[opt];
-    }
 
     this.autoResubscribe = typeof options.autoResubscribe === 'boolean'
       ? options.autoResubscribe
@@ -38,10 +39,6 @@ class Room {
     this.subscribeToSelf = typeof options.subscribeToSelf === 'boolean'
       ? options.subscribeToSelf
       : true;
-
-    for (const opt of ['autoResubscribe', 'subscribeToSelf']) {
-      delete this.options[opt];
-    }
 
     // force bind for further event listener calls
     this._channelListener = this._channelListener.bind(this);

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -29,9 +29,7 @@ class Room {
       state: this.options.state,
       scope: this.options.scope,
       users: this.options.users,
-      volatile: this.options.volatile,
-      // the "cluster" option is meant to be used by the embedded plugin SDK only
-      cluster: this.options.cluster
+      volatile: this.options.volatile
     };
 
     this.autoResubscribe = typeof options.autoResubscribe === 'boolean'

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -30,6 +30,7 @@ class Room {
       scope: this.options.scope,
       users: this.options.users,
       volatile: this.options.volatile,
+      // the "cluster" option is meant to be used by the embedded plugin SDK only
       cluster: this.options.cluster
     };
 

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -9,8 +9,10 @@ class Room {
    * @param {object} options
    */
   constructor (controller, index, collection, body, callback, options = {}) {
+    Reflect.defineProperty(this, '_kuzzle', {
+      value: controller.kuzzle
+    });
     this.controller = controller;
-    this.kuzzle = controller.kuzzle;
     this.index = index;
     this.collection = collection;
     this.callback = callback;
@@ -41,6 +43,10 @@ class Room {
 
     // force bind for further event listener calls
     this._channelListener = this._channelListener.bind(this);
+  }
+
+  get kuzzle () {
+    return this._kuzzle;
   }
 
   subscribe () {

--- a/src/core/searchResult/SearchResultBase.js
+++ b/src/core/searchResult/SearchResultBase.js
@@ -8,10 +8,18 @@ class SearchResultBase {
    * @param {object} response
    */
   constructor (kuzzle, request = {}, options = {}, response = {}) {
-    this._kuzzle = kuzzle;
-    this._request = request;
-    this._response = response;
-    this._options = options;
+    Reflect.defineProperty(this, '_kuzzle', {
+      value: kuzzle
+    });
+    Reflect.defineProperty(this, '_request', {
+      value: request
+    });
+    Reflect.defineProperty(this, '_options', {
+      value: options
+    });
+    Reflect.defineProperty(this, '_response', {
+      value: response
+    });
 
     this._controller = request.controller;
     this._searchAction = 'search';

--- a/src/core/security/Profile.js
+++ b/src/core/security/Profile.js
@@ -5,7 +5,11 @@ class Profile {
    * @param {Object} data
    */
   constructor (kuzzle, _id = null, content = null) {
-    this._kuzzle = kuzzle;
+    Reflect.defineProperty(this, '_kuzzle', {
+      value: kuzzle,
+      writable: true
+    });
+
     this._id = _id;
     this.rateLimit = content && content.rateLimit ? content.rateLimit : 0;
     this.policies = content && content.policies ? content.policies : [];

--- a/src/core/security/Profile.js
+++ b/src/core/security/Profile.js
@@ -6,8 +6,7 @@ class Profile {
    */
   constructor (kuzzle, _id = null, content = null) {
     Reflect.defineProperty(this, '_kuzzle', {
-      value: kuzzle,
-      writable: true
+      value: kuzzle
     });
 
     this._id = _id;

--- a/src/core/security/Role.js
+++ b/src/core/security/Role.js
@@ -5,7 +5,11 @@ class Role {
    * @param {Object} data
    */
   constructor (kuzzle, _id = null, controllers = {}) {
-    this._kuzzle = kuzzle;
+    Reflect.defineProperty(this, '_kuzzle', {
+      value: kuzzle,
+      writable: true
+    });
+
     this._id = _id;
     this.controllers = controllers;
   }

--- a/src/core/security/Role.js
+++ b/src/core/security/Role.js
@@ -6,8 +6,7 @@ class Role {
    */
   constructor (kuzzle, _id = null, controllers = {}) {
     Reflect.defineProperty(this, '_kuzzle', {
-      value: kuzzle,
-      writable: true
+      value: kuzzle
     });
 
     this._id = _id;

--- a/src/core/security/User.js
+++ b/src/core/security/User.js
@@ -6,11 +6,9 @@ class User {
    */
   constructor (kuzzle, _id = null, content = {}) {
     Reflect.defineProperty(this, '_kuzzle', {
-      value: kuzzle,
-      writable: true
+      value: kuzzle
     });
 
-    this._kuzzle = kuzzle;
     this._id = _id;
     this.content = content;
   }

--- a/src/core/security/User.js
+++ b/src/core/security/User.js
@@ -5,6 +5,11 @@ class User {
    * @param {Object} data
    */
   constructor (kuzzle, _id = null, content = {}) {
+    Reflect.defineProperty(this, '_kuzzle', {
+      value: kuzzle,
+      writable: true
+    });
+
     this._kuzzle = kuzzle;
     this._id = _id;
     this.content = content;

--- a/test/controllers/realtime.test.js
+++ b/test/controllers/realtime.test.js
@@ -60,6 +60,7 @@ describe('Realtime Controller', () => {
   describe('#publish', () => {
     it('should call realtime/publish query with the index, collection and body and return a Promise which resolves an acknowledgement', () => {
       kuzzle.query.resolves({result: {published: true}});
+      options._id = 'doc-id';
 
       return kuzzle.realtime.publish('index', 'collection', {foo: 'bar'}, options)
         .then(published => {
@@ -70,7 +71,8 @@ describe('Realtime Controller', () => {
               action: 'publish',
               index: 'index',
               collection: 'collection',
-              body: {foo: 'bar'}
+              body: {foo: 'bar'},
+              _id: 'doc-id'
             }, options);
 
           should(published).be.a.Boolean().and.be.true();

--- a/test/controllers/realtime.test.js
+++ b/test/controllers/realtime.test.js
@@ -178,16 +178,6 @@ describe('Realtime Controller', () => {
       kuzzle.query.resolves({result: roomId});
     });
 
-    it('should reject the promise if the room is not found', () => {
-      return kuzzle.realtime.unsubscribe('bar')
-        .then(() => {
-          throw new Error('Expected Function unsubscribe() to reject');
-        })
-        .catch(err => {
-          should(err.message).be.equal('not subscribed to bar');
-        });
-    });
-
     it('should call removeListeners for each room', () => {
       return kuzzle.realtime.unsubscribe(roomId)
         .then(() => {

--- a/test/controllers/security.test.js
+++ b/test/controllers/security.test.js
@@ -165,7 +165,7 @@ describe('Security Controller', () => {
               controller: 'security',
               action: 'createFirstAdmin',
               reset: true
-            }, {});
+            }, {reset: true});
 
           should(user).be.an.instanceOf(User);
           should(user._id).be.eql('id');

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -61,30 +61,30 @@ describe('Room', () => {
       should(room.request.state).be.undefined();
       should(room.request.users).be.undefined();
       should(room.request.volatile).be.undefined();
+      should(room.request.cluster).be.undefined();
 
       should(room.autoResubscribe).be.equal('default');
       should(room.subscribeToSelf).be.a.Boolean().and.be.True();
     });
 
-    it('should handle scope/state/users/volatile options', () => {
-      const
-        opts = {
-          scope: 'scope',
-          state: 'state',
-          users: 'users',
-          volatile: 'volatile'
-        },
-        body = {foo: 'bar'},
-        cb = sinon.stub();
+    it('should handle scope/state/users/volatile/cluster options', () => {
+      const opts = {
+        scope: 'scope',
+        state: 'state',
+        users: 'users',
+        volatile: 'volatile',
+        cluster: false
+      };
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
 
       const room = new Room(controller, 'index', 'collection', body, cb, opts);
-
-      should(room.options).be.empty();
 
       should(room.request.scope).be.equal('scope');
       should(room.request.state).be.equal('state');
       should(room.request.users).be.equal('users');
       should(room.request.volatile).be.equal('volatile');
+      should(room.request.cluster).be.equal(false);
     });
 
     it('should handle autoResubscribe option', () => {
@@ -103,10 +103,6 @@ describe('Room', () => {
         room3 = new Room(
           controller, 'index', 'collection', body, cb,
           {autoResubscribe: 'foobar'});
-
-      should(room1.options).be.empty();
-      should(room2.options).be.empty();
-      should(room3.options).be.empty();
 
       should(room1.autoResubscribe).be.a.Boolean().and.be.True();
       should(room2.autoResubscribe).be.a.Boolean().and.be.False();
@@ -127,10 +123,6 @@ describe('Room', () => {
         room3 = new Room(
           controller, 'index', 'collection', body, cb,
           {subscribeToSelf: 'foobar'});
-
-      should(room1.options).be.empty();
-      should(room2.options).be.empty();
-      should(room3.options).be.empty();
 
       should(room1.subscribeToSelf).be.a.Boolean().and.be.True();
       should(room2.subscribeToSelf).be.a.Boolean().and.be.False();
@@ -157,7 +149,8 @@ describe('Room', () => {
           scope: 'in',
           state: 'done',
           users: 'all',
-          volatile: {bar: 'foo'}
+          volatile: {bar: 'foo'},
+          cluster: false
         },
         body = {foo: 'bar'},
         cb = sinon.stub(),
@@ -176,8 +169,9 @@ describe('Room', () => {
               scope: 'in',
               state: 'done',
               users: 'all',
-              volatile: {bar: 'foo'}
-            }, options);
+              volatile: {bar: 'foo'},
+              cluster: false
+            }, opts);
 
           should(res).be.equal(response);
         });

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -61,19 +61,17 @@ describe('Room', () => {
       should(room.request.state).be.undefined();
       should(room.request.users).be.undefined();
       should(room.request.volatile).be.undefined();
-      should(room.request.cluster).be.undefined();
 
       should(room.autoResubscribe).be.equal('default');
       should(room.subscribeToSelf).be.a.Boolean().and.be.True();
     });
 
-    it('should handle scope/state/users/volatile/cluster options', () => {
+    it('should handle scope/state/users/volatile options', () => {
       const opts = {
         scope: 'scope',
         state: 'state',
         users: 'users',
-        volatile: 'volatile',
-        cluster: false
+        volatile: 'volatile'
       };
       const body = {foo: 'bar'};
       const cb = sinon.stub();
@@ -84,7 +82,6 @@ describe('Room', () => {
       should(room.request.state).be.equal('state');
       should(room.request.users).be.equal('users');
       should(room.request.volatile).be.equal('volatile');
-      should(room.request.cluster).be.equal(false);
     });
 
     it('should handle autoResubscribe option', () => {
@@ -149,8 +146,7 @@ describe('Room', () => {
           scope: 'in',
           state: 'done',
           users: 'all',
-          volatile: {bar: 'foo'},
-          cluster: false
+          volatile: {bar: 'foo'}
         },
         body = {foo: 'bar'},
         cb = sinon.stub(),
@@ -169,8 +165,7 @@ describe('Room', () => {
               scope: 'in',
               state: 'done',
               users: 'all',
-              volatile: {bar: 'foo'},
-              cluster: false
+              volatile: {bar: 'foo'}
             }, opts);
 
           should(res).be.equal(response);


### PR DESCRIPTION
## What does this PR do?

Use `Reflect` to hide the kuzzle object from log

### Other changes

 - Get ride of every `delete` keyword and use `Map` for RAM caches
 - Do not throw custom error when unsubscribing from unknown room (let Kuzzle trigger it's own documented error)
 - Allows to pass `_id` to `realtime.publish`
