### PR TITLE
[HOTFIX] Ensure returning the user body in the content property when serialized

### DIFF
--- a/doc/7/core-classes/profile/serialize/index.md
+++ b/doc/7/core-classes/profile/serialize/index.md
@@ -1,0 +1,25 @@
+---
+code: true
+type: page
+title: serialize
+description: Profile serialize method
+---
+
+# serialize
+
+<SinceBadge version="7.6.2" />
+
+Serialize the profile into a JSONObject.
+
+## Arguments
+
+```js
+serialize();
+```
+
+## Resolve
+
+Serialized profile with the following properties:
+  - `_id`: Profile ID
+  - `rateLimit`: Profile rate limits
+  - `policies`: Profile policies

--- a/doc/7/core-classes/role/serialize/index.md
+++ b/doc/7/core-classes/role/serialize/index.md
@@ -1,0 +1,24 @@
+---
+code: true
+type: page
+title: serialize
+description: Role serialize method
+---
+
+# serialize
+
+<SinceBadge version="7.6.2" />
+
+Serialize the profile into a JSONObject.
+
+## Arguments
+
+```js
+serialize();
+```
+
+## Resolve
+
+Serialized role with the following properties:
+  - `_id`: Role ID
+  - `controllers`: Controllers definition

--- a/doc/7/core-classes/user/serialize/index.md
+++ b/doc/7/core-classes/user/serialize/index.md
@@ -1,0 +1,24 @@
+---
+code: true
+type: page
+title: serialize
+description: User serialize method
+---
+
+# serialize
+
+<SinceBadge version="7.6.2" />
+
+Serialize the user into a JSONObject.
+
+## Arguments
+
+```js
+serialize();
+```
+
+## Resolve
+
+Serialized user with the following properties:
+  - `_id`: User ID
+  - `_source`: User content

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.6.1",
+  "version": "7.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.6.1",
+  "version": "7.6.2",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/controllers/Document.ts
+++ b/src/controllers/Document.ts
@@ -263,6 +263,7 @@ export class DocumentController extends BaseController {
    *    - `queuable` If true, queues the request during downtime, until connected to Kuzzle again
    *    - `refresh` If set to `wait_for`, Kuzzle will not respond until the API key is indexed
    *    - `silent` If true, then Kuzzle will not generate notifications
+   *    - `strict` If true, an error will occur if a document was not created
    *
    * @returns An object containing 2 arrays: "successes" and "errors"
    */
@@ -279,7 +280,7 @@ export class DocumentController extends BaseController {
        */
       body: JSONObject;
     }>,
-    options: { queuable?: boolean, refresh?: 'wait_for', silent?: boolean } = {}
+    options: { queuable?: boolean, refresh?: 'wait_for', silent?: boolean, strict?: boolean } = {}
   ): Promise<{
     /**
      * Array of successfully created documents
@@ -327,6 +328,7 @@ export class DocumentController extends BaseController {
    *    - `queuable` If true, queues the request during downtime, until connected to Kuzzle again
    *    - `refresh` If set to `wait_for`, Kuzzle will not respond until the API key is indexed
    *    - `silent` If true, then Kuzzle will not generate notifications
+   *    - `strict` If true, an error will occur if a document was not created
    *
    * @returns An object containing 2 arrays: "successes" and "errors"
    */
@@ -343,7 +345,7 @@ export class DocumentController extends BaseController {
        */
       body: JSONObject;
     }>,
-    options: { queuable?: boolean, refresh?: 'wait_for', silent?: boolean } = {}
+    options: { queuable?: boolean, refresh?: 'wait_for', silent?: boolean, strict?: boolean } = {}
   ): Promise<{
     /**
      * Array of successfully created documents
@@ -391,6 +393,7 @@ export class DocumentController extends BaseController {
    *    - `queuable` If true, queues the request during downtime, until connected to Kuzzle again
    *    - `refresh` If set to `wait_for`, Kuzzle will not respond until the API key is indexed
    *    - `silent` If true, then Kuzzle will not generate notifications
+   *    - `strict` If true, an error will occur if a document was not deleted
    *
    * @returns An object containing 2 arrays: "successes" and "errors"
    */
@@ -398,7 +401,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     ids: Array<string>,
-    options: { queuable?: boolean, refresh?: 'wait_for', silent?: boolean } = {}
+    options: { queuable?: boolean, refresh?: 'wait_for', silent?: boolean, strict?: boolean } = {}
   ): Promise<{
     /**
      * Array of successfully deleted documents IDS
@@ -482,6 +485,7 @@ export class DocumentController extends BaseController {
    *    - `queuable` If true, queues the request during downtime, until connected to Kuzzle again
    *    - `refresh` If set to `wait_for`, Kuzzle will not respond until the API key is indexed
    *    - `silent` If true, then Kuzzle will not generate notifications
+   *    - `strict` If true, an error will occur if a document was not replaced
    *
    * @returns An object containing 2 arrays: "successes" and "errors"
    */
@@ -498,7 +502,7 @@ export class DocumentController extends BaseController {
        */
       body: JSONObject;
     }>,
-    options: { queuable?: boolean, refresh?: 'wait_for', silent?: boolean } = {}
+    options: { queuable?: boolean, refresh?: 'wait_for', silent?: boolean, strict?: boolean } = {}
   ): Promise<{
     /**
      * Array of successfully replaced documents
@@ -550,6 +554,7 @@ export class DocumentController extends BaseController {
    *    - `refresh` If set to `wait_for`, Kuzzle will not respond until the API key is indexed
    *    - `silent` If true, then Kuzzle will not generate notifications
    *    - `retryOnConflict` Number of times the database layer should retry in case of version conflict
+   *    - `strict` If true, an error will occur if a document was not updated
    *
    * @returns An object containing 2 arrays: "successes" and "errors"
    */
@@ -570,7 +575,8 @@ export class DocumentController extends BaseController {
       queuable?: boolean,
       refresh?: 'wait_for',
       silent?: boolean,
-      retryOnConflict?: number
+      retryOnConflict?: number,
+      strict?: boolean,
     } = {}
   ): Promise<{
     /**

--- a/src/core/security/Profile.ts
+++ b/src/core/security/Profile.ts
@@ -1,22 +1,21 @@
 import { Role } from './Role';
-import { ProfilePolicy } from '../../types';
+import { JSONObject, ProfilePolicy } from '../../types';
 
 export class Profile {
   /**
    * Profile unique ID
    */
-  public _id: string;
+  _id: string;
 
   /**
    * Maximum number of requests per second and per node with this profile
    */
-  public rateLimit: number;
+  rateLimit: number;
 
   /**
    * Array of policies
    */
-  public policies: Array<ProfilePolicy>;
-
+  policies: Array<ProfilePolicy>;
 
   private _kuzzle: any;
 
@@ -50,5 +49,16 @@ export class Profile {
     return this.kuzzle.security.mGetRoles(
       this.policies.map(policy => policy.roleId),
       options);
+  }
+
+  /**
+   * Serialize the instance
+   */
+  serialize (): JSONObject {
+    return {
+      _id: this._id,
+      rateLimit: this.rateLimit,
+      policies: this.policies,
+    };
   }
 }

--- a/src/core/security/Role.ts
+++ b/src/core/security/Role.ts
@@ -1,14 +1,15 @@
-import { RoleRightsDefinition } from '../../types';
+import { JSONObject, RoleRightsDefinition } from '../../types';
 
 export class Role {
   /**
    * Role unique ID
    */
-  public _id: string;
+  _id: string;
+
   /**
    * List of rights on controllers/actions
    */
-  public controllers: RoleRightsDefinition;
+  controllers: RoleRightsDefinition;
 
   private _kuzzle: any;
 
@@ -27,6 +28,16 @@ export class Role {
 
   protected get kuzzle () {
     return this._kuzzle;
+  }
+
+  /**
+   * Serialize the instance
+   */
+  serialize (): JSONObject {
+    return {
+      _id: this._id,
+      controllers: this.controllers,
+    };
   }
 }
 

--- a/src/core/security/User.ts
+++ b/src/core/security/User.ts
@@ -5,21 +5,19 @@ export class User {
   /**
    * Kuid (Kuzzle unique ID)
    */
-  public _id: string;
+  _id: string;
 
   /**
    * User content
    */
-  public _source: JSONObject;
+  _source: JSONObject;
 
   /**
    * User content
    *
-   * @deprecated
+   * @deprecated Use User._source instead
    */
-  get content (): JSONObject {
-    return this._source;
-  }
+  content: JSONObject
 
   private _kuzzle: any;
 
@@ -31,6 +29,13 @@ export class User {
   constructor (kuzzle, _id = null, content = {}) {
     Reflect.defineProperty(this, '_kuzzle', {
       value: kuzzle
+    });
+
+    Reflect.defineProperty(this, 'content', {
+      enumerable: true,
+      get () {
+        return this._source;
+      }
     });
 
     this._id = _id;
@@ -59,6 +64,15 @@ export class User {
     return this.kuzzle.security.mGetProfiles(this.profileIds);
   }
 
+  /**
+   * Serialize the instance
+   */
+  serialize (): JSONObject {
+    return {
+      _id: this._id,
+      _source: this._source,
+    };
+  }
 }
 
 module.exports = { User };


### PR DESCRIPTION
## What does this PR do ?

Since the last release, the user content is accessible under the `user._source` property in addition to the `user.content` property.

A getter was added for backward compatibility but when a User object was returned in a controller action it was serialized with only the `_source` property, breaking existing APIs relying on the `content` property.

This PR fix that but the sent data will be duplicated. A safe `serialize` method has been added to the User, Role and Profile classes and should be used instead of returning the instances directly.

### Other changes



### Boyscout

<!--
  Finally, describe any improvements in the code base like:
  Typo fixes, improved/new comments, debug messages and so on.
-->
