### PR TITLE
Fix cookie authentication support for WebSocket

### DIFF
--- a/doc/7/core-classes/kuzzle/constructor/index.md
+++ b/doc/7/core-classes/kuzzle/constructor/index.md
@@ -41,7 +41,7 @@ Kuzzle SDK instance options.
 | `autoQueue`            | <pre>boolean</pre><br/>(`false`) | Automatically queue all requests during offline mode                                                |
 | `autoReplay`           | <pre>boolean</pre><br/>(`false`) | Automatically replay queued requests on a `reconnected` event                                       |
 | `autoResubscribe`      | <pre>boolean</pre><br/>(`true`)  | Automatically renew all subscriptions on a `reconnected` event                                      |
-| `cookieAuth`           | <pre>boolean</pre><br/>(`false`) | Uses cookie to store token, this option set `offlineMode` to `auto` and `autoResubscribe` to `true` |
+| `cookieAuth`           | <pre>boolean</pre><br/>(`false`) | Uses cookie to store token                                                                          |
 | `deprecationWarning`   | <pre>boolean</pre><br />(`true`) | Show deprecation warning in development (hidden either way in production)                           |
 | `eventTimeout`         | <pre>number</pre><br/>(`200`)    | Time (in ms) during which a similar event is ignored                                                |
 | `offlineMode`          | <pre>string</pre><br/>(`manual`) | Offline mode configuration. Can be `manual` or `auto`                                               |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -81,7 +81,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
   /**
    * Connect to the websocket server
    */
-  connect (): Promise<void> {
+  _connect (): Promise<void> {
     return new Promise((resolve, reject) => {
       const url = `${this.ssl ? 'wss' : 'ws'}://${this.host}:${this.port}`;
 
@@ -209,6 +209,14 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
         clearTimeout(this.pongTimeoutId);
       };
     });
+  }
+
+  connect (): Promise<void> {
+    if (this.cookieSupport) {
+      return this._httpProtocol.connect()
+        .then(() => this._connect());
+    }
+    return this._connect();
   }
 
   enableCookieSupport () {

--- a/test/protocol/WebSocket.test.js
+++ b/test/protocol/WebSocket.test.js
@@ -509,6 +509,30 @@ describe('WebSocket networking module', () => {
       });
   });
 
+  describe('#connect', () => {
+    it('connect should call the connect method of the HttpProtocol when cookieSupport is true', async () => {
+      websocket._cookieSupport = true;
+      websocket._httpProtocol = {
+        connect: sinon.stub().resolves()
+      };
+      websocket._connect = sinon.stub().resolves();
+      await websocket.connect();
+      await should(websocket._httpProtocol.connect).be.called();
+      await should(websocket._connect).be.called();
+    });
+
+    it('connect should not call the connect method of the HttpProtocol when cookieSupport is false', async () => {
+      websocket._cookieSupport = false;
+      websocket._httpProtocol = {
+        connect: sinon.stub().resolves()
+      };
+      websocket._connect = sinon.stub().resolves();
+      await websocket.connect();
+      await should(websocket._httpProtocol.connect).not.be.called();
+      await should(websocket._connect).be.called();
+    });
+  });
+
   describe('#constructor', () => {
     it('should throw if an invalid host is provided', () => {
       const invalidHosts = [undefined, null, 123, false, true, [], {}, ''];


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

This PR change the behaviour of the websocket's `connect` method to call `HttpProtocol.connect()` if the support of cookieAuthentication is enabled.
Without that the HttpProtocol routes are not constructed, causing it to not send the payloads.

### How should this be manually tested?

```bash
npm run test
```
### Other changes
Correction of a wrong statement in the cookieAuth option of the Kuzzle constructor.
