### PR TITLE
Implement index:stats

### DIFF
--- a/doc/7/controllers/index/stats/index.md
+++ b/doc/7/controllers/index/stats/index.md
@@ -1,0 +1,41 @@
+---
+code: true
+type: page
+title: stats
+description: Gets detailed storage statistics
+---
+
+# stats
+
+<SinceBadge version="Kuzzle 2.10.0"/>
+<SinceBadge version="auto-version"/>
+
+Gets detailed storage usage statistics.
+
+<br/>
+
+```js
+stats([options]);
+```
+
+<br/>
+
+| Arguments | Type              | Description   |
+| --------- | ----------------- | ------------- |
+| `options` | <pre>object</pre> | Query options |
+
+### options
+
+Additional query options
+
+| Property   | Type<br/>(default)              | Description                                                                  |
+| ---------- | ------------------------------- | ---------------------------------------------------------------------------- |
+| `queuable` | <pre>boolean</pre><br/>(`true`) | If true, queues the request during downtime, until connected to Kuzzle again |
+
+## Resolves
+
+Returns detailed storage usage statistics: overall index/collection sizes and the number of documents per collection.
+
+## Usage
+
+<<< ./snippets/stats.js

--- a/doc/7/controllers/index/stats/snippets/stats.js
+++ b/doc/7/controllers/index/stats/snippets/stats.js
@@ -2,18 +2,20 @@ const stats = await kuzzle.index.stats();
 
 console.log(JSON.stringify(stats));
 /*
-  indexes: [
-    {
-      name: 'nyc-open-data',
-      size: 42,
-      collections: [
-        {
-          name: 'yellow-taxi',
-          documentCount: 42,
-          size: 42,
-        }
-      ]
-    }
-  ],
-  size: 42
+  {
+    "indexes":[
+      {
+        "name":"nyc-open-data",
+        "size":42,
+        "collections":[
+          {
+            "name":"yellow-taxi",
+            "documentCount":42,
+            "size":42
+          }
+        ]
+      }
+    ],
+    "size":42
+  }
 */

--- a/doc/7/controllers/index/stats/snippets/stats.js
+++ b/doc/7/controllers/index/stats/snippets/stats.js
@@ -1,0 +1,3 @@
+const stats = await kuzzle.index.stats();
+
+console.log(JSON.stringify(stats));

--- a/doc/7/controllers/index/stats/snippets/stats.js
+++ b/doc/7/controllers/index/stats/snippets/stats.js
@@ -1,3 +1,19 @@
 const stats = await kuzzle.index.stats();
 
 console.log(JSON.stringify(stats));
+/*
+  indexes: [
+    {
+      name: 'nyc-open-data',
+      size: 42,
+      collections: [
+        {
+          name: 'yellow-taxi',
+          documentCount: 42,
+          size: 42,
+        }
+      ]
+    }
+  ],
+  size: 42
+*/

--- a/doc/7/controllers/index/stats/snippets/stats.test.yml
+++ b/doc/7/controllers/index/stats/snippets/stats.test.yml
@@ -1,0 +1,10 @@
+---
+name: index#stats
+description: Gets detailed storage statistics
+hooks:
+  before: |
+    curl -X POST kuzzle:7512/nyc-open-data/_create
+    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+  after: curl -X DELETE kuzzle:7512/nyc-open-data
+template: catch
+expected: ["documentCount":0]

--- a/src/controllers/Index.ts
+++ b/src/controllers/Index.ts
@@ -99,4 +99,19 @@ export class IndexController extends BaseController {
     return this.query(request, options)
       .then(response => response.result.deleted);
   }
+
+  /**
+   * Returns detailed storage usage statistics.
+   *
+   * @see https://docs.kuzzle.io/sdk/js/7/controllers/index/stats/
+   *
+   * @param options Additional options
+   *    - `queuable` If true, queues the request during downtime, until connected to Kuzzle again
+   */
+  stats (options: { queuable?: boolean } = {}): Promise<any> {
+    return this.query({
+      action: 'stats'
+    }, options)
+      .then(response => response.result);
+  }
 }

--- a/src/controllers/Index.ts
+++ b/src/controllers/Index.ts
@@ -1,4 +1,5 @@
 import { BaseController } from './Base';
+import { JSONObject } from '../types';
 
 export class IndexController extends BaseController {
 

--- a/src/controllers/Index.ts
+++ b/src/controllers/Index.ts
@@ -108,7 +108,7 @@ export class IndexController extends BaseController {
    * @param options Additional options
    *    - `queuable` If true, queues the request during downtime, until connected to Kuzzle again
    */
-  stats (options: { queuable?: boolean } = {}): Promise<any> {
+  stats (options: { queuable?: boolean } = {}): Promise<JSONObject> {
     return this.query({
       action: 'stats'
     }, options)

--- a/test/controllers/index.test.js
+++ b/test/controllers/index.test.js
@@ -121,7 +121,7 @@ describe('Index Controller', () => {
     });
   });
 
-  describe.only('stats', () => {
+  describe('stats', () => {
     it('should call index/stats query and return a Promise which resolves to an object containing detailed storage statistics', () => {
       const result = {
         indexes: [

--- a/test/controllers/index.test.js
+++ b/test/controllers/index.test.js
@@ -120,4 +120,37 @@ describe('Index Controller', () => {
         });
     });
   });
+
+  describe.only('stats', () => {
+    it('should call index/stats query and return a Promise which resolves to an object containing detailed storage statistics', () => {
+      const result = {
+        indexes: [
+          {
+            name: 'nyc-open-data',
+            size: 42,
+            collections: [
+              {
+                name: 'yellow-taxi',
+                documentCount: 42,
+                size: 42,
+              }
+            ]
+          }
+        ]
+      };
+      kuzzle.query.resolves({result});
+
+      return kuzzle.index.stats(options)
+        .then(res => {
+          should(kuzzle.query)
+            .be.calledOnce()
+            .be.calledWith({
+              controller: 'index',
+              action: 'stats'
+            }, options);
+
+          should(res).be.equal(result);
+        });
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do?
This **PR** implements the recently added [index:stats](https://docs.kuzzle.io/core/2/api/controllers/index/stats/) _(@ Kuzzle Backend v2.10.0)_
So it can be used directly, instead of having to use **query** to access it.

#### Todo:

- [x] Implementation
- [x] Unit Testing
- [x] Doc + Code Snippet

### How should this be manually tested?

1. Launch a Kuzzle stack.
2. Directly use `sdk.index.stats()`
3. Verify that you get stats that make sense.

Closes #608 

> :information_source: It seems that **Codecov** is not taking the latest commit? :facepalm: 