### PR TITLE
Fix re-subscription

### DIFF
--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -86,6 +86,7 @@ Triggered whenever Kuzzle responds with an error
 **Callback arguments:**
 
 `@param {KuzzleError} error - Error details`
+
 `@param {object} request - Request that caused the error`
 
 ## reconnected

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -523,8 +523,8 @@ export class Kuzzle extends KuzzleEventEmitter {
       throw new Error(`Kuzzle.query: Invalid "options" argument: ${JSON.stringify(opts)}`);
     }
 
-    const request = { ...req };
-    const options = { ...opts };
+    const request = JSON.parse(JSON.stringify(req));
+    const options = JSON.parse(JSON.stringify(opts));
 
     if (!request.requestId) {
       request.requestId = uuidv4();

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -13,7 +13,6 @@ import { MemoryStorageController } from './controllers/MemoryStorage';
 
 import { uuidv4 } from './utils/uuidv4';
 import { proxify } from './utils/proxify';
-import { clone } from './utils/clone';
 import { JSONObject } from './types';
 import { RequestPayload } from './types/RequestPayload';
 import { ResponsePayload } from './types/ResponsePayload';
@@ -516,16 +515,16 @@ export class Kuzzle extends KuzzleEventEmitter {
    * @param options - Optional arguments
    */
   query (req: RequestPayload = {}, opts: JSONObject = {}): Promise<ResponsePayload> {
-    const request = clone(req);
-    const options = clone(opts);
-
-    if (typeof request !== 'object' || Array.isArray(request)) {
-      throw new Error(`Kuzzle.query: Invalid request: ${JSON.stringify(request)}`);
+    if (typeof req !== 'object' || Array.isArray(req)) {
+      throw new Error(`Kuzzle.query: Invalid request: ${JSON.stringify(req)}`);
     }
 
-    if (typeof options !== 'object' || Array.isArray(options)) {
-      throw new Error(`Kuzzle.query: Invalid "options" argument: ${JSON.stringify(options)}`);
+    if (typeof opts !== 'object' || Array.isArray(opts)) {
+      throw new Error(`Kuzzle.query: Invalid "options" argument: ${JSON.stringify(opts)}`);
     }
+
+    const request = { ...req };
+    const options = { ...opts };
 
     if (!request.requestId) {
       request.requestId = uuidv4();

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -150,7 +150,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
             (new Error().stack),
             this.constructor.name);
 
-          this.emit('queryError', error, data);
+          this.emit('queryError', { error, request: data });
         }
       };
 

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -146,7 +146,7 @@ Discarded request: ${JSON.stringify(request)}`));
           error = response.error;
         }
 
-        this.emit('queryError', error, request);
+        this.emit('queryError', { error, request });
 
         if (request.action !== 'logout' && error.id === 'security.token.invalid') {
           this.emit('tokenExpired');

--- a/src/utils/clone.js
+++ b/src/utils/clone.js
@@ -1,5 +1,0 @@
-function clone (obj) {
-  return JSON.parse(JSON.stringify(obj));
-}
-
-module.exports = { clone };

--- a/src/utils/clone.js
+++ b/src/utils/clone.js
@@ -1,0 +1,5 @@
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+module.exports = { clone };

--- a/test/kuzzle/connect.test.js
+++ b/test/kuzzle/connect.test.js
@@ -1,9 +1,7 @@
-const
-  should = require('should'),
-  sinon = require('sinon'),
-  ProtocolMock = require('../mocks/protocol.mock'),
-  generateJwt = require('../mocks/generateJwt.mock'),
-  { Kuzzle } = require('../../src/Kuzzle');
+const should = require('should');
+const sinon = require('sinon');
+const ProtocolMock = require('../mocks/protocol.mock');
+const { Kuzzle } = require('../../src/Kuzzle');
 
 describe('Kuzzle connect', () => {
 

--- a/test/kuzzle/connect.test.js
+++ b/test/kuzzle/connect.test.js
@@ -96,42 +96,6 @@ describe('Kuzzle connect', () => {
         });
     });
 
-    it('should keep a valid JWT at reconnection', () => {
-      const
-        jwt = generateJwt(),
-        kuzzle = new Kuzzle(protocols.somewhereagain);
-
-      kuzzle.auth.checkToken = sinon.stub().resolves({
-        valid: true
-      });
-      kuzzle.jwt = jwt;
-
-      return kuzzle.connect()
-        .then(() => {
-          should(kuzzle.auth.checkToken).be.calledOnce();
-
-          should(kuzzle.jwt).be.eql(jwt);
-        });
-    });
-
-    it('should empty the JWT at reconnection if it has expired', () => {
-      const
-        jwt = generateJwt(),
-        kuzzle = new Kuzzle(protocols.somewhereagain);
-
-      kuzzle.auth.checkToken = sinon.stub().resolves({
-        valid: false
-      });
-      kuzzle.jwt = jwt;
-
-      return kuzzle.connect()
-        .then(() => {
-          should(kuzzle.auth.checkToken).be.calledOnce();
-
-          should(kuzzle.jwt).be.null();
-        });
-    });
-
     it('should register listeners upon receiving a "disconnect" event', () => {
       const
         kuzzle = new Kuzzle(protocols.somewhere),

--- a/test/kuzzle/protocol.test.js
+++ b/test/kuzzle/protocol.test.js
@@ -28,14 +28,17 @@ describe('Kuzzle protocol methods', () => {
       const
         eventStub = sinon.stub(),
         error = {message: 'foo-bar'},
-        query = {foo: 'bar'};
+        request  = {foo: 'bar'};
       kuzzle.connect();
       kuzzle.addListener('queryError', eventStub);
 
-      kuzzle.protocol.emit('queryError', error, query);
+      kuzzle.protocol.emit('queryError', { error, request });
 
       should(eventStub).be.calledOnce();
-      should(eventStub).be.calledWithMatch({message: 'foo-bar'}, {foo: 'bar'});
+      should(eventStub).be.calledWithMatch({
+        error: { message: 'foo-bar' },
+        request: { foo: 'bar'}
+      });
     });
 
     it('should propagate protocol "tokenExpired" events', () => {

--- a/test/kuzzle/protocol.test.js
+++ b/test/kuzzle/protocol.test.js
@@ -1,9 +1,8 @@
-const
-  should = require('should'),
-  sinon = require('sinon'),
-  ProtocolMock = require('../mocks/protocol.mock'),
-  generateJwt = require('../mocks/generateJwt.mock'),
-  { Kuzzle } = require('../../src/Kuzzle');
+const should = require('should');
+const sinon = require('sinon');
+const ProtocolMock = require('../mocks/protocol.mock');
+const generateJwt = require('../mocks/generateJwt.mock');
+const { Kuzzle } = require('../../src/Kuzzle');
 
 describe('Kuzzle protocol methods', () => {
   let kuzzle;
@@ -25,10 +24,10 @@ describe('Kuzzle protocol methods', () => {
 
   describe('#events', () => {
     it('should propagate protocol "queryError" events', () => {
-      const
-        eventStub = sinon.stub(),
-        error = {message: 'foo-bar'},
-        request  = {foo: 'bar'};
+      const eventStub = sinon.stub();
+      const error = { message: 'foo-bar' };
+      const request = { foo: 'bar' };
+
       kuzzle.connect();
       kuzzle.addListener('queryError', eventStub);
 

--- a/test/kuzzle/query.test.js
+++ b/test/kuzzle/query.test.js
@@ -191,7 +191,7 @@ describe('Kuzzle query management', () => {
       should(kuzzle.protocol.query).not.be.called();
       should(eventStub)
         .be.calledOnce()
-        .be.calledWith({request});
+        .be.calledWithMatch({ request });
 
       should(kuzzle._offlineQueue.length).be.eql(1);
     });
@@ -217,7 +217,7 @@ describe('Kuzzle query management', () => {
           should(kuzzle._offlineQueue.length).eql(0);
           should(eventStub)
             .be.calledOnce()
-            .be.calledWith({request});
+            .be.calledWithMatch({ request });
         });
     });
 
@@ -233,7 +233,14 @@ describe('Kuzzle query management', () => {
           should(kuzzle.protocol.query)
             .be.not.be.called();
         });
+    });
 
+    it('should clone the original request', async () => {
+      const request = { controller: 'server', action: 'now' };
+
+      await kuzzle.query(request);
+
+      should(request).be.eql({ controller: 'server', action: 'now' });
     });
   });
 });

--- a/test/protocol/WebSocket.test.js
+++ b/test/protocol/WebSocket.test.js
@@ -313,9 +313,9 @@ describe('WebSocket networking module', () => {
 
     let expectedError;
     websocket.on('discarded', cb);
-    websocket.on('queryError', (error, data) => {
+    websocket.on('queryError', ({ error, request }) => {
       expectedError = error;
-      cb2(error, data);
+      cb2(error, request);
     });
     websocket.connect();
 


### PR DESCRIPTION
## What does this PR do?

When resubscribing after a `reconnected` event, the SDK use the original subscription `request` to re-subscribe.

The `Kuzzle.query` method mutate request and inject the JWT inside. Meaning that the request saved for the re-subscription already has a JWT inside.

This can be an issue because developers rely on the `kuzzle.jwt` property of the SDK to know if 1) the token is still valid 2) there are connection information.

Now the `request` and `options` parameter of the query method are cloned before modification.  (:warning: to save resources it's not a deep clone so only the top level properties are duplicated. Nested objects will not be cloned but only referenced)

### How should this be manually tested?

Run a Kuzzle stack and then create this user and update anonymous role:
```
kourou security:createUser '{                                                             
  content: {
    profileIds: ["default"]
  },
  credentials: {
    local: {
      username: "test-admin",
      password: "password"
    },
  }
}'

kourou security:updateRole '{                                                             
  controllers: {
    "realtime": {
      actions: {
        "subscribe": false
      }
    },
    "*": {
      actions: {
        "*": true
      }
    }
  }
}'
```

Then run this script

<details><summary>resubscribe.js</summary>

```js
const { Kuzzle, WebSocket } = require('./index');

const kuzzle = new Kuzzle(new WebSocket('localhost'));

async function subscribeToNotifications () {
  console.log('subscribeToNotifications');
  await kuzzle.realtime.subscribe('test', 'test', {}, () => {
    console.log('Notification received');
  });
  console.log('Subscribed');
}

// authenticate and subscribe after a "tokenExpired" event
kuzzle.on('tokenExpired', async () => {
  await authenticateAndSubscribe();
});

kuzzle.on('reconnected', async () => {
  await authenticateAndSubscribe();
})

// authenticate and then subscribe
// re-try every 1 second until it works
async function authenticateAndSubscribe () {
  console.log('authenticateAndSubscribe()');
  try {
    const { valid } = await kuzzle.auth.checkToken();

    if (! valid) {
      await kuzzle.auth.login('local', { username: 'test-admin', password: 'password' }, '5s');
      console.log('Authenticated');
    }
    else {
      console.log('Already authenticated');
    }

    await subscribeToNotifications();
  }
  catch (error) {
    console.log('authenticateAndSubscribe ', error);
    // Wrong or revoked credentials
    if (error.id === 'plugin.strategy.missing_user') {
      throw error;
    }

    // An error occured (network, etc), try again in 1 sec
    setTimeout(async () => {
      try {
        await authenticateAndSubscribe();
      }
      catch (error) {
        // if we end up there it means that we don't have correct credentials anymore
      }
    }, 1000);
  }
}

async function refreshToken () {
  setInterval(async () => {
    try {
      await kuzzle.auth.refreshToken({ expiresIn: '5s' });
      console.log('Refreshed')
    }
    catch (error) {
      console.log('Cannot refresh token: ', error);
    }
  }, 4000);
}

async function run () {
  await kuzzle.connect();
  await authenticateAndSubscribe();

  await refreshToken();
}

run();
```

</details>

<details><summary>Logs</summary>

```
➜  sdk-javascript git:(fix-resubscription) ✗ node -r ts-node/register test.js
authenticateAndSubscribe()
Authenticated
subscribeToNotifications
Subscribed
Cannot refresh token:  Error: Unable to execute request: not connected to a Kuzzle server.
Discarded request: {"action":"refreshToken","expiresIn":"5s","controller":"auth","requestId":"02248d26-4cd9-4661-b5bf-628c95b30063","volatile":{"sdkInstanceId":"f346463c-2674-4753-8ab6-4ad8054157cd","sdkName":"js@7.5.3"},"jwt":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI4MjcwZTIxMS1kM2E5LTQzM2UtYTgzMS02ODkzZDUwMzU3ZDgiLCJpYXQiOjE2MTMzOTU1NTMsImV4cCI6MTYxMzM5NTU1OH0.cSfYw97kY_uah623nCRUnpOjXw6Zp1eJtEb3lj7zfwk"}
    at WebSocketProtocol.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/protocols/abstract/Base.ts:121:29)
    at Kuzzle.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/Kuzzle.ts:589:26)
    at AuthController.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/controllers/Base.ts:41:25)
    at AuthController.refreshToken (/home/aschen/projets/kuzzleio/sdk-javascript/src/controllers/Auth.ts:534:17)
    at Timeout._onTimeout (/home/aschen/projets/kuzzleio/sdk-javascript/test.js:57:25)
    at listOnTimeout (internal/timers.js:549:17)
    at processTimers (internal/timers.js:492:7)
Cannot refresh token:  Error: Unable to execute request: not connected to a Kuzzle server.
Discarded request: {"action":"refreshToken","expiresIn":"5s","controller":"auth","requestId":"ac2f20c0-5bbf-4469-8f91-e916db0d10e9","volatile":{"sdkInstanceId":"f346463c-2674-4753-8ab6-4ad8054157cd","sdkName":"js@7.5.3"},"jwt":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI4MjcwZTIxMS1kM2E5LTQzM2UtYTgzMS02ODkzZDUwMzU3ZDgiLCJpYXQiOjE2MTMzOTU1NTMsImV4cCI6MTYxMzM5NTU1OH0.cSfYw97kY_uah623nCRUnpOjXw6Zp1eJtEb3lj7zfwk"}
    at WebSocketProtocol.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/protocols/abstract/Base.ts:121:29)
    at Kuzzle.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/Kuzzle.ts:589:26)
    at AuthController.query (/home/aschen/projets/kuzzleio/sdk-javascript/src/controllers/Base.ts:41:25)
    at AuthController.refreshToken (/home/aschen/projets/kuzzleio/sdk-javascript/src/controllers/Auth.ts:534:17)
    at Timeout._onTimeout (/home/aschen/projets/kuzzleio/sdk-javascript/test.js:57:25)
    at listOnTimeout (internal/timers.js:549:17)
    at processTimers (internal/timers.js:492:7)
authenticateAndSubscribe()
Authenticated
subscribeToNotifications
Subscribed
Refreshed
Refreshed
```

</details>

Wait 2 sec and then stop Kuzzle:
 - refreshToken request should be queued
 - networkError should appear

Restart Kuzzle:
 - the automatic re-subscription will fail because the token is expired
 - the script should re-authenticate
 - only 1 subscription is registered (try `kourou realtime:publish test test '{ toto: 42 }' --username test-admin --password password` )

### Other changes

 - remove the `checkToken` when the SDK reconnect because it breaks the workflow on `tokenExpired` events

