### PR TITLE
Add an origin parameter to the kuzzle disconnected event

### DIFF
--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -43,11 +43,11 @@ Triggered when the current session has been unexpectedly disconnected.
 
 **Origins**
 
-| Name                        | Description                                                                                                                                                        |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `websocket/auth-renewal`    | The websocket protocol si reconnecting to renew the token. See [Websocket Cookie Authentication](sdk/js/7/protocols/websocket/introduction#cookie-authentication). |
-| `network/connection-closed` | The disconnection is either manual or issued by Kuzzle                                                                                                             |
-| `network/error`             | An network error occured and caused a disconnection                                                                                                                |
+| Name                     | Description                                                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `websocket/auth-renewal` | The websocket protocol si reconnecting to renew the token. See [Websocket Cookie Authentication](sdk/js/7/protocols/websocket/introduction#cookie-authentication). |
+| `user/connection-closed` | The disconnection is done by the user.                                                                                                                             |
+| `network/error`          | An network error occured and caused a disconnection.                                                                                                               |
 ## loginAttempt
 
 Triggered when a login attempt completes, either with a success or a failure result.

--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -32,6 +32,7 @@ Triggered when Kuzzle discards a request, typically if no connection is establis
 
 Triggered when the current session has been unexpectedly disconnected.
 
+<SinceBadge version="auto-version"/>
 **Callback arguments:**
 
 `@param {object} context`

--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -32,6 +32,21 @@ Triggered when Kuzzle discards a request, typically if no connection is establis
 
 Triggered when the current session has been unexpectedly disconnected.
 
+**Callback arguments:**
+
+`@param {object} context`
+
+| Property | Type              | Description                                |
+| -------- | ----------------- | ------------------------------------------ |
+| `origin` | <pre>string</pre> | Indicate what is causing the disconnection |
+
+**Origins**
+
+| Name                        | Description                                                                                                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `websocket/auth-renewal`    | The websocket protocol si reconnecting to renew the token. See [Websocket Cookie Authentication](sdk/js/7/protocols/websocket/introduction#cookie-authentication). |
+| `network/connection-closed` | The disconnection is either manual or issued by Kuzzle                                                                                                             |
+| `network/error`             | An network error occured and caused a disconnection                                                                                                                |
 ## loginAttempt
 
 Triggered when a login attempt completes, either with a success or a failure result.
@@ -75,8 +90,8 @@ Triggered whenever a request is added to the offline queue.
 
 `@param {object} data`
 
-| Property  | Type              | Description                                                        |
-| --------- | ----------------- | ------------------------------------------------------------------ |
+| Property  | Type              | Description                                                         |
+| --------- | ----------------- | ------------------------------------------------------------------- |
 | `request` | <pre>object</pre> | [Request](/core/2/guides/main-concepts/querying) added to the queue |
 
 ## queryError

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -501,8 +501,8 @@ export class Kuzzle extends KuzzleEventEmitter {
       this.emit('networkError', error);
     });
 
-    this.protocol.addListener('disconnect', () => {
-      this.emit('disconnected');
+    this.protocol.addListener('disconnect', (context) => {
+      this.emit('disconnected', context);
     });
 
     this.protocol.addListener('reconnect', () => {

--- a/src/protocols/DisconnectionOrigin.ts
+++ b/src/protocols/DisconnectionOrigin.ts
@@ -1,9 +1,9 @@
 const WEBSOCKET_AUTH_RENEWAL = 'websocket/auth-renewal';
-const NETWORK_CONNECTION_CLOSED = 'network/connection-closed';
+const USER_CONNECTION_CLOSED = 'user/connection-closed';
 const NETWORK_ERROR = 'network/error';
 
 export {
   WEBSOCKET_AUTH_RENEWAL,
-  NETWORK_CONNECTION_CLOSED,
+  USER_CONNECTION_CLOSED,
   NETWORK_ERROR,
 };

--- a/src/protocols/DisconnectionOrigin.ts
+++ b/src/protocols/DisconnectionOrigin.ts
@@ -1,0 +1,9 @@
+const WEBSOCKET_AUTH_RENEWAL = 'websocket/auth-renewal';
+const NETWORK_CONNECTION_CLOSED = 'network/connection-closed';
+const NETWORK_ERROR = 'network/error';
+
+export {
+  WEBSOCKET_AUTH_RENEWAL,
+  NETWORK_CONNECTION_CLOSED,
+  NETWORK_ERROR,
+};

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -146,7 +146,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
         }
 
         if (status === 1000) {
-          this.clientDisconnected(DisconnectionOrigin.NETWORK_CONNECTION_CLOSED);
+          this.clientDisconnected(DisconnectionOrigin.USER_CONNECTION_CLOSED);
         }
         // do not forward a connection close error if no
         // connection has been previously established

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -5,6 +5,7 @@ import { BaseProtocolRealtime } from './abstract/Realtime';
 import { JSONObject } from '../types';
 import { RequestPayload } from '../types/RequestPayload';
 import HttpProtocol from './Http';
+import * as DisconnectionOrigin from './DisconnectionOrigin';
 
 /**
  * WebSocket protocol used to connect to a Kuzzle server.
@@ -145,7 +146,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
         }
 
         if (status === 1000) {
-          this.clientDisconnected();
+          this.clientDisconnected(DisconnectionOrigin.NETWORK_CONNECTION_CLOSED);
         }
         // do not forward a connection close error if no
         // connection has been previously established
@@ -266,7 +267,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
       this.client.close();
     }
     this.client = null;
-    this.clientDisconnected(); // Simulate a disconnection, this will enable offline queue and trigger realtime subscriptions backup
+    this.clientDisconnected(DisconnectionOrigin.WEBSOCKET_AUTH_RENEWAL); // Simulate a disconnection, this will enable offline queue and trigger realtime subscriptions backup
 
     this._httpProtocol._sendHttpRequest(formattedRequest)
       .then(response => {
@@ -284,10 +285,10 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
   /**
    * @override
    */
-  clientDisconnected() {
+  clientDisconnected(origin: string) {
     clearInterval(this.pingIntervalId);
     clearTimeout(this.pongTimeoutId);
-    super.clientDisconnected();
+    super.clientDisconnected(origin);
   }
 
   /**

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { KuzzleAbstractProtocol } from './Base';
+import * as DisconnectionOrigin from '../DisconnectionOrigin';
 
 export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
   protected _autoReconnect: boolean;
@@ -51,10 +52,12 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
 
   /**
    * Called when the client's connection is closed
+   * 
+   * @param {string} origin String that describe what is causing the disconnection
    */
-  clientDisconnected () {
+  clientDisconnected (origin: string) {
     this.clear();
-    this.emit('disconnect');
+    this.emit('disconnect', { origin });
   }
 
   /**
@@ -93,7 +96,7 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
       }, this.reconnectionDelay);
     }
     else {
-      this.emit('disconnect');
+      this.emit('disconnect', { origin: DisconnectionOrigin.NETWORK_ERROR });
     }
   }
 

--- a/test/mocks/protocol.mock.js
+++ b/test/mocks/protocol.mock.js
@@ -55,7 +55,7 @@ class ProtocolMock extends KuzzleEventEmitter {
 
   disconnect () {
     this.state = 'offline';
-    this.emit('disconnect', {origin: DisconnectionOrigin.NETWORK_CONNECTION_CLOSED });
+    this.emit('disconnect', {origin: DisconnectionOrigin.USER_CONNECTION_CLOSED });
   }
 
   send (request) {

--- a/test/mocks/protocol.mock.js
+++ b/test/mocks/protocol.mock.js
@@ -1,6 +1,7 @@
 const
   sinon = require('sinon'),
-  { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter');
+  { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter'),
+  DisconnectionOrigin = require('../../src/protocols/DisconnectionOrigin');
 
 class ProtocolMock extends KuzzleEventEmitter {
 
@@ -54,7 +55,7 @@ class ProtocolMock extends KuzzleEventEmitter {
 
   disconnect () {
     this.state = 'offline';
-    this.emit('disconnect');
+    this.emit('disconnect', {origin: DisconnectionOrigin.NETWORK_CONNECTION_CLOSED });
   }
 
   send (request) {

--- a/test/protocol/WebSocket.test.js
+++ b/test/protocol/WebSocket.test.js
@@ -161,7 +161,7 @@ describe('WebSocket networking module', () => {
     websocket.connect = sinon.stub().resolves();
     clientStub.onopen();
     clientStub.onclose(1000);
-    should(cb).be.calledOnce().and.be.calledWith({origin: DisconnectionOrigin.NETWORK_CONNECTION_CLOSED });
+    should(cb).be.calledOnce().and.be.calledWith({origin: DisconnectionOrigin.USER_CONNECTION_CLOSED });
     websocket.close();
     should(clearTimeout)
       .be.calledOnce();
@@ -281,7 +281,7 @@ describe('WebSocket networking module', () => {
     clientStub.onclose(1000);
 
     clock.tick(10);
-    should(cb).be.calledOnce().and.be.calledWith({ origin: DisconnectionOrigin.NETWORK_CONNECTION_CLOSED });
+    should(cb).be.calledOnce().and.be.calledWith({ origin: DisconnectionOrigin.USER_CONNECTION_CLOSED });
     should(websocket.listeners('disconnect').length).be.eql(1);
     websocket.clear.should.be.calledOnce();
   });


### PR DESCRIPTION
## What does this PR do ?
This PR adds an `origin` parameter to the Kuzzle disconnected event.
This parameter describes what is causing the disconnected event.

**Origins**

| Name                     | Description                                                                                                                                                        |
| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `websocket/auth-renewal` | The websocket protocol si reconnecting to renew the token. See [Websocket Cookie Authentication](sdk/js/7/protocols/websocket/introduction#cookie-authentication). |
| `user/connection-closed` | The disconnection is done by the user.                                                                                                                             |
| `network/error`          | An network error occured and caused a disconnection.                                                                                                               |
### How should this be manually tested?

```bash
npm run test
```