### PR TITLE
Fix document notification result type

### DIFF
--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -1,4 +1,5 @@
 import { JSONObject } from './JSONObject';
+import { Document } from './Document';
 
 /**
  * Enum for notification types


### PR DESCRIPTION
## What does this PR do?

`Document` class was not imported for the `Notification` class so the default TS class was used