### PR TITLE
Remove mentions of admin console tests in workflow

### DIFF
--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -148,7 +148,7 @@ jobs:
   documentation-production:
     name: Deployment Doc Prod
     runs-on: ubuntu-18.04
-    needs: [functional-tests, admin-console-tests, documentation-snippet-tests, documentation-dead-links]
+    needs: [functional-tests, documentation-snippet-tests, documentation-dead-links]
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules
@@ -177,7 +177,7 @@ jobs:
   npm-deploy:
     name: Publish Package to NPM.js
     runs-on: ubuntu-18.04
-    needs: [functional-tests, admin-console-tests, documentation-snippet-tests, documentation-dead-links]
+    needs: [functional-tests, documentation-snippet-tests, documentation-dead-links]
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules


### PR DESCRIPTION
## What does this PR do ?

Remove mentions of admin-console-tests in workflow. Indeed those tests were commented in another [PR](https://github.com/kuzzleio/sdk-javascript/pull/625) and CI fails because of that.