### PR TITLE
Resubscription not working in the browser because of a bad transpilation

### DIFF
--- a/src/controllers/Realtime.ts
+++ b/src/controllers/Realtime.ts
@@ -279,7 +279,7 @@ export class RealtimeController extends BaseController {
      * Use forEach instead of iterating over Map.keys() because the Webpack 
      * transpilation is producing bad code leading to a loop not iterating.
      */
-    this._subscriptionsOff.forEach((rooms, roomId) => {
+    this._subscriptionsOff.forEach((rooms) => {
       for (const room of rooms) {
         room.removeListeners();
       }

--- a/src/controllers/Realtime.ts
+++ b/src/controllers/Realtime.ts
@@ -279,7 +279,7 @@ export class RealtimeController extends BaseController {
      * Use forEach instead of iterating over Map.keys() because the Webpack 
      * transpilation is producing bad code leading to a loop not iterating.
      */
-    this._subscriptionsOff.forEach((rooms) => {
+    this._subscriptions.forEach((rooms) => {
       for (const room of rooms) {
         room.removeListeners();
       }

--- a/src/controllers/Realtime.ts
+++ b/src/controllers/Realtime.ts
@@ -226,8 +226,13 @@ export class RealtimeController extends BaseController {
    * Called when kuzzle is disconnected
    */
   private saveSubscriptions () {
-    for (const roomId of this._subscriptions.keys()) {
-      for (const room of this._subscriptions.get(roomId)) {
+    /**
+     * Use forEach instead of iterating over Map.keys() because the Webpack 
+     * transpilation is producing bad code leading to a loop not iterating.
+     */
+    this._subscriptions.forEach((rooms, roomId) => {
+
+      for (const room of rooms) {
         room.removeListeners();
 
         if (room.autoResubscribe) {
@@ -239,15 +244,20 @@ export class RealtimeController extends BaseController {
       }
 
       this._subscriptions.delete(roomId);
-    }
+
+    });
   }
 
   /**
    * Called on kuzzle reconnection
    */
   private resubscribe () {
-    for (const roomId of this._subscriptionsOff.keys()) {
-      for (const room of this._subscriptionsOff.get(roomId)) {
+    /**
+     * Use forEach instead of iterating over Map.keys() because the Webpack 
+     * transpilation is producing bad code leading to a loop not iterating.
+     */
+    this._subscriptionsOff.forEach((rooms, roomId) => {
+      for (const room of rooms) {
         if (!this._subscriptions.has(roomId)) {
           this._subscriptions.set(roomId, []);
         }
@@ -258,18 +268,22 @@ export class RealtimeController extends BaseController {
       }
 
       this._subscriptionsOff.delete(roomId);
-    }
+    });
   }
 
   /**
    * Called when a token expire
    */
   private removeSubscriptions() {
-    for (const roomId of this._subscriptions.keys()) {
-      for (const room of this._subscriptions.get(roomId)) {
+    /**
+     * Use forEach instead of iterating over Map.keys() because the Webpack 
+     * transpilation is producing bad code leading to a loop not iterating.
+     */
+    this._subscriptionsOff.forEach((rooms, roomId) => {
+      for (const room of rooms) {
         room.removeListeners();
       }
-    }
+    });
 
     this._subscriptions = new Map();
     this._subscriptionsOff = new Map();


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

This PR make a slight changes in the way we loop over the `Map.keys()` in the `saveSubscription`, `resubscribe` and `removeSubscriptions` method, because Webpack is incorrectly transpiling the loops making those methods not working properly.

Instead of iterating this way
```js
for (const roomId of this._subscriptions.keys()) {
  // Body
}
```
The iteration is now done using `Map.forEeach`
```js
this._subscriptions.forEach((rooms, roomId) => {
  // Body
});
```

### Why those changes

Like I said, those changes are made to fix an issue where the resubscription mecanism wasn't working in the JS SDK but only in the browser.
This was caused by a bad transpilation of the loops using Webpack:
```js
for (const roomId of this._subscriptions.keys())
```
That were transpiled to:
```js
for(let e=0,t=this._subscriptions.keys();e<t.length;e++)
```

Since `_subscriptions` is a `Map` object, and `Map.keys()` return a `MapIterator` that doesn't have the property `length`, the loop wasn't executed since the condition was invalid.