### PR TITLE
[HOTFIX] Check client readyState before sending pings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.5.4",
+  "version": "7.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.5.4",
+  "version": "7.5.5",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -87,39 +87,40 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
       this.client = new this.WebSocketClient(url, this.options);
 
       this.client.onopen = () => {
-        this.clientConnected();
-        /**
-         * Defining behavior depending on the Websocket client type
-         * Which can be the browser or node one.
-         */
-        if (typeof WebSocket !== 'undefined') {
-          this.ping = () => {
-            this.client.send('{"p":1}');
-          };
-        }
-        else {
-          this.ping = () => {
-            this.client.ping();
-          };
-          this.client.on('pong', () => {
-            clearTimeout(this.pongTimeoutId);
-          });
-        }
-        /**
-        * Send pings to the server
-        */
-        this.pingIntervalId = setInterval(() => {
-          this.ping();
-          this.pongTimeoutId = setTimeout(() => {
-            const error: any = new Error('Connection lost.');
-            error.status = 503;
-            this.clientNetworkError(error);
-            this.emit('disconnect');
-            clearInterval(this.pingIntervalId);
-            clearTimeout(this.pongTimeoutId);
-          }, this._pongTimeout);
-        }, this._pingInterval);
-        return resolve();
+        this.clientConnected().then(() =>{
+          /**
+           * Defining behavior depending on the Websocket client type
+           * Which can be the browser or node one.
+           */
+          if (typeof WebSocket !== 'undefined') {
+            this.ping = () => {
+              this.client.send('{"p":1}');
+            };
+          }
+          else {
+            this.ping = () => {
+              this.client.ping();
+            };
+            this.client.on('pong', () => {
+              clearTimeout(this.pongTimeoutId);
+            });
+          }
+          /**
+          * Send pings to the server
+          */
+          this.pingIntervalId = setInterval(() => {
+            this.ping();
+            this.pongTimeoutId = setTimeout(() => {
+              const error: any = new Error('Connection lost.');
+              error.status = 503;
+              this.clientNetworkError(error);
+              this.emit('disconnect');
+              clearInterval(this.pingIntervalId);
+              clearTimeout(this.pongTimeoutId);
+            }, this._pongTimeout);
+          }, this._pingInterval);
+          return resolve();
+        });
       };
 
       this.client.onclose = (closeEvent, message) => {

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -87,7 +87,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
       this.client = new this.WebSocketClient(url, this.options);
 
       this.client.onopen = () => {
-        this.clientConnected().then(() =>{
+        this.clientConnected().then(() => {
           /**
            * Defining behavior depending on the Websocket client type
            * Which can be the browser or node one.

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -88,6 +88,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
 
       this.client.onopen = () => {
         this.clientConnected().then(() => {
+          console.log({state: this.state});
           /**
            * Defining behavior depending on the Websocket client type
            * Which can be the browser or node one.
@@ -109,7 +110,9 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
           * Send pings to the server
           */
           this.pingIntervalId = setInterval(() => {
-            this.ping();
+            if (this.state === 'connected') {
+              this.ping();
+            }
             this.pongTimeoutId = setTimeout(() => {
               const error: any = new Error('Connection lost.');
               error.status = 503;

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -85,28 +85,28 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
       }
 
       this.client = new this.WebSocketClient(url, this.options);
-      /**
-       * Defining behavior depending on the Websocket client type
-       * Which can be the browser or node one.
-       */
-      if (typeof WebSocket !== 'undefined') {
-        this.ping = () => {
-          this.client.send('{"p":1}');
-        };
-      }
-      else {
-        this.ping = () => {
-          this.client.ping();
-        };
-        this.client.on('pong', () => {
-          clearTimeout(this.pongTimeoutId);
-        });
-      }
 
       this.client.onopen = () => {
         this.clientConnected();
         /**
-         * Send pings to the server
+         * Defining behavior depending on the Websocket client type
+         * Which can be the browser or node one.
+         */
+        if (typeof WebSocket !== 'undefined') {
+          this.ping = () => {
+            this.client.send('{"p":1}');
+          };
+        }
+        else {
+          this.ping = () => {
+            this.client.ping();
+          };
+          this.client.on('pong', () => {
+            clearTimeout(this.pongTimeoutId);
+          });
+        }
+        /**
+        * Send pings to the server
         */
         this.pingIntervalId = setInterval(() => {
           this.ping();

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -46,14 +46,13 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
   /**
    * Called when the client's connection is established
    */
-  clientConnected (): Promise<any> {
+  clientConnected () {
     super.clientConnected('connected', this.wasConnected);
 
     this.state = 'connected';
     this.wasConnected = true;
     this.stopRetryingToConnect = false;
 
-    return Promise.resolve();
   }
 
   /**

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -46,14 +46,14 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
   /**
    * Called when the client's connection is established
    */
-  clientConnected () {
+  clientConnected (): Promise<any> {
     super.clientConnected('connected', this.wasConnected);
 
     this.state = 'connected';
     this.wasConnected = true;
     this.stopRetryingToConnect = false;
 
-    // return Promise.resolve();
+    return Promise.resolve();
   }
 
   /**

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -52,6 +52,8 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
     this.state = 'connected';
     this.wasConnected = true;
     this.stopRetryingToConnect = false;
+
+    // return Promise.resolve();
   }
 
   /**

--- a/test/protocol/WebSocket.test.js
+++ b/test/protocol/WebSocket.test.js
@@ -102,15 +102,11 @@ describe('WebSocket networking module', () => {
   it('should initialize a ping interval when the connection is established', () => {
     const setInterval = sinon.stub(clock, 'setInterval');
 
-    const clientConnected = sinon.stub(websocket, 'clientConnected').resolves();
     websocket.connect();
     clientStub.onopen();
 
-    return clientConnected()
-      .then(() => {
-        should(setInterval)
-          .be.calledOnce();
-      });
+    should(setInterval)
+      .be.calledOnce();
   });
 
   it('should call listeners on a "reconnect" event', () => {

--- a/test/protocol/WebSocket.test.js
+++ b/test/protocol/WebSocket.test.js
@@ -102,11 +102,15 @@ describe('WebSocket networking module', () => {
   it('should initialize a ping interval when the connection is established', () => {
     const setInterval = sinon.stub(clock, 'setInterval');
 
+    const clientConnected = sinon.stub(websocket, 'clientConnected').resolves();
     websocket.connect();
     clientStub.onopen();
 
-    should(setInterval)
-      .be.calledOnce();
+    return clientConnected()
+      .then(() => {
+        should(setInterval)
+          .be.calledOnce();
+      });
   });
 
   it('should call listeners on a "reconnect" event', () => {


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?
<!-- Please fulfill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
React Native WebSocket library throw an error when a message is sent through the socket while its state is still "CONNECTING".
Fix this issue by preventing send pings until its "OPEN"