### PR TITLE
Remove "scroll" option from security:searchRoles doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ jobs:
           npm ci
           npm install kuzzle-sdk-v7@$TRAVIS_BUILD_DIR
           cd test/e2e/run-test && npm ci && cd -
-          CYPRESS_RETRIES=5 npm run e2e
+          CYPRESS_RETRIES=5 npm run test:e2e
         fi
 
     - stage: Tests
@@ -116,7 +116,7 @@ jobs:
           npm ci
           npm install kuzzle-sdk-v6@$TRAVIS_BUILD_DIR
           cd test/e2e/run-test && npm ci && cd -
-          CYPRESS_RETRIES=5 npm run e2e
+          CYPRESS_RETRIES=5 npm run test:e2e
         fi
 
     - stage: Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ jobs:
           npm ci
           npm install kuzzle-sdk-v7@$TRAVIS_BUILD_DIR
           cd test/e2e/run-test && npm ci && cd -
-          CYPRESS_RETRIES=5 npm run test:e2e
+          CYPRESS_RETRIES=5 npm run e2e
         fi
 
     - stage: Tests
@@ -116,7 +116,7 @@ jobs:
           npm ci
           npm install kuzzle-sdk-v6@$TRAVIS_BUILD_DIR
           cd test/e2e/run-test && npm ci && cd -
-          CYPRESS_RETRIES=5 npm run test:e2e
+          CYPRESS_RETRIES=5 npm run e2e
         fi
 
     - stage: Tests

--- a/doc/7/controllers/security/search-roles/index.md
+++ b/doc/7/controllers/security/search-roles/index.md
@@ -35,7 +35,6 @@ searchRoles([body], [options]);
 | `queuable` | <pre>boolean</pre><br/>(`true`) | If true, queues the request during downtime, until connected to Kuzzle again                                                                                                                                      |
 | `from`     | <pre>number</pre><br/>(`0`)     | Offset of the first document to fetch                                                                                                                                                                             |
 | `size`     | <pre>number</pre><br/>(`10`)    | Maximum number of documents to retrieve per page                                                                                                                                                                  |
-| `scroll`   | <pre>string</pre><br/>(`""`)    | When set, gets a forward-only cursor having its ttl set to the given value (ie `30s`; cf [elasticsearch time limits](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/common-options.html#time-units)) |
 
 ## Resolves
 


### PR DESCRIPTION
## What does this PR do?

Remove "scroll" option from security:searchRoles doc

## Other change

Change script test name for admin console tests
depends on https://github.com/kuzzleio/kuzzle-admin-console/pull/829
