### PR TITLE
Add kuzzleStack property to KuzzleError

### DIFF
--- a/doc/7/core-classes/kuzzle-error/properties/index.md
+++ b/doc/7/core-classes/kuzzle-error/properties/index.md
@@ -9,11 +9,12 @@ order: 10
 
 # Properties
 
-| Property name        | Type     | Description          |
-| -------------------- | -------- | --------------------------------------- |
-| `message`            | <pre>string</pre> | Error message    |
-| `status`             | <pre>number</pre> | Error status code      |
-| `stack`              | <pre>string</pre> | Error stacktrace (only in development mode)   |
-| `id`  | <pre>string</pre> | Error unique identifier                    |
-| `code`  | <pre>string</pre> | Error unique code                    |
+| Property name | Type              | Description                                                         |
+|---------------|-------------------|---------------------------------------------------------------------|
+| `message`     | <pre>string</pre> | Error message                                                       |
+| `status`      | <pre>number</pre> | Error status code                                                   |
+| `stack`       | <pre>string</pre> | Complete error stacktrace (Kuzzle + SDK) (only in development mode) |
+| `kuzzleStack` | <pre>string</pre> | Kuzzle stacktrace (only in development mode)                        |
+| `id`          | <pre>string</pre> | Error unique identifier                                             |
+| `code`        | <pre>string</pre> | Error unique code                                                   |
 

--- a/doc/7/core-classes/kuzzle-error/properties/index.md
+++ b/doc/7/core-classes/kuzzle-error/properties/index.md
@@ -11,10 +11,10 @@ order: 10
 
 | Property name | Type              | Description                                                         |
 |---------------|-------------------|---------------------------------------------------------------------|
+| `kuzzleStack` | <pre>string</pre> | Kuzzle stacktrace (only in development mode)                        |
 | `message`     | <pre>string</pre> | Error message                                                       |
 | `status`      | <pre>number</pre> | Error status code                                                   |
 | `stack`       | <pre>string</pre> | Complete error stacktrace (Kuzzle + SDK) (only in development mode) |
-| `kuzzleStack` | <pre>string</pre> | Kuzzle stacktrace (only in development mode)                        |
 | `id`          | <pre>string</pre> | Error unique identifier                                             |
 | `code`        | <pre>string</pre> | Error unique code                                                   |
 

--- a/doc/7/essentials/error-handling/index.md
+++ b/doc/7/essentials/error-handling/index.md
@@ -12,11 +12,13 @@ All SDK methods return a promise, that can be rejected with a `KuzzleError` valu
 
 [KuzzleError](/sdk/js/7/core-classes/kuzzle-error/introduction) objects inherit the standard `Error` object, and add the following properties to it:
 
-| Property | Type              | Description                                                                                |
-| -------- | ----------------- | ------------------------------------------------------------------------------------------ |
-| `status` | <pre>number</pre> | Status following [HTTP Standards](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) |
-| `stack`  | <pre>string</pre> | Error stacktrace (Only in development mode)   | `id`  | <pre>string</pre> | Error unique identifier                    |
-| `code`  | <pre>string</pre> | Error unique code                    |
+| Property      | Type              | Description                                  |
+|---------------|-------------------|----------------------------------------------|
+| `kuzzleStack` | <pre>string</pre> | Kuzzle stacktrace (only in development mode) |
+| `status`      | <pre>number</pre> | Error status code                            |
+| `id`          | <pre>string</pre> | Error unique identifier                      |
+| `code`        | <pre>string</pre> | Error unique code                            |
+
 
 
 You can find a detailed list of possible errors messages and statuses in the [documentation API](/core/2/api/errors/types).

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -77,6 +77,7 @@ export class KuzzleError extends Error {
     // If we have a stacktrace coming from Kuzzle, merge it with
     // the SDK one
     if (apiError.stack) {
+      this.kuzzleStack = apiError.stack;
       this.stack = apiError.stack + '\n';
       this.stack += '          |\n';
       this.stack += '          |\n';


### PR DESCRIPTION
## What does this PR do?

Add the  `kuzzleStack` property containing the original stacktrace from Kuzzle.

It will allow to display only the Kuzzle stacktrace when an error occurs (e.g. in Kourou the user does not care about the SDK stacktrace)