### PR TITLE
Latest kuzdoc minor and dead-link check

### DIFF
--- a/.github/actions/dead-links/action.yml
+++ b/.github/actions/dead-links/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Install deps
-      run: npm ci
+      run: npm ci --production=false
       shell: bash
     - name: Install latest minor of Kuzdoc
       run: npm i --save-dev kuzdoc

--- a/.github/actions/dead-links/action.yml
+++ b/.github/actions/dead-links/action.yml
@@ -6,6 +6,9 @@ runs:
     - name: Install deps
       run: npm ci
       shell: bash
+    - name: Install latest minor of Kuzdoc
+      run: npm i --save-dev kuzdoc
+      shell: bash
     - name: Prepare documentation
       run: npm run doc-prepare
       shell: bash

--- a/.github/actions/doc-deploy/action.yml
+++ b/.github/actions/doc-deploy/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Build documentation
       run: |
         rm -fr doc/framework
-        npm ci
+        npm ci --production=false
         npm i --save-dev kuzdoc
         npm run doc-prepare
         npm run doc-build

--- a/.github/actions/doc-deploy/action.yml
+++ b/.github/actions/doc-deploy/action.yml
@@ -33,7 +33,8 @@ runs:
     - name: Build documentation
       run: |
         rm -fr doc/framework
-        npm install --production=false
+        npm ci
+        npm i kuzdoc
         npm run doc-prepare
         npm run doc-build
       env:

--- a/.github/actions/doc-deploy/action.yml
+++ b/.github/actions/doc-deploy/action.yml
@@ -34,7 +34,7 @@ runs:
       run: |
         rm -fr doc/framework
         npm ci
-        npm i kuzdoc
+        npm i --save-dev kuzdoc
         npm run doc-prepare
         npm run doc-build
       env:

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -28,51 +28,51 @@ jobs:
       - uses: ./.github/actions/es-lint
 
   unit-tests:
-     name: Unit Tests
-     runs-on: ubuntu-18.04
-     needs: [lint]
-     steps:
-       - uses: actions/checkout@v2
-       - name: Cache node modules
-         uses: actions/cache@v2
-         env:
-           cache-name: cache-node-modules
-         with:
-           path: ~/.npm
-           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-           restore-keys: |
-             ${{ runner.os }}-build-${{ env.cache-name }}-
-             ${{ runner.os }}-build-
-             ${{ runner.os }}-
-       - uses: actions/setup-node@v1.4.4
-         with:
-           node-version: "12"
-       - uses: ./.github/actions/unit-tests
+    name: Unit Tests
+    runs-on: ubuntu-18.04
+    needs: [lint]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - uses: actions/setup-node@v1.4.4
+        with:
+          node-version: "12"
+      - uses: ./.github/actions/unit-tests
 
   functional-tests:
-     name: Functional Tests
-     runs-on: ubuntu-18.04
-     needs: [unit-tests]
-     steps:
-       - uses: actions/checkout@v2
-         with:
-          submodules: 'recursive'
-       - name: Cache node modules
-         uses: actions/cache@v2
-         env:
-           cache-name: cache-node-modules
-         with:
-           path: ~/.npm
-           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-           restore-keys: |
-             ${{ runner.os }}-build-${{ env.cache-name }}-
-             ${{ runner.os }}-build-
-             ${{ runner.os }}-
-       - uses: actions/setup-node@v1.4.4
-         with:
-           node-version: "12"
-       - uses: ./.github/actions/functional-tests
-         with:
+    name: Functional Tests
+    runs-on: ubuntu-18.04
+    needs: [unit-tests]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - uses: actions/setup-node@v1.4.4
+        with:
+          node-version: "12"
+      - uses: ./.github/actions/functional-tests
+        with:
           CYPRESS_RECORD_KEY_DOC: ${{ secrets.CYPRESS_RECORD_KEY_DOC }}
 
   # admin-console-tests:
@@ -100,49 +100,52 @@ jobs:
   #         sdk-version: 7
   #         cypress-key: ${{ secrets.CYPRESS_RECORD_KEY }}
 
-  # documentation-dead-links:
-  #   name: Dead links
-  #   runs-on: ubuntu-18.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Cache node modules
-  #       uses: actions/cache@v2
-  #       env:
-  #         cache-name: cache-node-modules
-  #       with:
-  #         path: ~/.npm
-  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-build-${{ env.cache-name }}-
-  #           ${{ runner.os }}-build-
-  #           ${{ runner.os }}-
-  #     - uses: actions/setup-node@v1.4.4
-  #       with:
-  #         node-version: "12"
-  #     - uses: ./.github/actions/dead-links
+  documentation-dead-links:
+    name: Dead links
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - uses: actions/setup-node@v1.4.4
+        with:
+          node-version: "12"
+      - uses: webfactory/ssh-agent@v0.5.2
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+      - uses: ./.github/actions/dead-links
 
   documentation-snippet-tests:
-     name: Documentation Snippet Tests
-     needs: [unit-tests]
-     runs-on: ubuntu-18.04
-     steps:
-       - uses: actions/checkout@v2
-       - name: Cache node modules
-         uses: actions/cache@v2
-         env:
-           cache-name: cache-node-modules
-         with:
-           path: ~/.npm
-           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-           restore-keys: |
-             ${{ runner.os }}-build-${{ env.cache-name }}-
-             ${{ runner.os }}-build-
-             ${{ runner.os }}-
-       - uses: actions/setup-node@v1.4.4
-         with:
-           node-version: "12"
-       - uses: ./.github/actions/snippet-tests
-         with:
+    name: Documentation Snippet Tests
+    needs: [unit-tests]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - uses: actions/setup-node@v1.4.4
+        with:
+          node-version: "12"
+      - uses: ./.github/actions/snippet-tests
+        with:
           CYPRESS_RECORD_KEY_DOC: ${{ secrets.CYPRESS_RECORD_KEY_DOC }}
 
   documentation-production:
@@ -196,8 +199,8 @@ jobs:
             ${{ runner.os }}-
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish
         env:


### PR DESCRIPTION
Following the latest improvements in the Docs CI workflow, we need to have isomorphic dependencies (thus `npm ci`) but the latest Kuzdoc minor within the major specified by `package.json` (thus `npm i kuzdoc`). Having the latest minor of Kuzdoc enables us to easily deploy non-breaking changes to all the CIs without manually bump the Kuzdoc dependency (which would be the case if we just`npm ci`).

Also, this PR re-activates the dead-link check, using the SSH-key.

Sorry for the linting.

⚠️  Once merged, we should merge back to `7-dev`