### PR TITLE
Hotfix heartbeat race condition

### DIFF
--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -28,7 +28,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
    *    - `port` Kuzzle server port (default: `7512`)
    *    - `headers` Connection custom HTTP headers (Not supported by browsers)
    *    - `reconnectionDelay` Number of milliseconds between reconnection attempts (default: `1000`)
-   *    - `pingInterval` Number of milliseconds between two pings (default: `10000`)
+   *    - `pingInterval` Number of milliseconds between two pings (default: `2000`)
    *    - `ssl` Use SSL to connect to Kuzzle server. Default `false` unless port is 443 or 7443.
    */
   constructor(

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -118,9 +118,9 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
         this.waitForPong = false; // Reset when connection is established
         this.pingIntervalId = setInterval(() => {
           // If the connection is established and we are not waiting for a pong we ping Kuzzle
-          if (this.client &&
-              this.client.readyState === this.client.OPEN &&
-              !this.waitForPong
+          if ( this.client
+            && this.client.readyState === this.client.OPEN
+            && ! this.waitForPong
           ) {
             this.ping();
             this.waitForPong = true;
@@ -135,7 +135,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
              * Ensure that the websocket connection is closed because if the connection was fine but Kuzzle could not respond in time
              * a new connection will be created if `autoReconnect=true` and there would 2 opened websocket connection.
              */
-            this.client.close(); 
+            this.client.close();
             this.waitForPong = false;
             this.clientNetworkError(error);
           }
@@ -218,7 +218,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
         /**
          * In case you're running a Kuzzle version under 2.10.0
          * The response from a browser custom ping will be another payload.
-         * We need to clear this timeout at each message to keep 
+         * We need to clear this timeout at each message to keep
          * the connection alive if it's the case
          */
         this.waitForPong = false;
@@ -241,7 +241,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
 
     super.enableCookieSupport();
     this._httpProtocol = new HttpProtocol(
-      this.host, 
+      this.host,
       {
         port: this.port,
         ssl: this.ssl,
@@ -293,7 +293,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
           });
       })
       .catch(error => this.emit(formattedRequest.payload.requestId, {error}));
-    
+
   }
 
   /**

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -215,7 +215,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
          * We need to clear this timeout at each message to keep 
          * the connection alive if it's the case
          */
-         this.waitForPong = false;
+        this.waitForPong = false;
       };
     });
   }

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -129,7 +129,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
 
           // If we were waiting for a pong that never occured before the next ping cycle we throw an error
           if (this.waitForPong) {
-            const error: any = new Error('Connection lost.');
+            const error: any = new Error('Kuzzle does\'nt respond to ping. Connection lost.');
             error.status = 503;
             /**
              * Ensure that the websocket connection is closed because if the connection was fine but Kuzzle could not respond in time

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -130,6 +130,11 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
           if (this.waitForPong) {
             const error: any = new Error('Connection lost.');
             error.status = 503;
+            /**
+             * Ensure that the websocket connection is closed because if the connection was fine but Kuzzle could not respond in time
+             * a new connection will be created if `autoReconnect=true` and there would 2 opened websocket connection.
+             */
+            this.client.close(); 
             this.waitForPong = false;
             this.clientNetworkError(error);
           }

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -114,7 +114,8 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
         /**
         * Send pings to the server
         */
-        this.waitForPong = false; // Reset when connection established
+        clearInterval(this.pingIntervalId);
+        this.waitForPong = false; // Reset when connection is established
         this.pingIntervalId = setInterval(() => {
           // If the connection is established and we are not waiting for a pong we ping Kuzzle
           if (this.client &&

--- a/test/protocol/WebSocket.test.js
+++ b/test/protocol/WebSocket.test.js
@@ -105,7 +105,11 @@ describe('WebSocket networking module', () => {
     const setInterval = sinon.stub(clock, 'setInterval');
 
     websocket.connect();
+    websocket.waitForPong = true;
     clientStub.onopen();
+
+    should(websocket.waitForPong)
+      .be.false();
 
     should(setInterval)
       .be.calledOnce();
@@ -380,7 +384,7 @@ describe('WebSocket networking module', () => {
       .be.calledWithMatch(expectedError, payload);
   });
 
-  it('should clear the pongTimeOut when receiving a pong message and return', () => {
+  it('should set the waitForPong to false when receiving a pong message and return', () => {
     const
       cb = sinon.stub(),
       cb2 = sinon.stub();

--- a/test/protocol/WebSocket.test.js
+++ b/test/protocol/WebSocket.test.js
@@ -142,10 +142,11 @@ describe('WebSocket networking module', () => {
     should(websocket.listeners('networkError').length).be.eql(1);
 
     websocket.connect();
+
     clientStub.onopen();
     clientStub.onerror();
     should(clearInterval)
-      .be.calledOnce();
+      .be.calledTwice();
   });
 
   it('should clear pingInterval when the connection closes', () => {
@@ -161,7 +162,7 @@ describe('WebSocket networking module', () => {
     clientStub.onclose(1000);
     should(cb).be.calledOnce().and.be.calledWith({origin: DisconnectionOrigin.USER_CONNECTION_CLOSED });
     should(clearInterval)
-      .be.calledOnce();
+      .be.calledTwice();
   });
   
   it('should try to reconnect on a connection error with autoReconnect = true', () => {


### PR DESCRIPTION
## What does this PR do ?

This PR fixes a Race Condition that was occuring within the Heartbeat causing the SDK to think the connection was lost and making him engage the reconnection protocol which was causing the SDK to create multiple Websocket connection even though the previous connections were fine.

This is a serious problem that could cause applications to be overloaded with Websocket connections and can saturate the Event Loop or the limit of Websocket connections defined by the browsers.

What has been done:
- Avoid creating a Timeout in the the ping Interval since they had the same amount of time before execution and that caused  a race condition, we now only have an Interval that checks if there has been a pong since the last cycle, if not throw an Error, if there was a pong since the last ping cycle do another ping.
- Correct tests to verify the new behaviour
- Fixed: the ping Interval was not cleared when `websocket.close` was called
- Ensures that the websocket connection is closed on timeout before engaging the reconnection protocol otherwise if this was a false positive because Kuzzle could not respond in time we would have 2 connection opened.
- Ensures that the previous interval is cleared before creating a new one

## How should this be manually tested
Run this script, there should not be any network error messages, and only one active websocket connection to kuzzle.
Unfortunately this doesn't help testing the `Race Condition` as it's not easy to reproduce the exact conditions needed, but it somehow occurs frequently in one of our project.
```js
const { Kuzzle, WebSocket } = require('./index');

const kuzzle = new Kuzzle(new WebSocket('localhost'));

async function main() {
    kuzzle.on('networkError', (...args) => {
        console.log(...args);
    });
    for (let i  = 0; i < 10; i++) {
        await kuzzle.disconnect();
        await kuzzle.connect();
    }
}

main();
```