### PR TITLE
Add authenticator function used at reconnection

### DIFF
--- a/doc/7/core-classes/kuzzle/authenticate/index.md
+++ b/doc/7/core-classes/kuzzle/authenticate/index.md
@@ -1,0 +1,24 @@
+---
+code: true
+type: page
+title: authenticate
+description: Authenticate the SDK with the setted authenticator
+---
+
+# authenticate
+
+Authenticate the SDK by using the function set in the [authenticator](/sdk/js/7/core-classes/kuzzle/properties#authenticator) property.
+
+## Arguments
+
+```js
+authenticate();
+```
+
+## Resolves
+
+Resolves to the authentication token.
+
+## Usage
+
+<<< ./snippets/authenticate.js

--- a/doc/7/core-classes/kuzzle/authenticate/index.md
+++ b/doc/7/core-classes/kuzzle/authenticate/index.md
@@ -15,10 +15,6 @@ Authenticate the SDK by using the function set in the [authenticator](/sdk/js/7/
 authenticate();
 ```
 
-## Resolves
-
-Resolves to the authentication token.
-
 ## Usage
 
 <<< ./snippets/authenticate.js

--- a/doc/7/core-classes/kuzzle/authenticate/snippets/authenticate.js
+++ b/doc/7/core-classes/kuzzle/authenticate/snippets/authenticate.js
@@ -3,11 +3,8 @@ kuzzle.authenticator = async () => {
 };
 
 try {
-  const jwt = await kuzzle.authenticate();
-  console.log(jwt);
-  /*
-    'eyJhbGciOiJIUzI1NiIsIkpXVCJ9.eyJfaWQiOiJmb28iLCJpYXQiOjE.wSPmb0z2tErRdYEg'
-  */
+  await kuzzle.authenticate();
+
   console.log('Success');
 } catch (error) {
   console.error(error.message);

--- a/doc/7/core-classes/kuzzle/authenticate/snippets/authenticate.js
+++ b/doc/7/core-classes/kuzzle/authenticate/snippets/authenticate.js
@@ -1,0 +1,14 @@
+kuzzle.authenticator = async () => {
+  await kuzzle.auth.login('local', { username: 'foo', password: 'bar' });
+};
+
+try {
+  const jwt = await kuzzle.authenticate();
+  console.log(jwt);
+  /*
+    'eyJhbGciOiJIUzI1NiIsIkpXVCJ9.eyJfaWQiOiJmb28iLCJpYXQiOjE.wSPmb0z2tErRdYEg'
+  */
+  console.log('Success');
+} catch (error) {
+  console.error(error.message);
+}

--- a/doc/7/core-classes/kuzzle/authenticate/snippets/authenticate.test.yml
+++ b/doc/7/core-classes/kuzzle/authenticate/snippets/authenticate.test.yml
@@ -1,0 +1,8 @@
+---
+name: kuzzle#authenticate
+description: Authenticate the SDK
+hooks:
+  before: curl -X POST kuzzle:7512/users/foo/_create -H "Content-Type:application/json" --data '{"content":{"profileIds":["default"]},"credentials":{"local":{"username":"foo","password":"bar"}}}'
+  after: curl -X DELETE kuzzle:7512/users/foo
+template: default
+expected: Success

--- a/doc/7/core-classes/kuzzle/properties/index.md
+++ b/doc/7/core-classes/kuzzle/properties/index.md
@@ -44,7 +44,7 @@ The `authenticator` property can be set to a function returning a promise.
 
 This function will be called after a successful reconnection if the current authentication token is not valid anymore.  
 
-This function has to authenticate the SDK (by setting the `jwt` property). It can be a call to [auth.login](/sdk/js/7/controllers/auth/login) for example.
+This function has to authenticate the SDK. It can be a call to [auth.login](/sdk/js/7/controllers/auth/login) for example.
 
 ```js
 kuzzle.authenticator = async () => {
@@ -52,7 +52,7 @@ kuzzle.authenticator = async () => {
 }
 ```
 
-If the `authenticator` function fail, then the `reconnected` event is never emitted and a `reconnectionError` event is emitted.
+If the `authenticator` function fail to authenticate the SDK, then the `reconnected` event is never emitted and a `reconnectionError` event is emitted.
 
 ### offlineQueueLoader
 

--- a/doc/7/core-classes/kuzzle/properties/index.md
+++ b/doc/7/core-classes/kuzzle/properties/index.md
@@ -8,12 +8,12 @@ order: 10
 
 # Read-only properties
 
-| Property name        | Type     | Description          |
-| -------------------- | -------- | ---------------------|
-| `authenticated` | <pre>boolean</pre> | Returns `true` if the SDK holds a valid token |
-| `connected` | <pre>boolean</pre> | Returns `true` if the SDK is currently connected to a Kuzzle server. |
-| `offlineQueue` | <pre>object[]</pre> | Contains the queued requests during offline mode   |
-| `protocol` | <pre>Protocol</pre> | Protocol used by the SDK |
+| Property name   | Type                | Description                                                          |
+|-----------------|---------------------|----------------------------------------------------------------------|
+| `authenticated` | <pre>boolean</pre>  | Returns `true` if the SDK holds a valid token                        |
+| `connected`     | <pre>boolean</pre>  | Returns `true` if the SDK is currently connected to a Kuzzle server. |
+| `offlineQueue`  | <pre>object[]</pre> | Contains the queued requests during offline mode                     |
+| `protocol`      | <pre>Protocol</pre> | Protocol used by the SDK                                             |
 
 ### connected
 
@@ -24,18 +24,35 @@ See the associated documentation:
 
 # Writable properties
 
-| Property name        | Type     | Description          |
-| -------------------- | -------- | ---------------------|
-| `autoQueue` | <pre>boolean</pre> | If `true`, automatically queues all requests during offline mode |
-| `autoReplay` | <pre>boolean</pre> | If `true`, automatically replays queued requests on a `reconnected` event |
-| `autoResubscribe` | <pre>boolean</pre> | If `true`, automatically renews all subscriptions on a `reconnected` event |
-| `jwt` | <pre>string</pre> | Authentication token |
-| `offlineQueueLoader` | <pre>function</pre> | Called before dequeuing requests after exiting offline mode, to add items at the beginning of the offline queue  |
-| `queueFilter` | <pre>function</pre> | Custom function called during offline mode to filter queued requests on-the-fly |
-| `queueMaxSize` | <pre>number</pre>  | Number of maximum requests kept during offline mode|
-| `queueTTL` | <pre>number</pre>  | Time a queued request is kept during offline mode, in milliseconds |
-| `replayInterval` | <pre>number</pre>  | Delay between each replayed requests |
-| `volatile` | <pre>object</pre> | Common volatile data, will be sent to all future requests |
+| Property name        | Type                | Description                                                                                                     |
+|----------------------|---------------------|-----------------------------------------------------------------------------------------------------------------|
+| `authenticator`      | <pre>function</pre> | Authenticator function to authenticate the SDK. (After called, the `jwt` property of the SDK has to be set.)    |
+| `autoQueue`          | <pre>boolean</pre>  | If `true`, automatically queues all requests during offline mode                                                |
+| `autoReplay`         | <pre>boolean</pre>  | If `true`, automatically replays queued requests on a `reconnected` event                                       |
+| `autoResubscribe`    | <pre>boolean</pre>  | If `true`, automatically renews all subscriptions on a `reconnected` event                                      |
+| `jwt`                | <pre>string</pre>   | Authentication token                                                                                            |
+| `offlineQueueLoader` | <pre>function</pre> | Called before dequeuing requests after exiting offline mode, to add items at the beginning of the offline queue |
+| `queueFilter`        | <pre>function</pre> | Custom function called during offline mode to filter queued requests on-the-fly                                 |
+| `queueMaxSize`       | <pre>number</pre>   | Number of maximum requests kept during offline mode                                                             |
+| `queueTTL`           | <pre>number</pre>   | Time a queued request is kept during offline mode, in milliseconds                                              |
+| `replayInterval`     | <pre>number</pre>   | Delay between each replayed requests                                                                            |
+| `volatile`           | <pre>object</pre>   | Common volatile data, will be sent to all future requests                                                       |
+
+### authenticator
+
+The `authenticator` property can be set to a function returning a promise.
+
+This function will be called after a successful reconnection if the current authentication token is not valid anymore.  
+
+This function has to authenticate the SDK (by setting the `jwt` property). It can be a call to [auth.login](/sdk/js/7/controllers/auth/login) for example.
+
+```js
+kuzzle.authenticator = async () => {
+  await kuzzle.auth.login('local', { username: 'user', password: 'pass' });
+}
+```
+
+If the `authenticator` function fail, then the `reconnected` event is never emitted and a `reconnectionError` event is emitted.
 
 ### offlineQueueLoader
 
@@ -49,11 +66,11 @@ Promise<Object[]> offlineQueueLoader()
 
 The returned (or resolved) array must contain objects, each with the following properties:
 
-| Property | Type | Description |
-|---|---|---|
-| `query` | <pre>object</pre> | Object representing the request that is about to be sent to Kuzzle, following the [Kuzzle API](/core/2/guides/main-concepts/querying) format |
-| `reject` | <pre>function</pre> | A [Promise.reject](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject) function |
-| `resolve` | <pre>function</pre> | A [Promise.resolve](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve) function |
+| Property  | Type                | Description                                                                                                                                  |
+|-----------|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `query`   | <pre>object</pre>   | Object representing the request that is about to be sent to Kuzzle, following the [Kuzzle API](/core/2/guides/main-concepts/querying) format |
+| `reject`  | <pre>function</pre> | A [Promise.reject](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject) function                 |
+| `resolve` | <pre>function</pre> | A [Promise.resolve](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve) function               |
 
 ### queueFilter
 

--- a/doc/7/essentials/offline-tools/index.md
+++ b/doc/7/essentials/offline-tools/index.md
@@ -11,6 +11,33 @@ order: 400
 The Kuzzle SDK provides a set of properties that helps your application to be resilient to the loss of network connection
 during its lifespan.
 
+## Authentication after reconnection
+
+When the SDK reconnect, the authentication token may not be valid anymore.
+
+It's possible to set the [authenticator](/sdk/js/7/core-classes/kuzzle/properties#authenticator) function to allows the SDK to re-authenticate after a successful reconnection.
+
+<details><summary>Example to automatically re-authenticate on reconnection</summary>
+
+```js
+const { Kuzzle, WebSocket } = require('kuzzle');
+
+const kuzzle = new Kuzzle(new WebSocket('localhost'), { autoResubscribe: true });
+
+kuzzle.authenticator = async () => {
+  await kuzzle.auth.login('local', { username: 'test', password: 'test' });
+};
+
+await kuzzle.connect();
+await kuzzle.authenticate();
+
+await kuzzle.realtime.subscribe('test', 'test', {}, () => {
+  console.log('Received');
+});
+```
+
+</details>
+
 ## Contructor options and properties
 
 These properties can be set in the `options` object when [instantiating a new SDK](/sdk/js/7/core-classes/kuzzle/constructor#arguments).
@@ -76,6 +103,10 @@ Default value: `120000`
 A read-only `number` specifying the time in milliseconds between different reconnection attempts.
 
 Default value: *Depends on the Protocol*
+
+### reconnectionError
+
+Emitted when the SDK reconnect to Kuzzle and does not have a valid authentication token or can't renew it with the [authenticator](/sdk/js/7/core-classes/kuzzle/properties#authenticator) function.
 
 ## Methods
 

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -574,10 +574,6 @@ export class Kuzzle extends KuzzleEventEmitter {
         return true;
       }
 
-      if (! this.authenticator) {
-        throw new Error('No "authenticator" function is defined.');
-      }
-
       await this.authenticate();
 
       return true;

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -32,7 +32,6 @@ const events = [
   'offlineQueuePop',
   'queryError',
   'reconnected',
-  'resubscribe',
   'reconnectionError',
   'tokenExpired'
 ];
@@ -597,8 +596,8 @@ export class Kuzzle extends KuzzleEventEmitter {
    * @returns The authentication token
    */
   async authenticate (): Promise<string> {
-    if (! this.authenticator) {
-      throw new Error('No "authenticator" function is defined.');
+    if (typeof this.authenticator !== 'function') {
+      throw new Error('The "authenticator" property must be a function.');
     }
 
     await this.authenticator();

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -32,6 +32,8 @@ const events = [
   'offlineQueuePop',
   'queryError',
   'reconnected',
+  'resubscribe',
+  'reconnectionError',
   'tokenExpired'
 ];
 
@@ -42,41 +44,46 @@ export class Kuzzle extends KuzzleEventEmitter {
   /**
    * Protocol used by the SDK to communicate with Kuzzle.
    */
-  public protocol: any;
+  protocol: any;
   /**
    * If true, automatically renews all subscriptions on a reconnected event.
    */
-  public autoResubscribe: boolean;
+  autoResubscribe: boolean;
   /**
    * Timeout before sending again a similar event.
    */
-  public eventTimeout: number;
+  eventTimeout: number;
   /**
    * SDK version.
    */
-  public sdkVersion: string;
+  sdkVersion: string;
   /**
    * SDK name (e.g: `js@7.4.2`).
    */
-  public sdkName: string;
+  sdkName: string;
   /**
    * Common volatile data that will be sent to all future requests.
    */
-  public volatile: JSONObject;
+  volatile: JSONObject;
   /**
    * Handle deprecation warning in development mode (hidden in production)
    */
-  public deprecationHandler: Deprecation;
+  deprecationHandler: Deprecation;
+  /**
+   * Authenticator function called after a reconnection if the SDK is no longer
+   * authenticated.
+   */
+  authenticator: () => Promise<void> = null;
 
-  public auth: AuthController;
-  public bulk: any;
-  public collection: CollectionController;
-  public document: DocumentController;
-  public index: IndexController;
-  public ms: any;
-  public realtime: RealtimeController;
-  public security: any;
-  public server: any;
+  auth: AuthController;
+  bulk: any;
+  collection: CollectionController;
+  document: DocumentController;
+  index: IndexController;
+  ms: any;
+  realtime: RealtimeController;
+  security: any;
+  server: any;
 
   private _protectedEvents: any;
   private _offlineQueue: any;
@@ -236,38 +243,38 @@ export class Kuzzle extends KuzzleEventEmitter {
     this._cookieAuthentication = typeof options.cookieAuth === 'boolean'
       ? options.cookieAuth
       : false;
-    
+
     if (this._cookieAuthentication) {
       this.protocol.enableCookieSupport();
       let autoQueueState;
       let autoReplayState;
       let autoResbuscribeState;
-  
+
       this.protocol.addListener('websocketRenewalStart', () => {
         autoQueueState = this.autoQueue;
         autoReplayState = this.autoReplay;
         autoResbuscribeState = this.autoResubscribe;
-  
+
         this.autoQueue = true;
         this.autoReplay = true;
         this.autoResubscribe = true;
       });
-  
+
       this.protocol.addListener('websocketRenewalDone', () => {
         this.autoQueue = autoQueueState;
         this.autoReplay = autoReplayState;
         this.autoResubscribe = autoResbuscribeState;
       });
     }
-    
+
     this.deprecationHandler = new Deprecation(
       typeof options.deprecationWarning === 'boolean' ? options.deprecationWarning : true
     );
-    
+
     if (this._cookieAuthentication && typeof XMLHttpRequest === 'undefined') {
       throw new Error('Support for cookie authentication with cookieAuth option is not supported outside a browser');
     }
-    
+
     // controllers
     this.useController(AuthController, 'auth');
     this.useController(BulkController, 'bulk');
@@ -525,9 +532,17 @@ export class Kuzzle extends KuzzleEventEmitter {
       this.emit('disconnected', context);
     });
 
-    this.protocol.addListener('reconnect', () => {
+    this.protocol.addListener('reconnect', async () => {
       if (this.autoQueue) {
         this.stopQueuing();
+      }
+
+      // If the SDK was authenticated, check if the token is still valid and try
+      // to re-authenticate if needed. Otherwise the SDK is in disconnected state.
+      if (this.jwt && ! await this.tryReAuthenticate()) {
+        this.disconnect();
+
+        return;
       }
 
       if (this.autoReplay) {
@@ -540,6 +555,59 @@ export class Kuzzle extends KuzzleEventEmitter {
     this.protocol.addListener('discarded', data => this.emit('discarded', data));
 
     return this.protocol.connect();
+  }
+
+  /**
+   * Try to re-authenticate the SDK if the current token is invalid.
+   *
+   * If the token is invalid, this method will return false and emit a
+   * "reconnectionError" event when:
+   *   - the SDK cannot re-authenticate using the authenticator function
+   *   - the authenticator function is not set
+   */
+  private async tryReAuthenticate (): Promise<boolean> {
+    try {
+      const { valid } = await this.auth.checkToken();
+
+      if (! valid && this.authenticator) {
+        await this.authenticate();
+      }
+      else if (! valid && ! this.authenticator) {
+        this.emit('reconnectionError', {
+          error: new Error('SDK is not authenticated after reconnection and no "authenticator" function is defined.')
+        });
+
+        return false;
+      }
+    }
+    catch (err) {
+      this.emit('reconnectionError', {
+        error: new Error(`Failed to authenticate the SDK after reconnection: ${err}`)
+      });
+
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Use the "authenticator" function to authenticate the SDK.
+   *
+   * @returns The authentication token
+   */
+  async authenticate (): Promise<string> {
+    if (! this.authenticator) {
+      throw new Error('No "authenticator" function is defined.');
+    }
+
+    await this.authenticator();
+
+    if (! this.jwt) {
+      throw new Error('The "authenticator" function did not authenticate the SDK. ("jwt" is not set)');
+    }
+
+    return this.jwt;
   }
 
   /**
@@ -801,7 +869,7 @@ Discarded request: ${JSON.stringify(request)}`));
       uniqueQueue = {},
       dequeuingProcess = () => {
         if (this.offlineQueue.length > 0) {
-          
+
           this._timeoutRequest(
             this.offlineQueue[0].timeout,
             this.offlineQueue[0].request,
@@ -853,7 +921,7 @@ Discarded request: ${JSON.stringify(request)}`));
 
   /**
    * Sends a request with a timeout
-   * 
+   *
    * @param delay Delay before the request is rejected if not resolved
    * @param request Request object
    * @param options Request options

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -204,7 +204,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
         /**
          * In case you're running a Kuzzle version under 2.10.0
          * The response from a browser custom ping will be another payload.
-         * We need to clear this timeout at each message to keep 
+         * We need to clear this timeout at each message to keep
          * the connection alive if it's the case
          */
         clearTimeout(this.pongTimeoutId);
@@ -227,7 +227,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
 
     super.enableCookieSupport();
     this._httpProtocol = new HttpProtocol(
-      this.host, 
+      this.host,
       {
         port: this.port,
         ssl: this.ssl,
@@ -279,7 +279,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
           });
       })
       .catch(error => this.emit(formattedRequest.payload.requestId, {error}));
-    
+
   }
 
   /**

--- a/test/kuzzle/authenticator.test.js
+++ b/test/kuzzle/authenticator.test.js
@@ -119,15 +119,6 @@ describe('Kuzzle authenticator function mecanisms', () => {
       should(reconnectionErrorSpy).not.be.called();
     });
 
-    it('should emit "reconnectionError" if the token is not valid and no "authenticator" is set', async () => {
-      kuzzle.authenticator = null;
-
-      const ret = await kuzzle.tryReAuthenticate();
-
-      should(ret).be.false();
-      should(reconnectionErrorSpy).be.called();
-    });
-
     it('should emit "reconnectionError" if the "authenticator" function fail', async () => {
       kuzzle.authenticate.rejects('auth fail');
 

--- a/test/kuzzle/authenticator.test.js
+++ b/test/kuzzle/authenticator.test.js
@@ -1,0 +1,169 @@
+const should = require('should');
+const sinon = require('sinon');
+const ProtocolMock = require('../mocks/protocol.mock');
+const { Kuzzle } = require('../../src/Kuzzle');
+
+describe('Kuzzle authenticator function mecanisms', () => {
+  let kuzzle;
+  let protocol;
+  let validJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+
+  beforeEach(() => {
+    protocol = new ProtocolMock('somewhere');
+    kuzzle = new Kuzzle(protocol);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('reconnect listener', () => {
+    let reconnectedSpy;
+    let resolve;
+    let promise;
+
+    beforeEach(() => {
+      kuzzle.jwt = validJwt;
+
+      sinon.stub(kuzzle, 'tryReAuthenticate').resolves(true);
+      sinon.stub(kuzzle, 'disconnect');
+
+      reconnectedSpy = sinon.stub();
+      kuzzle.on('reconnected', reconnectedSpy);
+    });
+
+    it('should try to re-authenticate when reconnecting if a JWT was set', async () => {
+      promise = new Promise(_resolve => {
+        resolve = _resolve;
+      });
+      await kuzzle.connect();
+
+      protocol.emit('reconnect');
+
+      // We need a timeout since the listener on "reconnect" even is async
+      setTimeout(() => {
+        should(kuzzle.tryReAuthenticate).be.calledOnce();
+        should(reconnectedSpy).be.calledOnce();
+        resolve();
+      }, 1);
+
+      return promise;
+    });
+
+    it('should not fire the reconnected event and disconnect the SDK if authentication fail', async () => {
+      promise = new Promise(_resolve => {
+        resolve = _resolve;
+      });
+      await kuzzle.connect();
+      kuzzle.tryReAuthenticate.resolves(false);
+
+      protocol.emit('reconnect');
+
+      // We need a timeout since the listener on "reconnect" even is async
+      setTimeout(() => {
+        should(kuzzle.tryReAuthenticate).be.calledOnce();
+        should(kuzzle.disconnect).be.calledOnce();
+        resolve();
+      }, 1);
+
+      return promise;
+    });
+
+    it('should not try to authenticate if the SDK was not authenticated', async () => {
+      promise = new Promise(_resolve => {
+        resolve = _resolve;
+      });
+      await kuzzle.connect();
+      kuzzle.jwt = null;
+
+      protocol.emit('reconnect');
+
+      // We need a timeout since the listener on "reconnect" even is async
+      setTimeout(() => {
+        should(reconnectedSpy).be.calledOnce();
+        resolve();
+      }, 1);
+
+      return promise;
+    });
+  });
+
+  describe('#tryReAuthenticate', () => {
+    let reconnectionErrorSpy;
+
+    beforeEach(() => {
+      sinon.stub(kuzzle.auth, 'checkToken').resolves({ valid: false });
+      sinon.stub(kuzzle, 'authenticate').resolves();
+
+      reconnectionErrorSpy = sinon.stub();
+      kuzzle.on('reconnectionError', reconnectionErrorSpy);
+
+      kuzzle.authenticator = () => {};
+    });
+
+    it('should returns true if the token is still valid', async () => {
+      kuzzle.auth.checkToken.resolves({ valid: true });
+
+      const ret = await kuzzle.tryReAuthenticate();
+
+      should(ret).be.true();
+      should(kuzzle.authenticate).not.be.called();
+      should(reconnectionErrorSpy).not.be.called();
+    });
+
+    it('should call "authenticate" if the token is not valid', async () => {
+      const ret = await kuzzle.tryReAuthenticate();
+
+      should(ret).be.true();
+      should(kuzzle.authenticate).be.calledOnce();
+      should(reconnectionErrorSpy).not.be.called();
+    });
+
+    it('should emit "reconnectionError" if the token is not valid and no "authenticator" is set', async () => {
+      kuzzle.authenticator = null;
+
+      const ret = await kuzzle.tryReAuthenticate();
+
+      should(ret).be.false();
+      should(reconnectionErrorSpy).be.called();
+    });
+
+    it('should emit "reconnectionError" if the "authenticator" function fail', async () => {
+      kuzzle.authenticate.rejects('auth fail');
+
+      const ret = await kuzzle.tryReAuthenticate();
+
+      should(ret).be.false();
+      should(reconnectionErrorSpy).be.called();
+    });
+  });
+
+  describe('#authenticate', () => {
+    beforeEach(() => {
+      kuzzle.authenticator = async () => {
+        kuzzle.jwt = validJwt;
+      };
+
+      sinon.spy(kuzzle, 'authenticator');
+    });
+
+    it('should execute the "authenticator"', async () => {
+      const token = await kuzzle.authenticate();
+
+      should(kuzzle.authenticator).be.calledOnce();
+      should(token).be.eql(validJwt);
+    });
+
+    it('should throw an error if the "authenticator" is not set', () => {
+      kuzzle.authenticator = null;
+
+      should(kuzzle.authenticate()).be.rejected();
+    });
+
+    it('should throw an error if the "authenticator" does not set the JWT', () => {
+      kuzzle.authenticator = async () => {};
+
+      should(kuzzle.authenticate()).be.rejected();
+    });
+  });
+});

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -30,6 +30,7 @@ describe('Kuzzle listeners management', () => {
       'offlineQueuePop',
       'queryError',
       'reconnected',
+      'reconnectionError',
       'tokenExpired'
     ];
 


### PR DESCRIPTION
## What does this PR do ?

When the SDK reconnect to Kuzzle, it trigger the `reconnected` event. The Realtime controller will try to resubscribe when this event is triggered.

If the token had expired, then the Realtime controller will try to resubscribe with no authentication and thus the subscriptions request may fail.

This PR include a new `authenticator` property, this property should contain a function that authenticate the SDK (with `auth.login` for example).  
The SDK will call the function before emitting the reconnected event, if the SDK was authenticated and cannot re-authenticate then the `reconnected` event will not be emitted and the SDK will be in the `disconnected` state.

A new `reconnectionError` has been added and is triggered when the reconnection has failed

### How should this be manually tested?

Create an user:
```
kourou security:createUser '{           
  content: {    
    profileIds: ["admin"]
  },                    
  credentials: {          
    local: {
      username: "test",
      password: "test"
    }
  }
}'
```

Then run this script:
```
const { Kuzzle, WebSocket } = require('./index');

const kuzzle = new Kuzzle(new WebSocket('localhost'), { autoResubscribe: true });

kuzzle.authenticator = async () => {
  await kuzzle.auth.login('local', { username: 'test', password: 'test' });
};

;(async () => {
  await kuzzle.connect();
  console.log(await kuzzle.authenticate());

  await kuzzle.realtime.subscribe('test', 'test', {}, () => {
    console.log('Received');
  });

  console.log('Subscribed');
})();
```

Disconnect your user  `kourou auth:logout -a global=true --username test --password test`

Then stop and restart Kuzzle, the SDK should re-subscribe successfully

