### PR TITLE
Adds a specific error when the request is too big to use the GET verb 

### DIFF
--- a/src/protocols/Http.ts
+++ b/src/protocols/Http.ts
@@ -297,7 +297,6 @@ export default class HttpProtocol extends KuzzleAbstractProtocol {
         path = `/${path}`;
       }
       const url = `${this.protocol}://${this.host}:${this.port}${path}`;
-
       const headers = payload.headers || {};
       headers['Content-Length'] = Buffer.byteLength(payload.body || '');
 
@@ -306,7 +305,13 @@ export default class HttpProtocol extends KuzzleAbstractProtocol {
         body: payload.body,
         timeout: this._timeout
       })
-        .then(response => JSON.parse(response.body));
+        .then(response => {
+          if (response.statusCode === 431) {
+            throw new Error(`Request query string is too large. Try to use the method with the POST verb instead.`);
+          }
+
+          return JSON.parse(response.body);
+        });
     }
 
     // Browser implementation, using XMLHttpRequest:

--- a/src/protocols/Http.ts
+++ b/src/protocols/Http.ts
@@ -307,7 +307,7 @@ export default class HttpProtocol extends KuzzleAbstractProtocol {
       })
         .then(response => {
           if (response.statusCode === 431) {
-            throw new Error(`Request query string is too large. Try to use the method with the POST verb instead.`);
+            throw new Error('Request query string is too large. Try to use the method with the POST verb instead.');
           }
 
           return JSON.parse(response.body);

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -122,7 +122,7 @@ export abstract class KuzzleAbstractProtocol extends KuzzleEventEmitter {
 Discarded request: ${JSON.stringify(request)}`));
     }
 
-    const stack = Error().stack;
+    let stack = Error().stack;
 
     const pending = new PendingRequest(request);
     this._pendingRequests.set(request.requestId, pending);
@@ -131,7 +131,19 @@ Discarded request: ${JSON.stringify(request)}`));
       this._pendingRequests.delete(request.requestId);
 
       if (response.error) {
-        const error = new KuzzleError(response.error, stack);
+        let error;
+
+        // Wrap API error but directly throw errors that comes from SDK
+        if (response.error.id) {
+          error = new KuzzleError(response.error, stack);
+        }
+        else {
+          // Keep both stacktrace
+          const lines = stack.split('\n');
+          lines[0] = '';
+          response.error.stack += '\n' + lines.join('\n');
+          error = response.error;
+        }
 
         this.emit('queryError', error, request);
 

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -119,22 +119,21 @@ describe('Common Protocol', () => {
     });
 
     it('should fire a "queryError" event and reject if an error occurred', () => {
-      const
-        eventStub = sinon.stub(),
-        response = {
-          error: {
-            message: 'foo-bar'
-          }
-        };
+      const eventStub = sinon.stub();
+      const response = {
+        error: {
+          message: 'foo-bar'
+        }
+      };
 
       protocol.addListener('queryError', eventStub);
 
       return protocol.query({requestId: 'foobar', response: response})
-        .then(() => Promise.reject({message: 'No error'}))
-        .catch(error => {
+        .then(() => Promise.reject(new Error('message')))
+        .catch(err => {
           should(eventStub).be.calledOnce();
-          should(error).be.instanceOf(KuzzleError);
-          should(error.message).be.exactly('foo-bar');
+          should(err).be.eql(response.error);
+          should(err.message).be.exactly('foo-bar');
         });
     });
 
@@ -175,7 +174,8 @@ describe('Common Protocol', () => {
         error: {
           message: 'foo-bar',
           status: 442,
-          stack: 'you are the bug'
+          stack: 'you are the bug',
+          id: 'api.foo.bar'
         }
       };
 
@@ -199,12 +199,13 @@ describe('Common Protocol', () => {
             'some',
             'error'
           ],
-          count: 42
+          count: 42,
+          id: 'api.foo.bar'
         }
       };
 
       return protocol.query({ requestId: 'foobar', response: response })
-        .then(() => Promise.reject({message: 'No error'}))
+        .then(() => Promise.reject(new Error('message')))
         .catch(error => {
           should(error).be.instanceOf(KuzzleError);
           should(error.message).be.eql('foo-bar');


### PR DESCRIPTION
## What does this PR do?

HTTP headers request field have a size limite: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/431

When using the `document.mGet` method with the `get` verb, you can hit this limit who result in an 431 response with an empty body.

Now a specific error is trowed so developers can understand what is wrong  