### PR TITLE
Stick `realtime:unsubscribe` behavior to documentation

### DIFF
--- a/doc/7/getting-started/.react-native/package.json
+++ b/doc/7/getting-started/.react-native/package.json
@@ -7,7 +7,7 @@
     "ios": "node_modules/.bin/expo-cli start --ios",
     "web": "node_modules/.bin/expo-cli start --web",
     "eject": "node_modules/.bin/expo-cli eject",
-    "test": "node_modules/.bin/cypress run --record"
+    "test": "node_modules/.bin/cypress run --record --key $CYPRESS_RECORD_KEY_DOC"
   },
   "dependencies": {
     "cypress": "^3.8.1",

--- a/doc/7/getting-started/.react/with-redux/package.json
+++ b/doc/7/getting-started/.react/with-redux/package.json
@@ -16,7 +16,7 @@
     "postinstall": "if [ ! -f  ../../../../../dist/kuzzle.js ]; then npm run build --prefix ../../../../../;fi && rm -rf ./node_modules/kuzzle-sdk/* && rsync -r --exclude 'getting-started' ../../../../../ ./node_modules/kuzzle-sdk",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "./node_modules/.bin/cypress run --record",
+    "test": "./node_modules/.bin/cypress run --record --key $CYPRESS_RECORD_KEY_DOC",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/doc/7/getting-started/.vuejs/package.json
+++ b/doc/7/getting-started/.vuejs/package.json
@@ -10,7 +10,7 @@
     "serve-with-vuex": "cd with-vuex && vue-cli-service serve",
     "build-with-vuex": "cd with-vuex && vue-cli-service build",
     "lint-with-vuex": "cd with-vuex && vue-cli-service lint",
-    "test": "./node_modules/.bin/cypress run --record"
+    "test": "./node_modules/.bin/cypress run --record --key $CYPRESS_RECORD_KEY_DOC"
   },
   "dependencies": {
     "core-js": "^2.6.5",

--- a/src/controllers/Realtime.ts
+++ b/src/controllers/Realtime.ts
@@ -187,7 +187,7 @@ export class RealtimeController extends BaseController {
     };
 
     return this.query(request, options)
-      .then(response => {
+      .then(() => {
         const rooms = this._subscriptions.get(roomId);
 
         if (rooms) {
@@ -197,8 +197,6 @@ export class RealtimeController extends BaseController {
 
           this._subscriptions.delete(roomId);
         }
-
-        return response.result;
       });
   }
 

--- a/test/controllers/realtime.test.js
+++ b/test/controllers/realtime.test.js
@@ -239,7 +239,7 @@ describe('Realtime Controller', () => {
 
     it('should call realtime/unsubscribe query with the roomId and return a Promise which resolves the roomId', () => {
       return kuzzle.realtime.unsubscribe(roomId, options)
-        .then(res => {
+        .then(() => {
           should(kuzzle.query)
             .be.calledOnce()
             .be.calledWith({
@@ -247,8 +247,6 @@ describe('Realtime Controller', () => {
               action: 'unsubscribe',
               body: {roomId}
             }, options);
-
-          should(res).be.equal(roomId);
         });
     });
   });


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?

Stick behavior of `realtime:unsubscribe` to documentation

## Other change

Fix cypress tests by specifying `CYPRESS_RECORD_KEY_DOC` in `package.json` and Travis settings.
Since by default it uses `CYPRESS_RECORD_KEY`, it could not work since it's already used in the AC repo

<!-- Please fulfill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
