### PR TITLE
Fix types for Document and CollectionMappings

### DIFF
--- a/src/types/ApiKey.ts
+++ b/src/types/ApiKey.ts
@@ -1,5 +1,7 @@
 /**
  * ApiKey
+ *
+ * @see https://docs.kuzzle.io/core/2/guides/advanced/api-keys/
  */
 export type ApiKey = {
   /**

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -2,26 +2,26 @@ import { JSONObject } from './JSONObject';
 
 /**
  * Kuzzle metadata
- * @see https://docs.kuzzle.io/core/2/guides/essentials/document-metadata/
+ * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#kuzzle-metadata
  */
 export interface DocumentMetadata {
-  _kuzzle_info: {
+  _kuzzle_info?: {
     /**
      * Kuid of the user who created the document
      */
-    author: string,
+    author?: string,
     /**
      * Creation date in micro-timestamp
      */
-    createdAt: number,
+    createdAt?: number,
     /**
      * Kuid of the user who last updated the document
      */
-    updater: string | null,
+    updater?: string | null,
     /**
      * Update date in micro-timestamp
      */
-    updatedAt: number | null
+    updatedAt?: number | null
   }
 }
 

--- a/src/types/HttpRoutes.ts
+++ b/src/types/HttpRoutes.ts
@@ -1,5 +1,8 @@
 /**
  * HTTP routes definition format
+ *
+ * @see https://docs.kuzzle.io/core/2/guides/develop-on-kuzzle/api-controllers/#http-routes
+ *
  * @example
  * {
  *    <controller>: {

--- a/src/types/Mappings.ts
+++ b/src/types/Mappings.ts
@@ -4,39 +4,41 @@ export type MappingsProperties = {
   /**
    * Properties types definition
    *
-   * @see https://docs.kuzzle.io/core/2/guides/essentials/database-mappings/#properties-types-definition
+   * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-properties
    */
   properties?: MappingsProperties,
   /**
    * Dynamic mapping policy
    *
-   * @see https://docs.kuzzle.io/core/2/guides/essentials/database-mappings/#dynamic-mapping-policy
+   * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-dynamic-policy
    */
   dynamic?: 'true' | 'false' | 'strict'
+
+  [property: string]: JSONObject | string;
 }
 
 /**
  * Collection mappings definition
  *
- * @see https://docs.kuzzle.io/core/2/guides/essentials/database-mappings/
+ * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#collection-mappings
  */
 export type CollectionMappings = {
   /**
    * Collection metadata
    *
-   * @see https://docs.kuzzle.io/core/2/guides/essentials/database-mappings/#collection-metadata
+   * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-metadata
    */
   _meta?: JSONObject;
   /**
    * Properties types definition
    *
-   * @see https://docs.kuzzle.io/core/2/guides/essentials/database-mappings/#properties-types-definition
+   * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-properties
    */
   properties?: MappingsProperties,
   /**
    * Dynamic mapping policy
    *
-   * @see https://docs.kuzzle.io/core/2/guides/essentials/database-mappings/#dynamic-mapping-policy
+   * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-dynamic-polic
    */
   dynamic?: 'true' | 'false' | 'strict',
 }

--- a/src/types/ProfilePolicy.ts
+++ b/src/types/ProfilePolicy.ts
@@ -13,7 +13,7 @@
  *   }
  * }
  *
- * @see https://docs.kuzzle.io/core/2/guides/essentials/security/#defining-profiles
+ * @see https://docs.kuzzle.io/core/2/guides/main-concepts/permissions/#policies
  */
 export type ProfilePolicy = {
   /**

--- a/src/types/RoleRightsDefinition.ts
+++ b/src/types/RoleRightsDefinition.ts
@@ -19,7 +19,7 @@
  *   }
  * }
  *
- * @see https://docs.kuzzle.io/core/2/guides/essentials/security#defining-roles
+ * @see https://docs.kuzzle.io/core/2/guides/main-concepts/permissions/#roles
  */
 export type RoleRightsDefinition = {
   /**


### PR DESCRIPTION
## What does this PR do?

Allows to instantiate a `Document` without `_kuzzle_info`.

Fix the declaration of properties in `CollectionMappings`