### PR TITLE
docs: use index from callback argument instead of indexOf

### DIFF
--- a/doc/7/getting-started/.react/with-redux/src/App.js
+++ b/doc/7/getting-started/.react/with-redux/src/App.js
@@ -104,8 +104,8 @@ class App extends Component {
         {/* snippet:end  */}
         {/* snippet:start:13  */}
         <div>
-          {[...messages].reverse().map(message => (
-            <p key={messages.indexOf(message)}>{message.text}</p>
+          {[...messages].reverse().map((message, index) => (
+            <p key={index}>{message.text}</p>
           ))}
         </div>
         {/* snippet:end  */}


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

Change in documentation: using `messages.indexOf(message)` is not necessary to get index because we can get it from callback 2nd argument
