### PR TITLE
Fix usage of SearchResult.next with HTTP

### DIFF
--- a/src/core/searchResult/SearchResultBase.ts
+++ b/src/core/searchResult/SearchResultBase.ts
@@ -107,7 +107,7 @@ export class SearchResultBase<T> implements SearchResult<T> {
         action: this._scrollAction,
         scroll: this._request.scroll,
         scrollId: this._result.scrollId
-      }, this._options)
+      })
         .then(({ result }) => this._buildNextSearchResult(result));
     }
     else if (this._request.size && this._request.body.sort) {

--- a/test/core/searchResult/document.test.js
+++ b/test/core/searchResult/document.test.js
@@ -135,7 +135,7 @@ describe('DocumentSearchResult', () => {
                 action: 'scroll',
                 scroll: '10s',
                 scrollId: 'scroll-id'
-              }, options);
+              });
             should(nextSearchResult).not.be.equal(searchResult);
             should(nextSearchResult).be.instanceOf(DocumentSearchResult);
           });

--- a/test/core/searchResult/profile.test.js
+++ b/test/core/searchResult/profile.test.js
@@ -134,7 +134,7 @@ describe('ProfileSearchResult', () => {
                 action: 'scrollProfiles',
                 scroll: '10s',
                 scrollId: 'scroll-id'
-              }, options);
+              });
             should(nextSearchResult).not.be.equal(searchResult);
             should(nextSearchResult).be.instanceOf(ProfileSearchResult);
           });

--- a/test/core/searchResult/specifications.test.js
+++ b/test/core/searchResult/specifications.test.js
@@ -123,7 +123,7 @@ describe('SpecificationsSearchResult', () => {
                 action: 'scrollSpecifications',
                 scroll: '10s',
                 scrollId: 'scroll-id'
-              }, options);
+              });
             should(nextSearchResult).not.be.equal(searchResult);
             should(nextSearchResult).be.instanceOf(SpecificationsSearchResult);
           });

--- a/test/core/searchResult/user.test.js
+++ b/test/core/searchResult/user.test.js
@@ -136,7 +136,7 @@ describe('UserSearchResult', () => {
                 action: 'scrollUsers',
                 scroll: '10s',
                 scrollId: 'scroll-id'
-              }, options);
+              });
             should(nextSearchResult).not.be.equal(searchResult);
             should(nextSearchResult).be.instanceOf(UserSearchResult);
           });


### PR DESCRIPTION
## What does this PR do ?

When using the `SearchResult.next` method with HTTP, the route was used with the `search` options, including the use of the `POST` verb. 

This leads to use a different API action (`collection:update`) since the `document:scroll` API action only exists with the `GET` verb