### PR TITLE
Error stacktrace overhaul

### DIFF
--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-const { hilightUserCode } = require('./utils/stackTrace');
+import { hilightUserCode } from './utils/stackTrace';
 
 /**
  * Standard Kuzzle error.

--- a/src/controllers/Auth.ts
+++ b/src/controllers/Auth.ts
@@ -2,7 +2,7 @@ import { Jwt } from '../core/Jwt';
 import { BaseController } from './Base';
 import { User } from '../core/security/User';
 import { JSONObject, ApiKey } from '../types';
-import { RequestPayload } from 'src/types/RequestPayload';
+import { RequestPayload } from '../types/RequestPayload';
 
 /**
  * Auth controller

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -145,7 +145,11 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
           // @deprecated
           this.emit('discarded', data);
 
-          const error = new KuzzleError(data.error);
+          const error = new KuzzleError(
+            data.error,
+            (new Error().stack),
+            this.constructor.name);
+
           this.emit('queryError', error, data);
         }
       };

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -136,18 +136,17 @@ Discarded request: ${JSON.stringify(request)}`));
         let error;
 
         // Wrap API error but directly throw errors that comes from SDK
-        if (response.error.id) {
-          error = new KuzzleError(response.error, stack);
+        if (response.error.status) {
+          error = new KuzzleError(response.error, stack, this.constructor.name);
         }
         else {
-          // Keep both stacktrace
+          // Keep both stacktrace because the one we captured in "stack" will give
+          // more information (async stacktrace are not very talkative)
           const lines = stack.split('\n');
           lines[0] = '';
           response.error.stack += '\n' + lines.join('\n');
           error = response.error;
         }
-
-        error.stack = error.stack.split('\n').map(hilightUserCode).join('\n');
 
         this.emit('queryError', error, request);
 

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -7,8 +7,6 @@ import { PendingRequest } from './PendingRequest';
 import { JSONObject } from '../../types';
 import { RequestPayload } from '../../types/RequestPayload';
 
-const { hilightUserCode } = require('../../utils/stackTrace');
-
 export abstract class KuzzleAbstractProtocol extends KuzzleEventEmitter {
   private _pendingRequests: Map<string, PendingRequest>;
   private _host: string;

--- a/src/utils/stackTrace.js
+++ b/src/utils/stackTrace.js
@@ -18,7 +18,6 @@ function hilightUserCode (line) {
   if ( line.includes('sdk-javascript/src/') // ignore kuzzle code
     || (line.indexOf('at /') === -1 && line.charAt(line.indexOf('(') + 1) !== '/') // ignore node internal
     || line.includes('node_modules') // ignore dependencies
-    // @todo ignore in browser
   ) {
     return '   ' + line;
   }

--- a/src/utils/stackTrace.js
+++ b/src/utils/stackTrace.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Hilight user code
+ *
+ * e.g.
+ *      at HttpProtocol.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/protocols/abstract/Base.ts:127:19)
+ *      at Proxy.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/Kuzzle.ts:598:26)
+ * >  at /home/aschen/projets/kuzzleio/sdk-javascript/test.js:8:18
+ *      at processTicksAndRejections (internal/process/task_queues.js:97:5)]
+ */
+function hilightUserCode (line) {
+  // ignore first line (error message)
+  if (! line.includes(' at ')) {
+    return line;
+  }
+
+  if ( line.includes('sdk-javascript/src/') // ignore kuzzle code
+    || (line.indexOf('at /') === -1 && line.charAt(line.indexOf('(') + 1) !== '/') // ignore node internal
+    || line.includes('node_modules') // ignore dependencies
+    // @todo ignore in browser
+  ) {
+    return '   ' + line;
+  }
+
+  // hilight user code
+  return '>' + line;
+}
+
+module.exports = {
+  hilightUserCode,
+};

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -187,7 +187,7 @@ describe('Common Protocol', () => {
           should(error.status).be.eql(442);
           should(error.stack).match(/you are the bug/);
           should(error.stack).match(/KuzzleAbstractProtocol/);
-          should(error.stack).match(/>    at Context.<anonymous>/);
+          should(error.stack).match(/>\s{4}at Context.<anonymous>/);
         });
     });
 
@@ -214,7 +214,7 @@ describe('Common Protocol', () => {
           should(error.status).be.eql(206);
           should(error.stack).match(/you are the bug/);
           should(error.stack).match(/KuzzleAbstractProtocol/);
-          should(error.stack).match(/>    at Context.<anonymous>/);
+          should(error.stack).match(/>\s{4}at Context.<anonymous>/);
           should(error.errors).be.an.Array();
           should(error.errors.length).eql(2);
           should(error.count).eql(42);

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -185,7 +185,9 @@ describe('Common Protocol', () => {
           should(error).be.instanceOf(KuzzleError);
           should(error.message).be.eql('foo-bar');
           should(error.status).be.eql(442);
-          should(error.kuzzleStack).be.eql('you are the bug');
+          should(error.stack).match(/you are the bug/);
+          should(error.stack).match(/KuzzleAbstractProtocol/);
+          should(error.stack).match(/>    at Context.<anonymous>/);
         });
     });
 
@@ -210,7 +212,9 @@ describe('Common Protocol', () => {
           should(error).be.instanceOf(KuzzleError);
           should(error.message).be.eql('foo-bar');
           should(error.status).be.eql(206);
-          should(error.kuzzleStack).be.eql('you are the bug');
+          should(error.stack).match(/you are the bug/);
+          should(error.stack).match(/KuzzleAbstractProtocol/);
+          should(error.stack).match(/>    at Context.<anonymous>/);
           should(error.errors).be.an.Array();
           should(error.errors.length).eql(2);
           should(error.count).eql(42);


### PR DESCRIPTION
## What does this PR do?

Improve SDK stacktrace by highlighting the user code and displaying Kuzzle stacktrace as well.

### How should this be manually tested?

```
const { Kuzzle, Http, WebSocket } = require('./index');

const kuzzle = new Kuzzle(new WebSocket('localhost'));

function executeQuery () {
  return kuzzle.query({
    controller: 'greeting',
    action: 'sayHello'
  });
}

(async () => {
  try {
    await kuzzle.connect();
    await executeQuery();
  }
  catch (error) {
    console.error(error)
  }
  finally {
    kuzzle.disconnect();
  }
})();
```

If Kuzzle is running in `development` mode then we display both stacktrace:
```
NotFoundError: API controller "greeting" not found.
    [...Kuzzle internal calls deleted...]
    at Funnel.getController (/var/app/node_modules/kuzzle/lib/api/funnel.js:595:24)
    at Funnel.processRequest (/var/app/node_modules/kuzzle/lib/api/funnel.js:409:29)
    at /var/app/node_modules/kuzzle/lib/api/funnel.js:285:27
          |
          |
          WebSocketProtocol
          |
          |
       at WebSocketProtocol.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/protocols/abstract/Base.ts:127:19)
       at Proxy.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/Kuzzle.ts:598:26)
>    at executeQuery (/home/aschen/projets/kuzzleio/sdk-javascript/test.js:6:17)
>    at /home/aschen/projets/kuzzleio/sdk-javascript/test.js:15:11
       at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

If Kuzzle is not running in `development` mode we display only SDK stacktrace:

```
[KuzzleError: API controller "greeting" not found.
       at WebSocketProtocol.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/protocols/abstract/Base.ts:127:19)
       at Proxy.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/Kuzzle.ts:598:26)
>    at executeQuery (/home/aschen/projets/kuzzleio/sdk-javascript/test.js:6:17)
>    at /home/aschen/projets/kuzzleio/sdk-javascript/test.js:15:11
       at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
