### PR TITLE
Add event type to document notification

### DIFF
--- a/doc/7/controllers/realtime/subscribe/snippets/document-notifications-leave-scope.js
+++ b/doc/7/controllers/realtime/subscribe/snippets/document-notifications-leave-scope.js
@@ -9,6 +9,7 @@ function callback (notification) {
     collection: 'yellow-taxi',
     controller: 'document',
     action: 'update',
+    event: 'write',
     protocol: 'websocket',
     scope: 'out',
     state: 'done',

--- a/doc/7/controllers/realtime/subscribe/snippets/document-notifications.js
+++ b/doc/7/controllers/realtime/subscribe/snippets/document-notifications.js
@@ -9,6 +9,7 @@ function callback (notification) {
     collection: 'yellow-taxi',
     controller: 'document',
     action: 'create',
+    event: 'write',
     protocol: 'websocket',
     scope: 'in',
     result:

--- a/doc/7/essentials/realtime-notifications/index.md
+++ b/doc/7/essentials/realtime-notifications/index.md
@@ -15,23 +15,24 @@ The [realtime.subscribe](/sdk/js/7/controllers/realtime) method takes a callback
 These notifications represent [documents changes & messages](/core/2/api/payloads/notifications#document-notification).
 
 | Property     | Type              | Description                                                                                           |
-| ------------ | ----------------- | ----------------------------------------------------------------------------------------------------- |
-| `action`     | <pre>string</pre> | API controller's action                                                                               |
-| `collection` | <pre>string</pre> | Data collection                                                                                       |
+|--------------|-------------------|-------------------------------------------------------------------------------------------------------|
+| `action`     | <pre>string</pre> | API action                                                                                            |
+| `collection` | <pre>string</pre> | Collection name                                                                                       |
 | `controller` | <pre>string</pre> | API controller                                                                                        |
-| `index`      | <pre>string</pre> | Data index                                                                                            |
+| `event`      | <pre>string</pre> | Event type (`write`, `delete` or `publish`)                                                           |
+| `index`      | <pre>string</pre> | Index name                                                                                            |
 | `protocol`   | <pre>string</pre> | Network protocol used to modify the document                                                          |
 | `result`     | <pre>object</pre> | Notification content                                                                                  |
 | `room`       | <pre>string</pre> | Subscription channel identifier. Can be used to link a notification to its corresponding subscription |
-| `scope`      | <pre>string</pre> | `in`: document enters (or stays) in the scope<br/>`out`: document leaves the scope                      |
+| `scope`      | <pre>string</pre> | `in`: document enters (or stays) in the scope<br/>`out`: document leaves the scope                    |
 | `timestamp`  | <pre>number</pre> | Timestamp of the event, in Epoch-millis format                                                        |
 | `type`       | <pre>string</pre> | `document`: Notification type                                                                         |
-| `volatile`   | <pre>object</pre> | Request [volatile data](/core/2/guides/main-concepts/api#volatile-data)                                        |
+| `volatile`   | <pre>object</pre> | Request [volatile data](/core/2/guides/main-concepts/api#volatile-data)                               |
 
 The `result` object is the notification content, and it has the following structure:
 
 | Property  | Type              | Description                                                                             |
-| --------- | ----------------- | --------------------------------------------------------------------------------------- |
+|-----------|-------------------|-----------------------------------------------------------------------------------------|
 | `_id`     | <pre>string</pre> | Document unique ID<br/null` if the notification is from a real-time message             |
 | `_source` | <pre>object</pre> | Message or full document content. Not present if the event is about a document deletion |
 
@@ -40,7 +41,7 @@ The `result` object is the notification content, and it has the following struct
 These notifications represent [user events](/core/2/api/payloads/notifications#user-notification).
 
 | Property     | Type              | Description                                                                                           |
-| ------------ | ----------------- | ----------------------------------------------------------------------------------------------------- |
+|--------------|-------------------|-------------------------------------------------------------------------------------------------------|
 | `action`     | <pre>string</pre> | API controller's action                                                                               |
 | `collection` | <pre>string</pre> | Data collection                                                                                       |
 | `controller` | <pre>string</pre> | API controller                                                                                        |
@@ -50,13 +51,13 @@ These notifications represent [user events](/core/2/api/payloads/notifications#u
 | `room`       | <pre>string</pre> | Subscription channel identifier. Can be used to link a notification to its corresponding subscription |
 | `timestamp`  | <pre>number</pre> | Timestamp of the event, in Epoch-millis format                                                        |
 | `type`       | <pre>string</pre> | `user`: Notification type                                                                             |
-| `user`       | <pre>string</pre> | `in`: a new user has subscribed to the same filters<br/>`out`: a user cancelled a shared subscription   |
-| `volatile`   | <pre>object</pre> | Request [volatile data](/core/2/guides/main-concepts/api#volatile-data)                                        |
+| `user`       | <pre>string</pre> | `in`: a new user has subscribed to the same filters<br/>`out`: a user cancelled a shared subscription |
+| `volatile`   | <pre>object</pre> | Request [volatile data](/core/2/guides/main-concepts/api#volatile-data)                               |
 
 The `result` object is the notification content, and it has the following structure:
 
 | Property | Type              | Description                                        |
-| -------- | ----------------- | -------------------------------------------------- |
+|----------|-------------------|----------------------------------------------------|
 | `count`  | <pre>number</pre> | Updated users count sharing that same subscription |
 
 ## Server
@@ -64,6 +65,6 @@ The `result` object is the notification content, and it has the following struct
 These notifications represent [server events](/core/2/api/payloads/notifications#server-notification).
 
 | Property  | Type              | Value                                                              |
-| --------- | ----------------- | ------------------------------------------------------------------ |
+|-----------|-------------------|--------------------------------------------------------------------|
 | `message` | <pre>string</pre> | Server message explaining why this notification has been triggered |
 | `type`    | <pre>string</pre> | `TokenExpired`: notification type                                  |

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -27,6 +27,10 @@ export interface BaseNotification extends Notification {
    */
   action: string;
   /**
+   * Event type according to API action
+   */
+  event: 'write' | 'delete' | 'publish';
+  /**
    * Index name
    */
   index: string;


### PR DESCRIPTION
## What does this PR do?

Add `event` property to document notifications

Related to https://github.com/kuzzleio/kuzzle/pull/1922

