### PR TITLE
Add _source property to user objects

### DIFF
--- a/doc/7/controllers/security/create-user/snippets/create-user.test.yml
+++ b/doc/7/controllers/security/create-user/snippets/create-user.test.yml
@@ -6,5 +6,5 @@ template: default
 expected:
   - "User {"
   - "_id: 'jdoe',"
-  - "content: {"
+  - "_source: {"
   - "profileIds: \\[ \\'default\\' \\],"

--- a/doc/7/core-classes/user/properties/index.md
+++ b/doc/7/core-classes/user/properties/index.md
@@ -9,16 +9,17 @@ order: 10
 # Properties
 
 
-| Property | Type | Description |
-|--- |--- |--- |
-| `_id` | <pre>string</pre> | User ID (kuid) |
-| `content` | <pre>object</pre> | User internal content |
+| Property  | Type              | Description                                                   |
+|-----------|-------------------|---------------------------------------------------------------|
+| `_id`     | <pre>string</pre> | User ID (kuid)                                                |
+| `_source` | <pre>object</pre> | User internal content <SinceBadge since="auto-version"/>      |
+| `content` | <pre>object</pre> | User internal content <DeprecatedBadge since="auto-version"/> |
 
-### content
+### _source
 
-The `content` property is an object containing, alongside custom defined values, the following generic properties:
+The `_source` property is an object containing, alongside custom defined values, the following generic properties:
 
-| Property | Type | Description |
-|--- |--- |--- |
-| `profileIds` | <pre>string[]</pre> | Profiles IDs for this user |
-| `_kuzzle_info` | <pre>object</pre> | [Kuzzle metadata](/core/2/guides/main-concepts/data-storage#kuzzle-metadata) |
+| Property       | Type                | Description                                                                  |
+|----------------|---------------------|------------------------------------------------------------------------------|
+| `profileIds`   | <pre>string[]</pre> | Profiles IDs for this user                                                   |
+| `_kuzzle_info` | <pre>object</pre>   | [Kuzzle metadata](/core/2/guides/main-concepts/data-storage#kuzzle-metadata) |

--- a/src/core/security/User.ts
+++ b/src/core/security/User.ts
@@ -6,10 +6,20 @@ export class User {
    * Kuid (Kuzzle unique ID)
    */
   public _id: string;
+
   /**
-   * Custom content
+   * User content
    */
-  public content: JSONObject;
+  public _source: JSONObject;
+
+  /**
+   * User content
+   *
+   * @deprecated
+   */
+  get content (): JSONObject {
+    return this._source;
+  }
 
   private _kuzzle: any;
 
@@ -24,7 +34,7 @@ export class User {
     });
 
     this._id = _id;
-    this.content = content;
+    this._source = content;
   }
 
   private get kuzzle () {
@@ -35,7 +45,7 @@ export class User {
    * Array of profile IDs
    */
   get profileIds (): Array<string> {
-    return this.content.profileIds || [];
+    return this._source.profileIds || [];
   }
 
   /**

--- a/test/core/security/user.test.js
+++ b/test/core/security/user.test.js
@@ -41,4 +41,18 @@ describe('User', () => {
         });
     });
   });
+
+  describe('#_source', () => {
+    it('should return the user custom content', () => {
+      user = new User({}, 'foobar', { email: 'foobar@goo.com' });
+
+      should(user._source).be.eql({ email: 'foobar@goo.com' });
+    });
+
+    it('should keep accessors to deprecated "content" getter', () => {
+      user = new User({}, 'foobar', { email: 'foobar@goo.com' });
+
+      should(user.content).be.eql({ email: 'foobar@goo.com' });
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Add a `_source` property containing the user custom content to match the API.

Fix #604 
