### PR TITLE
[Hotfix] Fix type MappingProperties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5119,9 +5119,9 @@
       }
     },
     "kuzdoc": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/kuzdoc/-/kuzdoc-1.4.3.tgz",
-      "integrity": "sha512-kbKX36PBFDFWKJ3NwX+VGUNT/E8PodwiCSXnFilolCifnXdxu+/PrR+HwGkGoftLB4K1kXDcJ8xj4xb29jBYDA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/kuzdoc/-/kuzdoc-1.4.4.tgz",
+      "integrity": "sha512-3OTytqABU/eUdo/2+boo83EpjZK78DO6XTKm/BM9l9a1f4D8R2yxn8F5ZSdPztGnNmkBGe15+Jd2YSfJHGUFUA==",
       "dev": true,
       "requires": {
         "@oclif/command": "^1.5.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-friendly-formatter": "^4.0.1",
     "eslint-loader": "^4.0.2",
     "https-browserify": "^1.0.0",
-    "kuzdoc": "^1.4.3",
+    "kuzdoc": "^1.4.4",
     "lolex": "^6.0.0",
     "mocha": "8.2.1",
     "mock-require": "^3.0.3",

--- a/src/types/Mappings.ts
+++ b/src/types/Mappings.ts
@@ -6,15 +6,13 @@ export type MappingsProperties = {
    *
    * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-properties
    */
-  properties?: MappingsProperties,
+  properties?: MappingsProperties | JSONObject,
   /**
    * Dynamic mapping policy
    *
    * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-dynamic-policy
    */
   dynamic?: 'true' | 'false' | 'strict'
-
-  [property: string]: JSONObject | string;
 }
 
 /**


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?

Fix `MappingProperties` types

<!-- Please fulfill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

### How should this be manually tested?

Launch Admin Console on `4-dev`
```
ERROR in /private/tmp/admin-console/node_modules/kuzzle-sdk-v7/src/types/Mappings.d.ts(8,5):
8:5 Property 'properties' of type 'MappingsProperties | undefined' is not assignable to string index type 'string | JSONObject'.
     6 |      * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-properties
     7 |      */
  >  8 |     properties?: MappingsProperties;
       |     ^
     9 |     /**
    10 |      * Dynamic mapping policy
    11 |      *
ERROR in /private/tmp/admin-console/node_modules/kuzzle-sdk-v7/src/types/Mappings.d.ts(14,5):
14:5 Property 'dynamic' of type '"false" | "true" | "strict" | undefined' is not assignable to string index type 'string | JSONObject'.
    12 |      * @see https://docs.kuzzle.io/core/2/guides/main-concepts/data-storage/#mappings-dynamic-policy
    13 |      */
  > 14 |     dynamic?: 'true' | 'false' | 'strict';
       |     ^
    15 |     [property: string]: JSONObject | string;
    16 | };
    17 | /**
```

Those errors are now fixed with this PR

### Other changes

Update kuzdoc to 1.4.4

