### PR TITLE
Implement security:getUserStrategies

### DIFF
--- a/doc/7/controllers/security/get-user-strategies/index.md
+++ b/doc/7/controllers/security/get-user-strategies/index.md
@@ -1,0 +1,37 @@
+---
+code: true
+type: page
+title: getUserStrategies
+description: Gets all the available authentication strategies of a user
+---
+
+# getUserStrategies
+
+Gets all the available authentication strategies of a user.
+
+<br />
+
+```js
+getUserStrategies(kui, [options]);
+```
+
+<br />
+
+| Property | Type | Description |
+|--- |--- |--- |
+| `kuid` | <pre>string</pre> | User [kuid](/core/2/guides/main-concepts/authentication#kuzzle-user-identifier-kuid) |
+| `options` | <pre>object</pre> | Query options |
+
+### options
+
+| Property | Type<br />(default) | Description |
+| --- | --- | --- |
+| `queuable` | <pre>boolean</pre><br />(`true`) | If true, queues the request during downtime, until connected to Kuzzle again |
+
+## Resolves
+
+Resolves to an array of strings containing all the authentication strategies available for the requested user.
+
+## Usage
+
+<<< ./snippets/get-user-strategies.js

--- a/doc/7/controllers/security/get-user-strategies/index.md
+++ b/doc/7/controllers/security/get-user-strategies/index.md
@@ -12,7 +12,7 @@ Gets all the available authentication strategies of a user.
 <br />
 
 ```js
-getUserStrategies(kui, [options]);
+getUserStrategies(kuid, [options]);
 ```
 
 <br />

--- a/doc/7/controllers/security/get-user-strategies/index.md
+++ b/doc/7/controllers/security/get-user-strategies/index.md
@@ -7,6 +7,9 @@ description: Gets all the available authentication strategies of a user
 
 # getUserStrategies
 
+<SinceBadge version="Kuzzle 2.9.0"/>
+<SinceBadge version="auto-version"/>
+
 Gets all the available authentication strategies of a user.
 
 <br />

--- a/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.js
+++ b/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.js
@@ -1,10 +1,6 @@
-try {
-  const response = await kuzzle.security.getUserStrategies('john.doe');
+const response = await kuzzle.security.getUserStrategies('john.doe');
 
-  console.log(response);
-  /*
-  [ 'local' ]
-   */
-} catch (e) {
-  console.error(e);
-}
+console.log(response);
+/*
+[ 'local' ]
+ */

--- a/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.js
+++ b/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.js
@@ -1,0 +1,10 @@
+try {
+  const response = await kuzzle.security.getUserStrategies('john.doe');
+
+  console.log(response);
+  /*
+  [ 'local' ]
+   */
+} catch (e) {
+  console.error(e);
+}

--- a/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.js
+++ b/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.js
@@ -1,6 +1,4 @@
-const response = await kuzzle.security.getUserStrategies('john.doe');
+const strategies = await kuzzle.security.getUserStrategies('john.doe');
 
-console.log(response);
-/*
-[ 'local' ]
- */
+console.log(strategies);
+// [ 'local' ]

--- a/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.test.yml
+++ b/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.test.yml
@@ -1,0 +1,20 @@
+name: security#getUserStrategies
+description: get user strategies
+hooks:
+  before: >
+    curl --fail -H "Content-type: application/json" -d '{
+      "content": {
+        "profileIds": [ "default" ],
+        "fullName": "John Doe"
+      },
+      "credentials": {
+        "local": {
+          "username": "jdoe",
+          "password": "password"
+        }
+      }
+    }' kuzzle:7512/users/john.doe/_create
+  after: curl -XDELETE kuzzle:7512/users/john.doe
+template: default
+expected:
+  - "[ 'local' ]"

--- a/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.test.yml
+++ b/doc/7/controllers/security/get-user-strategies/snippets/get-user-strategies.test.yml
@@ -15,6 +15,6 @@ hooks:
       }
     }' kuzzle:7512/users/john.doe/_create
   after: curl -XDELETE kuzzle:7512/users/john.doe
-template: default
+template: catch
 expected:
   - "[ 'local' ]"

--- a/src/controllers/Security.js
+++ b/src/controllers/Security.js
@@ -330,6 +330,14 @@ class SecurityController extends BaseController {
       .then(response => response.result.hits);
   }
 
+  getUserStrategies (_id, options = {}) {
+    return this.query({
+      _id,
+      action: 'getUserStrategies'
+    }, options)
+      .then(response => response.result.strategies);
+  }
+
   hasCredentials (strategy, _id, options = {}) {
     return this.query({
       strategy,

--- a/src/protocols/routes.json
+++ b/src/protocols/routes.json
@@ -250,6 +250,10 @@
       "url": "/users/:_id/_rights",
       "verb": "GET"
     },
+    "getUserStrategies": {
+      "url": "/users/:_id/_strategies",
+      "verb": "GET"
+    },
     "searchUsers": {
       "url": "/users/_search",
       "verb": "POST"

--- a/test/controllers/security.test.js
+++ b/test/controllers/security.test.js
@@ -760,6 +760,28 @@ describe('Security Controller', () => {
     });
   });
 
+  describe('getUserStrategies', () => {
+    it('should call security/getUserStrategies query with the user id return a Promise which resolves the list of strategies', () => {
+      const result = {
+        strategies: ['local']
+      };
+      kuzzle.query.resolves({result});
+
+      return kuzzle.security.getUserStrategies('kuid', options)
+        .then(res => {
+          should(kuzzle.query)
+            .be.calledOnce()
+            .be.calledWith({
+              _id: 'kuid',
+              controller: 'security',
+              action: 'getUserStrategies'
+            }, options);
+
+          should(res).be.eql(result.strategies);
+        });
+    });
+  });
+
   describe('hasCredentials', () => {
     it('should call security/hasCredentials query and return a Promise which resolves a boolean', () => {
       kuzzle.query.resolves({result: true});


### PR DESCRIPTION
## What does this PR do?
As the title suggests, this **PR** implements the recently added [security:getUserStrategies](https://docs.kuzzle.io/core/2/api/controllers/security/get-user-strategies/) _(@ Kuzzle Backend)_
So it can be used directly, instead of having to use **query** to access it.

#### Todo:

- [x] Implementation
- [x] Unit Testing
- [x] Doc + Code Snippet

### How should this be manually tested?

1. Create an example user and give it an auth strategy (ex. local).
2. Directly use `sdk.security.getUserStrategies(userKuid)`
3. Verify that you get a string array containing: `[ "local" ]` as response.

Closes #611 