### PR TITLE
Pick first route when multiple non-GET routes of the same size are available

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -27,3 +27,5 @@ src/core/searchResult/Profile.js
 src/core/searchResult/Role.js
 src/core/searchResult/Specifications.js
 src/core/searchResult/User.js
+src/utils/Deprecation.js
+src/utils/interfaces.js

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ src/core/searchResult/Profile.js
 src/core/searchResult/Role.js
 src/core/searchResult/Specifications.js
 src/core/searchResult/User.js
+src/utils/Deprecation.js
+src/utils/interfaces.js

--- a/src/protocols/Http.ts
+++ b/src/protocols/Http.ts
@@ -395,11 +395,10 @@ function getPostRoute (routes) {
 }
 
 function getCorrectRoute (routes) {
-  let
-    shortestRoute = routes[0],
-    getRoute,
-    minLength = routes[0].url.length,
-    sameLength = true;
+  let shortestRoute = routes[0];
+  let getRoute = routes[0];
+  let minLength = routes[0].url.length;
+  let sameLength = true;
 
   for (const route of routes) {
     if (route.url.length !== minLength) {
@@ -416,7 +415,7 @@ function getCorrectRoute (routes) {
     }
   }
 
-  // with same URL size, we keep the GET route
+  // with same URL size, we prefer the GET route
   // with differents URL sizes, we keep the shortest because URL params
   // will be in the query string
   return sameLength ? getRoute : shortestRoute;

--- a/test/protocol/Http.test.js
+++ b/test/protocol/Http.test.js
@@ -70,6 +70,52 @@ describe('HTTP networking module', () => {
         });
     });
 
+    it('should prefer GET routes when multiple routes are available for a same action', async () => {
+      protocol._sendHttpRequest.resolves({
+        result: {
+          foo: {
+            bar: {
+              http: [
+                { path: 'samesize', url: 'samesize', verb: 'OHNOES' },
+                { path: 'samesize', url: 'samesize', verb: 'GET' },
+              ]
+            }
+          }
+        }
+      });
+
+      await protocol.connect();
+
+      should(protocol.routes).match({
+        foo: {
+          bar: { verb: 'GET', url: 'samesize' },
+        }
+      });
+    });
+
+    it('should pick a route at random when no GET route is available', async () => {
+      protocol._sendHttpRequest.resolves({
+        result: {
+          foo: {
+            bar: {
+              http: [
+                { path: 'samesize', url: 'samesize', verb: 'SURE' },
+                { path: 'samesize', url: 'samesize', verb: 'YOU\'RE KEN' },
+              ]
+            }
+          }
+        }
+      });
+
+      await protocol.connect();
+
+      should(protocol.routes).match({
+        foo: {
+          bar: { verb: 'SURE', url: 'samesize' },
+        }
+      });
+    });
+
     it('should fallback to static routes if server:publicApi is restricted', () => {
       protocol._sendHttpRequest.onCall(0).resolves({ error: { status: 401 } });
 


### PR DESCRIPTION
# Description

When Kuzzle exposes multiple HTTP routes for the same controller action, the SDK picks either the one with the shortest URL and, if there is a tie in URL lengths, it prefers the GET route to favor content caching.

But when multiple routes are available, all with the same size, and none are a GET route, the SDK picks... none of them. Resulting in some actions returning a "URL not found" when trying to use them.

This PR fixes that.
