### PR TITLE
Encode URI parameters when using the HTTTP protocol

### DIFF
--- a/features/steps/document.js
+++ b/features/steps/document.js
@@ -334,7 +334,7 @@ Then('the document is successfully deleted', function (cb) {
 
 Then(/^the document is (successfully|not) found$/, function (yesno) {
   should(this.error).be.null();
-  should(this.content.constructor.name).eql('DocumentsSearchResult');
+  should(this.content.constructor.name).eql('DocumentSearchResult');
   should(this.content.total).eql(yesno === 'successfully' ? 1 : 0);
 });
 
@@ -386,7 +386,7 @@ Then('the documents should be retrieved', function () {
 });
 
 Then(/^The search result should have (fetched|a total of) (\d+) documents$/, function (what, number) {
-  should(this.content.constructor.name).eql('DocumentsSearchResult');
+  should(this.content.constructor.name).eql('DocumentSearchResult');
 
   let field;
   switch (what) {

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import { KuzzleAbstractProtocol } from './src/protocols/abstract/Base';
 import { KuzzleEventEmitter } from './src/core/KuzzleEventEmitter';
 
 import { SearchResultBase } from './src/core/searchResult/SearchResultBase';
-import { DocumentsSearchResult } from './src/core/searchResult/Document';
+import { DocumentSearchResult } from './src/core/searchResult/Document';
 import { ProfileSearchResult } from './src/core/searchResult/Profile';
 import { RoleSearchResult } from './src/core/searchResult/Role';
 import { SpecificationSearchResult } from './src/core/searchResult/Specifications';
@@ -29,7 +29,7 @@ const exported = {
   KuzzleAbstractProtocol,
   KuzzleEventEmitter,
   SearchResultBase,
-  DocumentsSearchResult,
+  DocumentSearchResult,
   ProfileSearchResult,
   RoleSearchResult,
   SpecificationSearchResult,

--- a/index.ts
+++ b/index.ts
@@ -10,16 +10,16 @@ if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
 
 import { Kuzzle } from './src/Kuzzle';
 import { Http, WebSocket } from './src/protocols';
-import * as BaseController from './src/controllers/Base';
-import * as KuzzleAbstractProtocol from './src/protocols/abstract/Base';
-import * as KuzzleEventEmitter from './src/core/KuzzleEventEmitter';
+import { BaseController } from './src/controllers/Base';
+import { KuzzleAbstractProtocol } from './src/protocols/abstract/Base';
+import { KuzzleEventEmitter } from './src/core/KuzzleEventEmitter';
 
-import * as SearchResultBase from './src/core/searchResult/SearchResultBase';
-import * as DocumentSearchResult from './src/core/searchResult/Document';
-import * as ProfileSearchResult from './src/core/searchResult/Profile';
-import * as RoleSearchResult from './src/core/searchResult/Role';
-import * as SpecificationSearchResult from './src/core/searchResult/Specifications';
-import * as UserSearchResult from './src/core/searchResult/User';
+import { SearchResultBase } from './src/core/searchResult/SearchResultBase';
+import { DocumentsSearchResult } from './src/core/searchResult/Document';
+import { ProfileSearchResult } from './src/core/searchResult/Profile';
+import { RoleSearchResult } from './src/core/searchResult/Role';
+import { SpecificationSearchResult } from './src/core/searchResult/Specifications';
+import { UserSearchResult } from './src/core/searchResult/User';
 
 const exported = {
   Kuzzle,
@@ -29,7 +29,7 @@ const exported = {
   KuzzleAbstractProtocol,
   KuzzleEventEmitter,
   SearchResultBase,
-  DocumentSearchResult,
+  DocumentsSearchResult,
   ProfileSearchResult,
   RoleSearchResult,
   SpecificationSearchResult,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "prepublishOnly": "npm run build",
-    "test": "npm run --silent lint && npm run unit-testing && npm run functional-testing",
+    "test": "npm run test:lint && npm run test:unit && npm run test:functional",
     "test:unit": "nyc --reporter=text-summary --reporter=lcov mocha",
     "test:functional": "cucumber-js --exit --fail-fast",
     "test:lint": "npm run test:lint:js && npm run test:lint:ts",

--- a/src/controllers/Document.ts
+++ b/src/controllers/Document.ts
@@ -1,6 +1,6 @@
 import { BaseController } from './Base';
 import { SearchResult } from '../core/searchResult/SearchResultBase';
-import { DocumentsSearchResult } from '../core/searchResult/Document';
+import { DocumentSearchResult } from '../core/searchResult/Document';
 import { JSONObject, Document, DocumentHit } from '../utils/interfaces';
 
 export class DocumentController extends BaseController {
@@ -640,7 +640,7 @@ export class DocumentController extends BaseController {
   ): Promise<SearchResult<DocumentHit>> {
     return this._search(index, collection, query, options)
       .then(({ response, request, opts }) => (
-        new DocumentsSearchResult(this.kuzzle, request, opts, response.result)
+        new DocumentSearchResult(this.kuzzle, request, opts, response.result)
       ));
   }
 

--- a/src/core/searchResult/Document.ts
+++ b/src/core/searchResult/Document.ts
@@ -1,7 +1,7 @@
 import { SearchResultBase } from './SearchResultBase';
 import { DocumentHit } from '../../utils/interfaces';
 
-export class DocumentsSearchResult extends SearchResultBase<DocumentHit> {
+export class DocumentSearchResult extends SearchResultBase<DocumentHit> {
   /**
    * @param {Kuzzle} kuzzle
    * @param {object} query
@@ -16,4 +16,4 @@ export class DocumentsSearchResult extends SearchResultBase<DocumentHit> {
   }
 }
 
-module.exports = { DocumentsSearchResult };
+module.exports = { DocumentSearchResult };

--- a/src/protocols/Http.js
+++ b/src/protocols/Http.js
@@ -201,7 +201,7 @@ class HttpProtocol extends KuzzleAbstractProtocol {
         return;
       }
 
-      url = url.replace(regex, '/' + data[ matches[1] ]);
+      url = url.replace(regex, `/${encodeURIComponent(data[matches[1]])}`);
 
       delete(queryArgs[ matches[1] ]);
 
@@ -212,10 +212,11 @@ class HttpProtocol extends KuzzleAbstractProtocol {
     const queryString = [];
 
     for (const key of Object.keys(queryArgs)) {
-      const value = queryArgs[key];
+      let value = queryArgs[key];
+      const encodedKey = encodeURIComponent(key);
 
       if (Array.isArray(value)) {
-        queryString.push(`${key}=${value.join()}`);
+        queryString.push(`${encodedKey}=${encodeURIComponent(value.join())}`);
       }
       else if (typeof value === 'boolean') {
         // In Kuzzle, an optional boolean option is set to true if present in
@@ -223,11 +224,12 @@ class HttpProtocol extends KuzzleAbstractProtocol {
         // As there is no boolean type in querystrings, encoding a boolean
         // option "foo=false" in it will make Kuzzle consider it as truthy.
         if (value === true) {
-          queryString.push(key);
+          queryString.push(encodedKey);
         }
       }
       else {
-        queryString.push(`${key}=${typeof value === 'object' ? JSON.stringify(value) : value}`);
+        value = typeof value === 'object' ? JSON.stringify(value) : value;
+        queryString.push(`${encodedKey}=${encodeURIComponent(value)}`);
       }
     }
 

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -2,7 +2,7 @@ const sinon = require('sinon');
 const should = require('should');
 
 const { DocumentController } = require('../../src/controllers/Document');
-const { DocumentsSearchResult } = require('../../src/core/searchResult/Document');
+const { DocumentSearchResult } = require('../../src/core/searchResult/Document');
 
 describe('Document Controller', () => {
   const options = {opt: 'in'};
@@ -366,7 +366,7 @@ describe('Document Controller', () => {
   });
 
   describe('search', () => {
-    it('should call document/search query and return a Promise which resolves a DocumentsSearchResult instance', () => {
+    it('should call document/search query and return a Promise which resolves a DocumentSearchResult instance', () => {
       const result = {
         scrollId: 'scroll-id',
         hits: [
@@ -394,7 +394,7 @@ describe('Document Controller', () => {
               scroll: undefined
             }, options);
 
-          should(res).be.an.instanceOf(DocumentsSearchResult);
+          should(res).be.an.instanceOf(DocumentSearchResult);
           should(res._options).match(options);
           should(res._options.verb).be.eql('POST');
           should(res._response).be.equal(result);
@@ -403,7 +403,7 @@ describe('Document Controller', () => {
         });
     });
 
-    it('should call document/search query and return a Promise which resolves a DocumentsSearchResult instance', () => {
+    it('should call document/search query and return a Promise which resolves a DocumentSearchResult instance', () => {
       const result = {
         scrollId: 'scroll-id',
         hits: [
@@ -433,7 +433,7 @@ describe('Document Controller', () => {
               scroll: undefined
             }, options);
 
-          should(res).be.an.instanceOf(DocumentsSearchResult);
+          should(res).be.an.instanceOf(DocumentSearchResult);
           should(res._options).match(options);
           should(res._options.verb).be.eql('GET');
           should(res._response).be.equal(result);
@@ -469,7 +469,7 @@ describe('Document Controller', () => {
               scroll: '10s'
             }, {});
 
-          should(res).be.an.instanceOf(DocumentsSearchResult);
+          should(res).be.an.instanceOf(DocumentSearchResult);
           should(res._options).match({ verb: 'POST' });
           should(res._response).be.equal(result);
           should(res.fetched).be.equal(2);

--- a/test/core/searchResult/document.test.js
+++ b/test/core/searchResult/document.test.js
@@ -1,9 +1,9 @@
 const sinon = require('sinon');
 const should = require('should');
 
-const { DocumentsSearchResult } = require('../../../src/core/searchResult/Document');
+const { DocumentSearchResult } = require('../../../src/core/searchResult/Document');
 
-describe('DocumentsSearchResult', () => {
+describe('DocumentSearchResult', () => {
   const options = {opt: 'in'};
 
   let
@@ -31,7 +31,7 @@ describe('DocumentsSearchResult', () => {
   });
 
   describe('constructor', () => {
-    it('should create a DocumentsSearchResult instance with good properties', () => {
+    it('should create a DocumentSearchResult instance with good properties', () => {
       response = {
         hits: [
           {_id: 'document1', _score: 0.9876, _source: {foo: 'bar'}},
@@ -40,7 +40,7 @@ describe('DocumentsSearchResult', () => {
         total: 3
       };
 
-      searchResult = new DocumentsSearchResult(kuzzle, request, options, response);
+      searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
       should(searchResult._request).be.equal(request);
       should(searchResult._options).be.equal(options);
@@ -67,7 +67,7 @@ describe('DocumentsSearchResult', () => {
         total: 2
       };
 
-      searchResult = new DocumentsSearchResult(kuzzle, request, options, response);
+      searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
       return searchResult.next()
         .then(result => {
@@ -87,7 +87,7 @@ describe('DocumentsSearchResult', () => {
         total: 30
       };
 
-      searchResult = new DocumentsSearchResult(kuzzle, request, options, response);
+      searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
       return should(searchResult.next())
         .be.rejectedWith('Unable to retrieve next results from search: missing scrollId, from/sort, or from/size params');
@@ -116,12 +116,12 @@ describe('DocumentsSearchResult', () => {
           aggregations: 'aggregations',
           total: 30
         };
-        searchResult = new DocumentsSearchResult(kuzzle, request, options, response);
+        searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call document/scroll action with scrollId parameter and resolve to a new DocumentsSearchResult', () => {
+      it('should call document/scroll action with scrollId parameter and resolve to a new DocumentSearchResult', () => {
         return searchResult.next()
           .then(nextSearchResult => {
             should(kuzzle.query)
@@ -133,7 +133,7 @@ describe('DocumentsSearchResult', () => {
                 scrollId: 'scroll-id'
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);
-            should(nextSearchResult).be.instanceOf(DocumentsSearchResult);
+            should(nextSearchResult).be.instanceOf(DocumentSearchResult);
           });
       });
 
@@ -175,12 +175,12 @@ describe('DocumentsSearchResult', () => {
           aggregations: 'aggregations',
           total: 30
         };
-        searchResult = new DocumentsSearchResult(kuzzle, request, options, response);
+        searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
         kuzzle.query.resolves({result: nextResponse});
       });
 
-      it('should call document/search action with search_after parameter and resolve to a new DocumentsSearchResult', () => {
+      it('should call document/search action with search_after parameter and resolve to a new DocumentSearchResult', () => {
         return searchResult.next()
           .then(nextSearchResult => {
             should(kuzzle.query)
@@ -200,7 +200,7 @@ describe('DocumentsSearchResult', () => {
                 size: 2
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);
-            should(nextSearchResult).be.instanceOf(DocumentsSearchResult);
+            should(nextSearchResult).be.instanceOf(DocumentSearchResult);
           });
       });
 
@@ -219,7 +219,7 @@ describe('DocumentsSearchResult', () => {
 
       it('should reject with an error if the sort is invalid', () => {
         request.body.sort = [];
-        searchResult = new DocumentsSearchResult(kuzzle, request, options, response);
+        searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
         return should(searchResult.next())
           .be.rejected();
@@ -227,7 +227,7 @@ describe('DocumentsSearchResult', () => {
 
       it('should reject if the sort combination does not allow to retrieve all the documents', () => {
         response.hits = [];
-        searchResult = new DocumentsSearchResult(kuzzle, request, options, response);
+        searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
         return should(searchResult.next())
           .be.rejected();
@@ -256,7 +256,7 @@ describe('DocumentsSearchResult', () => {
           aggregations: 'aggregations',
           total: 30
         };
-        searchResult = new DocumentsSearchResult(kuzzle, request, options, response);
+        searchResult = new DocumentSearchResult(kuzzle, request, options, response);
 
         kuzzle.query.resolves({result: nextResponse});
       });
@@ -273,7 +273,7 @@ describe('DocumentsSearchResult', () => {
       });
 
 
-      it('should call document/search action with from/size parameters and resolve to a new DocumentsSearchResult', () => {
+      it('should call document/search action with from/size parameters and resolve to a new DocumentSearchResult', () => {
         return searchResult.next()
           .then(nextSearchResult => {
             should(kuzzle.query)
@@ -288,7 +288,7 @@ describe('DocumentsSearchResult', () => {
                 from: 2
               }, options);
             should(nextSearchResult).not.be.equal(searchResult);
-            should(nextSearchResult).be.instanceOf(DocumentsSearchResult);
+            should(nextSearchResult).be.instanceOf(DocumentSearchResult);
           });
       });
 

--- a/test/protocol/Http.test.js
+++ b/test/protocol/Http.test.js
@@ -1,9 +1,9 @@
-const
-  proxyquire = require('proxyquire'),
-  should = require('should'),
-  sinon = require('sinon'),
-  staticHttpRoutes = require('../../src/protocols/routes.json'),
-  Http = require('../../src/protocols/Http');
+const proxyquire = require('proxyquire');
+const should = require('should');
+const sinon = require('sinon');
+
+const staticHttpRoutes = require('../../src/protocols/routes.json');
+const Http = require('../../src/protocols/Http');
 
 describe('HTTP networking module', () => {
   let protocol;
@@ -216,24 +216,29 @@ describe('HTTP networking module', () => {
       };
 
       protocol.on('requestId', () => {
-        should(protocol._sendHttpRequest).be.calledOnce();
+        try {
+          should(protocol._sendHttpRequest).be.calledOnce();
 
-        should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
-        should(protocol._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar');
-        should(protocol._sendHttpRequest.firstCall.args[2]).match({
-          requestId: 'requestId',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          controller: 'foo',
-          action: 'bar',
-          index: 'index',
-          collection: 'collection',
-          meta: 'meta',
-          body: JSON.stringify({foo: 'bar'})
-        });
+          should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
+          should(protocol._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar');
+          should(protocol._sendHttpRequest.firstCall.args[2]).match({
+            requestId: 'requestId',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            controller: 'foo',
+            action: 'bar',
+            index: 'index',
+            collection: 'collection',
+            meta: 'meta',
+            body: JSON.stringify({foo: 'bar'})
+          });
 
-        done();
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
       });
 
       protocol.send(data);
@@ -248,20 +253,25 @@ describe('HTTP networking module', () => {
       };
 
       protocol.on('requestId', () => {
-        should(protocol._sendHttpRequest).be.calledOnce();
+        try {
+          should(protocol._sendHttpRequest).be.calledOnce();
 
-        should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
-        should(protocol._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar');
-        should(protocol._sendHttpRequest.firstCall.args[2]).match({
-          requestId: 'requestId',
-          headers: {
-            authorization: 'Bearer fake-jwt'
-          },
-          controller: 'foo',
-          action: 'bar'
-        });
+          should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
+          should(protocol._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar');
+          should(protocol._sendHttpRequest.firstCall.args[2]).match({
+            requestId: 'requestId',
+            headers: {
+              authorization: 'Bearer fake-jwt'
+            },
+            controller: 'foo',
+            action: 'bar'
+          });
 
-        done();
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
       });
 
       protocol.send(data);
@@ -278,20 +288,25 @@ describe('HTTP networking module', () => {
       };
 
       protocol.on('requestId', () => {
-        should(protocol._sendHttpRequest).be.calledOnce();
+        try {
+          should(protocol._sendHttpRequest).be.calledOnce();
 
-        should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
-        should(protocol._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar');
-        should(protocol._sendHttpRequest.firstCall.args[2]).match({
-          requestId: 'requestId',
-          headers: {
-            'x-kuzzle-volatile': '{"some":"volatile-data"}'
-          },
-          controller: 'foo',
-          action: 'bar'
-        });
+          should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
+          should(protocol._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar');
+          should(protocol._sendHttpRequest.firstCall.args[2]).match({
+            requestId: 'requestId',
+            headers: {
+              'x-kuzzle-volatile': '{"some":"volatile-data"}'
+            },
+            controller: 'foo',
+            action: 'bar'
+          });
 
-        done();
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
       });
 
       protocol.send(data);
@@ -310,7 +325,7 @@ describe('HTTP networking module', () => {
           should(protocol._sendHttpRequest).be.calledOnce();
           should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('GET');
           should(protocol._sendHttpRequest.firstCall.args[1])
-            .be.equal('/foo?foo=bar&baz=oh,an,array');
+            .be.equal(`/foo?foo=bar&baz=${encodeURIComponent('oh,an,array')}`);
           done();
         }
         catch (error) {
@@ -326,7 +341,7 @@ describe('HTTP networking module', () => {
         requestId: 'requestId',
         action: 'action',
         controller: 'getreq',
-        body: { foo: { foofoo: { barbar: 'bar' } }, baz: ['oh', 'an', 'array'] }
+        body: { foo: { foofoo: { barbar: 'bar' } }, '&baz': ['oh', 'an', 'array'] }
       };
 
       protocol.on('requestId', () => {
@@ -334,7 +349,7 @@ describe('HTTP networking module', () => {
           should(protocol._sendHttpRequest).be.calledOnce();
           should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('GET');
           should(protocol._sendHttpRequest.firstCall.args[1])
-            .be.equal('/foo?foo={"foofoo":{"barbar":"bar"}}&baz=oh,an,array');
+            .be.equal(`/foo?foo=${encodeURIComponent('{"foofoo":{"barbar":"bar"}}')}&${encodeURIComponent('&baz')}=${encodeURIComponent('oh,an,array')}`);
           done();
         }
         catch (error) {
@@ -350,14 +365,15 @@ describe('HTTP networking module', () => {
         requestId: 'requestId',
         action: 'bar',
         controller: 'foo',
-        foo: 'bar'
+        'foo?lol': 'bar&baz'
       };
 
       protocol.on('requestId', () => {
         should(protocol._sendHttpRequest).be.calledOnce();
 
         should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
-        should(protocol._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar?foo=bar');
+        should(protocol._sendHttpRequest.firstCall.args[1])
+          .be.equal(`/foo/bar?${encodeURIComponent('foo?lol')}=${encodeURIComponent('bar&baz')}`);
 
         done();
       });
@@ -370,7 +386,7 @@ describe('HTTP networking module', () => {
         requestId: 'requestId',
         controller: 'foo',
         action: 'bar',
-        foo: 'baz'
+        foo: 'baz&qux'
       };
       protocol._routes = {
         foo: {bar: {verb: 'VERB', url: '/foo/bar/:foo'}}
@@ -380,7 +396,8 @@ describe('HTTP networking module', () => {
         should(protocol._sendHttpRequest).be.calledOnce();
 
         should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
-        should(protocol._sendHttpRequest.firstCall.args[1]).be.equal('/foo/bar/baz');
+        should(protocol._sendHttpRequest.firstCall.args[1])
+          .be.equal(`/foo/bar/${encodeURIComponent('baz&qux')}`);
 
         done();
       });
@@ -470,7 +487,7 @@ describe('HTTP networking module', () => {
           should(protocol._sendHttpRequest).be.calledOnce();
           should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
           should(protocol._sendHttpRequest.firstCall.args[1])
-            .be.equal('/foo/bar?foo=bar,baz,qux&qux=123');
+            .be.equal(`/foo/bar?foo=${encodeURIComponent('bar,baz,qux')}&qux=123`);
         }
         catch (error) {
           return done(error);
@@ -488,7 +505,7 @@ describe('HTTP networking module', () => {
         action: 'bar',
         controller: 'foo',
         foo: false,
-        bar: true,
+        '?bar': true,
         qux: 123
       };
 
@@ -497,7 +514,7 @@ describe('HTTP networking module', () => {
           should(protocol._sendHttpRequest).be.calledOnce();
           should(protocol._sendHttpRequest.firstCall.args[0]).be.equal('VERB');
           should(protocol._sendHttpRequest.firstCall.args[1])
-            .be.equal('/foo/bar?bar&qux=123');
+            .be.equal(`/foo/bar?${encodeURIComponent('?bar')}&qux=123`);
         }
         catch (error) {
           return done(error);


### PR DESCRIPTION
# Description

When using the HTTP protocol, URI parameters are sent as-is by the SDK, which leads to invalid URLs sent when parameters contain reserved or unicode characters.

# Changes

* Encode URI keys and values when adding them in the URI
* Encode values when replacing URI placeholders

# Other changes

* Fix an incorrect module exports (e.g. "KuzzleEventEmitter" and other modules were exposed as subobjects)
* The `npm run test` script was outdated: it now uses the renamed npm scripts (i.e. test:* scripts)
* The `DocumentSearchResult` class was renamed `DocumentsSearchResult`, which _might_ be considered a breaking change (and is inconsistent with other *SearchResult object names anyway)