### PR TITLE
Fix upsert options.default 

### DIFF
--- a/doc/7/controllers/document/upsert/index.md
+++ b/doc/7/controllers/document/upsert/index.md
@@ -30,7 +30,7 @@ Additional query options
 
 | Options           | Type<br/>(default)               | Description                                                                                                           |
 | ----------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `defaults`        | <pre>object</pre><br/>(`{}`)     | Fields to add to the document if it gets created                                                                      |
+| `default`        | <pre>object</pre><br/>(`{}`)     | Fields to add to the document if it gets created                                                                      |
 | `refresh`         | <pre>string</pre><br/>(`""`)     | If set to `wait_for`, waits for the change to be reflected for `search` (up to 1s)                                    |
 | `retryOnConflict` | <pre>int</pre><br/>(`10`)        | The number of times the database layer should retry in case of version conflict                                       |
 | `silent`          | <pre>boolean</pre><br/>(`false`) | If `true`, then Kuzzle will not generate notifications <SinceBadge version="7.5.3"/>                                  |

--- a/src/controllers/Document.ts
+++ b/src/controllers/Document.ts
@@ -250,7 +250,7 @@ export class DocumentController extends BaseController {
       silent: options.silent,
       source: options.source,
     };
-  
+
     return this.query(request, options)
       .then(response => response.result);
   }
@@ -730,7 +730,7 @@ export class DocumentController extends BaseController {
 
   /**
    * Applies partial updates to multiple documents.
-   * 
+   *
    * If a document doesn't already exist, a new document is created.
    * @see https://docs.kuzzle.io/sdk/js/7/controllers/document/m-upsert/
    *
@@ -1038,7 +1038,7 @@ export class DocumentController extends BaseController {
    * @param _id Unique document identifier
    * @param changes Partial content of the document to update
    * @param [options]
-   *    - `defaults` Fields to add to the document if it gets created
+   *    - `default` Fields to add to the document if it gets created
    *    - `refresh` If set to `wait_for`, Kuzzle will not respond until the API key is indexed
    *    - `silent` If true, then Kuzzle will not generate notifications
    *    - `retryOnConflict` Number of times the database layer should retry in case of version conflict
@@ -1052,7 +1052,7 @@ export class DocumentController extends BaseController {
     _id: string,
     changes: JSONObject,
     options: {
-      defaults?: JSONObject;
+      default?: JSONObject;
       refresh?: string,
       silent?: boolean,
       retryOnConflict?: boolean,
@@ -1064,7 +1064,7 @@ export class DocumentController extends BaseController {
       index,
       collection,
       _id,
-      body: { changes, defaults: options.defaults },
+      body: { changes, default: options.default },
       action: 'upsert',
       source: options.source,
       silent: options.silent,

--- a/src/controllers/Document.ts
+++ b/src/controllers/Document.ts
@@ -397,6 +397,7 @@ export class DocumentController extends BaseController {
       body: { documents },
       action: 'mCreate',
       silent: options.silent,
+      strict: options.strict,
     };
 
     return this.query(request, options)
@@ -469,6 +470,7 @@ export class DocumentController extends BaseController {
       body: { documents },
       action: 'mCreateOrReplace',
       silent: options.silent,
+      strict: options.strict,
     };
 
     return this.query(request, options)
@@ -528,6 +530,7 @@ export class DocumentController extends BaseController {
       body: { ids },
       action: 'mDelete',
       silent: options.silent,
+      strict: options.strict,
     };
 
     return this.query(request, options)
@@ -645,6 +648,7 @@ export class DocumentController extends BaseController {
       body: { documents },
       action: 'mReplace',
       silent: options.silent,
+      strict: options.strict,
     };
 
     return this.query(request, options)
@@ -722,6 +726,7 @@ export class DocumentController extends BaseController {
       body: { documents },
       action: 'mUpdate',
       silent: options.silent,
+      strict: options.strict,
     };
 
     return this.query(request, options)
@@ -742,6 +747,7 @@ export class DocumentController extends BaseController {
    *    - `refresh` If set to `wait_for`, Kuzzle will not respond until the API key is indexed
    *    - `silent` If true, then Kuzzle will not generate notifications
    *    - `retryOnConflict` Number of times the database layer should retry in case of version conflict
+   *    - `strict` If true, an error will occur if a document was not updated
    *
    * @returns An object containing 2 arrays: "successes" and "errors"
    */
@@ -767,6 +773,7 @@ export class DocumentController extends BaseController {
       refresh?: 'wait_for',
       silent?: boolean,
       retryOnConflict?: number,
+      strict?: boolean
     } = {}
   ): Promise<{
     /**
@@ -797,6 +804,7 @@ export class DocumentController extends BaseController {
       body: { documents },
       action: 'mUpsert',
       silent: options.silent,
+      strict: options.strict,
     };
 
     return this.query(request, options)

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -118,7 +118,7 @@ describe('Document Controller', () => {
     });
   });
 
-  
+
   describe('deleteFields', () => {
     it('should call document/deleteFields query and return a Promise which resolves the updated document', () => {
       kuzzle.query.resolves({result: {_id: 'document-id', _source: {foo: 'bar'}}});
@@ -262,6 +262,38 @@ describe('Document Controller', () => {
               collection: 'collection',
               silent: true,
               body: {documents: [{_id: 'document-id', body: {foo: 'bar'}}]}
+            }, options);
+
+          should(res).be.equal(result);
+        });
+    });
+  });
+
+  describe('upsert', () => {
+    it('should call document/upsert query and return a Promise which resolves Kuzzle result', () => {
+      const result = {
+        _id: 'document-1629897817507',
+        _version: 1,
+        created: true
+      };
+      kuzzle.query.resolves({result});
+      options.silent = true;
+      options.default = { def: 'default' };
+      options.source = true;
+
+      return kuzzle.document.upsert('index', 'collection', 'some-id', { changes: 'changes' }, options)
+        .then(res => {
+          should(kuzzle.query)
+            .be.calledOnce()
+            .be.calledWith({
+              controller: 'document',
+              action: 'upsert',
+              index: 'index',
+              collection: 'collection',
+              _id: 'some-id',
+              silent: true,
+              source: true,
+              body: { changes: { changes: 'changes' }, default: { def: 'default' } },
             }, options);
 
           should(res).be.equal(result);

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -220,6 +220,7 @@ describe('Document Controller', () => {
       };
       kuzzle.query.resolves({result});
       options.silent = true;
+      options.strict = true;
 
       return kuzzle.document.mCreate('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options)
         .then(res => {
@@ -231,6 +232,7 @@ describe('Document Controller', () => {
               index: 'index',
               collection: 'collection',
               silent: true,
+              strict: true,
               body: {documents: [{_id: 'document-id', body: {foo: 'bar'}}]}
             }, options);
 
@@ -251,6 +253,7 @@ describe('Document Controller', () => {
       };
       kuzzle.query.resolves({result});
       options.silent = true;
+      options.strict = true;
 
       return kuzzle.document.mCreateOrReplace('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options)
         .then(res => {
@@ -262,6 +265,7 @@ describe('Document Controller', () => {
               index: 'index',
               collection: 'collection',
               silent: true,
+              strict: true,
               body: {documents: [{_id: 'document-id', body: {foo: 'bar'}}]}
             }, options);
 
@@ -307,6 +311,7 @@ describe('Document Controller', () => {
       const result = ['document1', 'document2'];
       kuzzle.query.resolves({result});
       options.silent = true;
+      options.strict = true;
 
       return kuzzle.document.mDelete('index', 'collection', ['document1', 'document2'], options)
         .then(res => {
@@ -318,6 +323,7 @@ describe('Document Controller', () => {
               index: 'index',
               collection: 'collection',
               silent: true,
+              strict: true,
               body: {ids: ['document1', 'document2']}
             }, options);
 
@@ -369,6 +375,7 @@ describe('Document Controller', () => {
       };
       kuzzle.query.resolves({result});
       options.silent = true;
+      options.strict = true;
 
       return kuzzle.document.mReplace('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options)
         .then(res => {
@@ -380,6 +387,7 @@ describe('Document Controller', () => {
               index: 'index',
               collection: 'collection',
               silent: true,
+              strict: true,
               body: {documents: [{_id: 'document-id', body: {foo: 'bar'}}]}
             }, options);
 
@@ -400,6 +408,7 @@ describe('Document Controller', () => {
       };
       kuzzle.query.resolves({result});
       options.silent = true;
+      options.strict = true;
 
       return kuzzle.document.mUpdate('index', 'collection', [{_id: 'document-id', body: {foo: 'bar'}}], options)
         .then(res => {
@@ -411,6 +420,7 @@ describe('Document Controller', () => {
               index: 'index',
               collection: 'collection',
               silent: true,
+              strict: true,
               body: {documents: [{_id: 'document-id', body: {foo: 'bar'}}]}
             }, options);
 

--- a/test/controllers/document.test.js
+++ b/test/controllers/document.test.js
@@ -5,7 +5,7 @@ const { DocumentController } = require('../../src/controllers/Document');
 const { DocumentSearchResult } = require('../../src/core/searchResult/Document');
 
 describe('Document Controller', () => {
-  const options = {opt: 'in'};
+  let options;
   let kuzzle;
 
   beforeEach(() => {
@@ -13,6 +13,7 @@ describe('Document Controller', () => {
       query: sinon.stub().resolves()
     };
     kuzzle.document = new DocumentController(kuzzle);
+    options = { opt: 'in' };
   });
 
   describe('count', () => {


### PR DESCRIPTION
## What does this PR do ?

The `options.default` option of `document.upsert` method was wrong: instead of `default`, the `defaults` property was sent to Kuzzle