### PR TITLE
Add cookie authentication support

### DIFF
--- a/doc/7/controllers/auth/login/index.md
+++ b/doc/7/controllers/auth/login/index.md
@@ -9,7 +9,11 @@ description: Authenticate a user
 
 Authenticates a user.
 
-If this action is successful, then the [jwt](/sdk/js/7/core-classes/kuzzle/properties) property of this class instance is set to the new authentication token.
+When the SDK is constructed with the option [cookieAuth](/sdk/js/7/core-classes/kuzzle/constructor)
+- If this action is successful, then http cookie is set to the new authentication token.
+  
+Otherwise
+- If this action is successful, then the [jwt](/sdk/js/7/core-classes/kuzzle/properties) property of this class instance is set to the new authentication token.
 
 All further requests emitted by this SDK instance will be on behalf of the authenticated user, until either the authenticated token expires, the [logout](/sdk/js/7/controllers/auth/logout) action is called, or the `jwt` property is manually set to another value.
 
@@ -42,7 +46,11 @@ Check the appropriate [authentication plugin](/core/2/guides/write-plugins/integ
 
 ## Resolves
 
-The **login** action returns the encrypted JSON Web Token.
+When the SDK is constructed with the option [cookieAuth](/sdk/js/7/core-classes/kuzzle/constructor)
+- The **login** action returns nothing, the token is stored in the cookies.
+  
+Otherwise
+- The **login** action returns the encrypted JSON Web Token.
 
 ## Usage
 

--- a/doc/7/controllers/auth/refresh-token/index.md
+++ b/doc/7/controllers/auth/refresh-token/index.md
@@ -24,19 +24,19 @@ refreshToken ([options])
 
 <br/>
 
-| Arguments    | Type    | Description |
-|--------------|---------|-------------|
-| `options`  | <pre>object</pre> | Query options |
+| Arguments | Type              | Description   |
+| --------- | ----------------- | ------------- |
+| `options` | <pre>object</pre> | Query options |
 
 
 ### options
 
 Additional query options
 
-| Property     | Type<br/>(default)    | Description   |
-| -------------- | --------- | ------------- |
-| `expiresIn` | <pre>string</pre> | Expiration time in [ms library](https://www.npmjs.com/package/ms) format. (e.g. `2h`) |
-| `queuable` | <pre>boolean</pre><br/>(`true`)| If true, queues the request during downtime, until connected to Kuzzle again |
+| Property    | Type<br/>(default)              | Description                                                                           |
+| ----------- | ------------------------------- | ------------------------------------------------------------------------------------- |
+| `expiresIn` | <pre>string</pre>               | Expiration time in [ms library](https://www.npmjs.com/package/ms) format. (e.g. `2h`) |
+| `queuable`  | <pre>boolean</pre><br/>(`true`) | If true, queues the request during downtime, until connected to Kuzzle again          |
 
 ### expiresIn
 
@@ -46,12 +46,12 @@ The default value for the `expiresIn` option is defined at server level, in Kuzz
 
 The `refreshToken` action resolves to a token object with the following properties:
 
-| Property   | Type    | Description  |
-|--------------|---------|-------------|
-| `_id` | <pre>string</pre> | User unique identifier ([kuid](/core/2/guides/main-concepts/authentication#kuzzle-user-identifier-kuid)) |
-| `expiresAt` | <pre>number</pre> | Expiration timestamp in Epoch-millis format (UTC) |
-| `jwt` | <pre>string</pre> | Authentication token |
-| `ttl` | <pre>number</pre> | Time to live of the authentication token, in milliseconds |
+| Property    | Type              | Description                                                                                                                                                              |
+| ----------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `_id`       | <pre>string</pre> | User unique identifier ([kuid](/core/2/guides/main-concepts/authentication#kuzzle-user-identifier-kuid))                                                                 |
+| `expiresAt` | <pre>number</pre> | Expiration timestamp in Epoch-millis format (UTC)                                                                                                                        |
+| `jwt`       | <pre>string</pre> | Authentication token (returned only if the option [cookieAuth](/sdk/js/7/core-classes/kuzzle/constructor) is not enabled in the SDK, otherwise stored in an http cookie) |
+| `ttl`       | <pre>number</pre> | Time to live of the authentication token, in milliseconds                                                                                                                |
 
 ## Usage
 

--- a/doc/7/core-classes/kuzzle/constructor/index.md
+++ b/doc/7/core-classes/kuzzle/constructor/index.md
@@ -36,18 +36,19 @@ It can be one of the following available protocols:
 
 Kuzzle SDK instance options.
 
-| Property          | Type<br/>(default)               | Description                                                        |
-| ----------------- | -------------------------------- | ------------------------------------------------------------------ |
-| `autoQueue`       | <pre>boolean</pre><br/>(`false`) | Automatically queue all requests during offline mode               |
-| `autoReplay`      | <pre>boolean</pre><br/>(`false`) | Automatically replay queued requests on a `reconnected` event      |
-| `autoResubscribe` | <pre>boolean</pre><br/>(`true`)  | Automatically renew all subscriptions on a `reconnected` event     |
-| `eventTimeout`    | <pre>number</pre><br/>(`200`)    | Time (in ms) during which a similar event is ignored               |
-| `offlineMode`     | <pre>string</pre><br/>(`manual`) | Offline mode configuration. Can be `manual` or `auto`              |
-| `queueTTL`        | <pre>number</pre><br/>(`120000`) | Time a queued request is kept during offline mode, in milliseconds |
-| `queueMaxSize`    | <pre>number</pre><br/>(`500`)    | Number of maximum requests kept during offline mode                |
-| `replayInterval`  | <pre>number</pre><br/>(`10`)     | Delay between each replayed requests, in milliseconds              |
-| `tokenExpiredInterval` | <pre>number</pre><br/>(`1000`)    | Time (in ms) during which a TokenExpired event is ignored               |
-| `volatile`        | <pre>object</pre><br/>(`{}`)     | Common volatile data, will be sent to all future requests          |
+| Property               | Type<br/>(default)               | Description                                                        |
+| ---------------------- | -------------------------------- | ------------------------------------------------------------------ |
+| `autoQueue`            | <pre>boolean</pre><br/>(`false`) | Automatically queue all requests during offline mode               |
+| `autoReplay`           | <pre>boolean</pre><br/>(`false`) | Automatically replay queued requests on a `reconnected` event      |
+| `autoResubscribe`      | <pre>boolean</pre><br/>(`true`)  | Automatically renew all subscriptions on a `reconnected` event     |
+| `cookieAuth`           | <pre>boolean</pre><br/>(`false`) | Uses cookie to store token                                         |
+| `eventTimeout`         | <pre>number</pre><br/>(`200`)    | Time (in ms) during which a similar event is ignored               |
+| `offlineMode`          | <pre>string</pre><br/>(`manual`) | Offline mode configuration. Can be `manual` or `auto`              |
+| `queueTTL`             | <pre>number</pre><br/>(`120000`) | Time a queued request is kept during offline mode, in milliseconds |
+| `queueMaxSize`         | <pre>number</pre><br/>(`500`)    | Number of maximum requests kept during offline mode                |
+| `replayInterval`       | <pre>number</pre><br/>(`10`)     | Delay between each replayed requests, in milliseconds              |
+| `tokenExpiredInterval` | <pre>number</pre><br/>(`1000`)   | Time (in ms) during which a TokenExpired event is ignored          |
+| `volatile`             | <pre>object</pre><br/>(`{}`)     | Common volatile data, will be sent to all future requests          |
 
 ## Return
 

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -84,6 +84,7 @@ export class Kuzzle extends KuzzleEventEmitter {
   private _replayInterval: any;
   private _tokenExpiredInterval: any;
   private _lastTokenExpired: any;
+  private _cookieAuthentication: boolean;
 
   private __proxy__: any;
 
@@ -164,6 +165,12 @@ export class Kuzzle extends KuzzleEventEmitter {
        * If set to `auto`, the `autoQueue` and `autoReplay` are also set to `true`
        */
       offlineMode?: 'auto';
+      /**
+       * If `true` uses cookie to store token
+       * Only supported in a browser
+       * Default: `false`
+       */
+      cookieAuth?: boolean;
     } = {}
   ) {
     super();
@@ -208,6 +215,14 @@ export class Kuzzle extends KuzzleEventEmitter {
       ? options.volatile
       : {};
 
+    this._cookieAuthentication = typeof options.cookieAuth === 'boolean'
+      ? options.cookieAuth
+      : false;
+    
+    if (this._cookieAuthentication && typeof XMLHttpRequest === 'undefined') {
+      throw new Error('Support for cookie authentication with cookieAuth option is not supported outside a browser');
+    }
+    
     // controllers
     this.useController(AuthController, 'auth');
     this.useController(BulkController, 'bulk');
@@ -290,6 +305,10 @@ export class Kuzzle extends KuzzleEventEmitter {
   set autoReplay (value) {
     this._checkPropertyType('_autoReplay', 'boolean', value);
     this._autoReplay = value;
+  }
+
+  get cookieAuthentication () {
+    return this._cookieAuthentication;
   }
 
   get connected () {

--- a/src/controllers/Auth.ts
+++ b/src/controllers/Auth.ts
@@ -197,7 +197,7 @@ export class AuthController extends BaseController {
     if (token === undefined) {
       cookieAuth = this.kuzzle.cookieAuthentication;
 
-      if (! cookieAuth) {
+      if (! cookieAuth && this.authenticationToken) {
         token = this.authenticationToken.encodedJwt;
       }
     }

--- a/src/controllers/Auth.ts
+++ b/src/controllers/Auth.ts
@@ -51,6 +51,10 @@ export class AuthController extends BaseController {
    * a developer simply wishes to verify their token
    */
   authenticateRequest (request: any) {
+    if (this.kuzzle.cookieAuthentication) {
+      return;
+    }
+
     if ( ! this.authenticationToken
       || (request.controller === 'auth'
         && (request.action === 'checkToken' || request.action === 'login'))
@@ -189,13 +193,19 @@ export class AuthController extends BaseController {
      */
     expiresAt: number
   }> {
-    if (token === undefined && this.authenticationToken) {
-      token = this.authenticationToken.encodedJwt;
-    }
+    let cookieAuth = false;
+    if (token === undefined) {
+      cookieAuth = this.kuzzle.cookieAuthentication;
 
+      if (! cookieAuth) {
+        token = this.authenticationToken.encodedJwt;
+      }
+    }
+    
     return this.query({
       action: 'checkToken',
-      body: { token }
+      body: { token },
+      cookieAuth
     }, { queuable: false })
       .then(response => response.result);
   }
@@ -370,7 +380,8 @@ export class AuthController extends BaseController {
 
   /**
    * Send login request to kuzzle with credentials
-   * If login success, store the jwt into kuzzle object
+   * If kuzzle cookieAuthentication is false and login success, store the jwt into kuzzle object
+   * If kuzzle cookieAuthentication true and login success, the token is stored in a cookie
    *
    * @see https://docs.kuzzle.io/sdk/js/7/controllers/auth/login
    *
@@ -389,11 +400,21 @@ export class AuthController extends BaseController {
       strategy,
       expiresIn,
       body: credentials,
-      action: 'login'
+      action: 'login',
+      cookieAuth: this.kuzzle.cookieAuthentication
     };
 
     return this.query(request, { queuable: false, verb: 'POST' })
       .then(response => {
+        if (this.kuzzle.cookieAuthentication) {
+          if (response.result.jwt) {
+            throw new Error('Kuzzle support for cookie authentication is disabled or not supported');
+          }
+
+          this.kuzzle.emit('loginAttempt', { success: true });
+          return;
+        }
+
         this._authenticationToken = new Jwt(response.result.jwt);
 
         this.kuzzle.emit('loginAttempt', { success: true });
@@ -413,7 +434,8 @@ export class AuthController extends BaseController {
    */
   logout (): Promise<void> {
     return this.query({
-      action: 'logout'
+      action: 'logout',
+      cookieAuth: this.kuzzle.cookieAuthentication
     }, { queuable: false })
       .then(() => {
         this._authenticationToken = null;
@@ -528,12 +550,15 @@ export class AuthController extends BaseController {
   }> {
     const query = {
       action: 'refreshToken',
-      expiresIn: options.expiresIn
+      expiresIn: options.expiresIn,
+      cookieAuth: this.kuzzle.cookieAuthentication
     };
 
     return this.query(query, options)
       .then(response => {
-        this._authenticationToken = new Jwt(response.result.jwt);
+        if (! this.kuzzle.cookieAuthentication) {
+          this._authenticationToken = new Jwt(response.result.jwt);
+        }
 
         return response.result;
       });

--- a/src/protocols/Http.ts
+++ b/src/protocols/Http.ts
@@ -330,6 +330,9 @@ export default class HttpProtocol extends KuzzleAbstractProtocol {
 
       xhr.open(method, url);
 
+      // Authorize the reception of cookies
+      xhr.withCredentials = true;
+
       for (const header of Object.keys(payload.headers || {})) {
         xhr.setRequestHeader(header, payload.headers[header]);
       }

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -174,8 +174,8 @@ describe('Auth Controller', () => {
         }
       });
 
-      const jwt = generateJwt();
-      kuzzle.auth.authenticationToken = jwt
+      const token = generateJwt();
+      kuzzle.auth.authenticationToken = token;
 
       kuzzle.cookieAuthentication = false;
 
@@ -187,7 +187,7 @@ describe('Auth Controller', () => {
               controller: 'auth',
               action: 'checkToken',
               body: {
-                token: jwt
+                token
               },
               cookieAuth: false
             }, {queuable: false});
@@ -208,8 +208,8 @@ describe('Auth Controller', () => {
         }
       });
 
-      const jwt = generateJwt();
-      kuzzle.auth.authenticationToken = jwt
+      const token = generateJwt();
+      kuzzle.auth.authenticationToken = token;
 
       kuzzle.cookieAuthentication = true;
 
@@ -429,15 +429,15 @@ describe('Auth Controller', () => {
         .be.rejected()
         .then(() => {
           should(kuzzle.query)
-          .be.calledOnce()
-          .be.calledWith({
-            controller: 'auth',
-            action: 'login',
-            strategy: 'strategy',
-            expiresIn: 'expiresIn',
-            body: credentials,
-            cookieAuth: true
-          }, {queuable: false, verb: 'POST'})
+            .be.calledOnce()
+            .be.calledWith({
+              controller: 'auth',
+              action: 'login',
+              strategy: 'strategy',
+              expiresIn: 'expiresIn',
+              body: credentials,
+              cookieAuth: true
+            }, {queuable: false, verb: 'POST'});
         });
     });
 


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?
<!-- Please fulfill this section -->

This PR adds the option `cookieAuthentication` to enable the  support of cookie authentication in the SDK
along with some tests to ensure that everything is working properly.

Why making this an SDK option instead of a specific option for `auth:login`, `auth:checkToken`, `auth:refreshToken`, `auth:logout` ?

By making this a an option that can only be set at the initialization of the SDK we can avoid the user mixing cookie and token authentication at runtime, we can also throw at the initialization of the SDK if the feature is enabled when the SDK is not used in a browser