### PR TITLE
Correctly reject aborted queued requests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,7 @@ src/**/*.js.map
 
 src/Kuzzle.js
 src/KuzzleError.js
+src/RequestTimeoutError.js
 src/controllers/Auth.js
 src/controllers/Bulk.js
 src/controllers/Document.js
@@ -16,6 +17,7 @@ src/core/security/Profile.js
 src/core/security/Role.js
 src/protocols/abstract/Base.js
 src/protocols/abstract/Realtime.js
+src/protocols/DisconnectionOrigin.js
 src/protocols/Http.js
 src/protocols/WebSocket.js
 src/protocols/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ test-*.js
 index.js
 src/Kuzzle.js
 src/KuzzleError.js
+src/RequestTimeoutError.js
 src/controllers/Auth.js
 src/controllers/Bulk.js
 src/controllers/Document.js
@@ -44,6 +45,7 @@ src/core/security/Profile.js
 src/core/security/Role.js
 src/protocols/abstract/Base.js
 src/protocols/abstract/Realtime.js
+src/protocols/DisconnectionOrigin.js
 src/protocols/Http.js
 src/protocols/WebSocket.js
 src/protocols/index.js

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -777,7 +777,8 @@ Discarded request: ${JSON.stringify(request)}`));
         this.offlineQueue
           .splice(0, lastDocumentIndex + 1)
           .forEach(droppedRequest => {
-            this.emit('offlineQueuePop', droppedRequest.query);
+            this.emit('offlineQueuePop', droppedRequest.request);
+            droppedRequest.reject(new Error('Query aborted: queued time exceeded the queueTTL option value'));
           });
       }
     }
@@ -786,7 +787,8 @@ Discarded request: ${JSON.stringify(request)}`));
       this.offlineQueue
         .splice(0, this.offlineQueue.length - this.queueMaxSize)
         .forEach(droppedRequest => {
-          this.emit('offlineQueuePop', droppedRequest.query);
+          this.emit('offlineQueuePop', droppedRequest.request);
+          droppedRequest.reject(new Error('Query aborted: too many queued requests (see the queueMaxSize option)'));
         });
     }
   }
@@ -807,7 +809,7 @@ Discarded request: ${JSON.stringify(request)}`));
             .then(this.offlineQueue[0].resolve)
             .catch(this.offlineQueue[0].reject);
 
-          this.emit('offlineQueuePop', this.offlineQueue.shift());
+          this.emit('offlineQueuePop', this.offlineQueue.shift().request);
 
           setTimeout(() => {
             dequeuingProcess();


### PR DESCRIPTION
# Description

When requests are queued, there are 2 constructor options that can lead to abort them before they can be sent to Kuzzle:

* queueTTL: if set to a value larger than 0, queued requests can expire
* queueMaxSize: if set to a value larger than 0, the queue has a maximum number of requests it can hold. If reached, older requests are aborted to make place for newer ones

When requests are aborted because of those configurations, an `offlineQueuePop` event is emitted, but:
* the invalid argument is provided, making the event deliver an `undefined` payload
* the promise associated to the aborted request is not rejected, making clients await indefinitely for them

This PR fixes these issues, and add the missing unit tests that should have caught these problems earlier.

# Other changes

* the `offlineQueuePop` event emitted when the queue is being played does not deliver the right payload. The entire queued object is delivered (containing the queued request and additional information about it), instead of just the request, as per the documentation. So, I fixed that too.