### PR TITLE
Add meaningful stacktrace

### DIFF
--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -11,10 +11,6 @@ export class KuzzleError extends Error {
    */
   public status: number;
   /**
-   * Kuzzle stacktrace (only if NODE_ENV=development)
-   */
-  public backendStack?: string;
-  /**
    * Stacktrace
    */
   public stack: string;
@@ -38,13 +34,18 @@ export class KuzzleError extends Error {
    */
   public count?: number;
 
-  constructor (apiError) {
+  constructor (apiError, stack = null) {
     super(apiError.message);
 
     this.status = apiError.status;
-    if (apiError.stack) {
-      this.backendStack = apiError.stack;
+
+    if (stack) {
+      const lines = stack.split('\n');
+      lines[0] += apiError.message;
+      lines[3] = ' 🡆  ' + lines[3].trimStart();
+      this.stack = lines.join('\n');
     }
+
     this.id = apiError.id;
     this.code = apiError.code;
 

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -11,9 +11,13 @@ export class KuzzleError extends Error {
    */
   public status: number;
   /**
-   * Stacktrace (only if NODE_ENV=development)
+   * Kuzzle stacktrace (only if NODE_ENV=development)
    */
-  public stack?: string;
+  public backendStack?: string;
+  /**
+   * Stacktrace
+   */
+  public stack: string;
   /**
    * Unique ID
    */
@@ -38,7 +42,9 @@ export class KuzzleError extends Error {
     super(apiError.message);
 
     this.status = apiError.status;
-    this.stack = apiError.stack;
+    if (apiError.stack) {
+      this.backendStack = apiError.stack;
+    }
     this.id = apiError.id;
     this.code = apiError.code;
 

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -15,6 +15,10 @@ export class KuzzleError extends Error {
    */
   public stack: string;
   /**
+   * Kuzzle stacktrace (development mode only)
+   */
+  public kuzzleStack?: string;
+  /**
    * Unique ID
    */
   public id: string;
@@ -38,6 +42,11 @@ export class KuzzleError extends Error {
     super(apiError.message);
 
     this.status = apiError.status;
+    if (apiError.stack) {
+      Reflect.defineProperty(this, 'kuzzleStack', {
+        value: apiError.stack
+      });
+    }
 
     if (stack) {
       const lines = stack.split('\n');

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -56,8 +56,6 @@ export abstract class KuzzleAbstractProtocol extends KuzzleEventEmitter {
         this[opt] = options[opt];
       }
     });
-
-    this._stacks = new Map();
   }
 
   get host () {

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -56,6 +56,8 @@ export abstract class KuzzleAbstractProtocol extends KuzzleEventEmitter {
         this[opt] = options[opt];
       }
     });
+
+    this._stacks = new Map();
   }
 
   get host () {
@@ -109,6 +111,8 @@ export abstract class KuzzleAbstractProtocol extends KuzzleEventEmitter {
 Discarded request: ${JSON.stringify(request)}`));
     }
 
+    const stack = Error().stack;
+
     const pending = new PendingRequest(request);
     this._pendingRequests.set(request.requestId, pending);
 
@@ -116,7 +120,7 @@ Discarded request: ${JSON.stringify(request)}`));
       this._pendingRequests.delete(request.requestId);
 
       if (response.error) {
-        const error = new KuzzleError(response.error);
+        const error = new KuzzleError(response.error, stack);
 
         this.emit('queryError', error, request);
 

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -185,7 +185,7 @@ describe('Common Protocol', () => {
           should(error).be.instanceOf(KuzzleError);
           should(error.message).be.eql('foo-bar');
           should(error.status).be.eql(442);
-          should(error.stack).be.eql('you are the bug');
+          should(error.kuzzleStack).be.eql('you are the bug');
         });
     });
 
@@ -209,7 +209,7 @@ describe('Common Protocol', () => {
           should(error).be.instanceOf(KuzzleError);
           should(error.message).be.eql('foo-bar');
           should(error.status).be.eql(206);
-          should(error.stack).be.eql('you are the bug');
+          should(error.kuzzleStack).be.eql('you are the bug');
           should(error.errors).be.an.Array();
           should(error.errors.length).eql(2);
           should(error.count).eql(42);


### PR DESCRIPTION
## What does this PR do?

Keep the stacktrace from the client side instead of using Kuzzle's one

Before
```
NotFoundError: Controller action "valt" not found.
[...Kuzzle internal calls deleted...]
    at Funnel.getController (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:582:28)
    at Funnel.processRequest (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:400:29)
    at /home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:282:23
```

After
```
KuzzleError: Controller action "valt" not found.
    at WebSocketProtocol.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/protocols/abstract/Base.ts:112:19)
    at Proxy.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/Kuzzle.ts:516:26)
 🡆  at run (/home/aschen/projets/kuzzleio/sdk-javascript/test.js:10:30)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

fix #539 

### How should this be manually tested?

```js
const { Kuzzle, WebSocket } = require('./index')

const kuzzle = new Kuzzle(new WebSocket('localhost'))

kuzzle.on('networkError', error => console.log(error));

const run = async () => {
  await kuzzle.connect();
  try {
    console.log(await kuzzle.query({
      controller: 'tests',
      action: 'valt'
    }))
  }
  catch (error) {
    console.log(error)
  }
};

run();
```

