### PR TITLE
Allows to define custom headers for HTTP protocol

### DIFF
--- a/doc/7/protocols/http/constructor/index.md
+++ b/doc/7/protocols/http/constructor/index.md
@@ -19,7 +19,7 @@ Http(host, [options]);
 <br/>
 
 | Argument  | Type              | Description                  |
-| --------- | ----------------- | ---------------------------- |
+|-----------|-------------------|------------------------------|
 | `host`    | <pre>string</pre> | Kuzzle server hostname or IP |
 | `options` | <pre>object</pre> | Http connection options      |
 
@@ -27,13 +27,14 @@ Http(host, [options]);
 
 Http protocol connection options.
 
-| Property        | Type<br/>(default)               | Description                         |
-| --------------- | -------------------------------- | ----------------------------------- |
-| `port`          | <pre>number</pre><br/>(`7512`)   | Kuzzle server port                  |
-| `sslConnection`     | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server   <DeprecatedBadge version="7.4.0"/>   |
-| `ssl`     | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server. Defaults to `true` for ports 443 and 7443.   |
-| `customRoutes` | <pre>object</pre><br/>(`{}`) | Add custom routes <SinceBadge version="6.2.0"/> |
-| `timeout` | <pre>number</pre><br/>(`0`) | Connection timeout in milliseconds (`0` means no timeout)<SinceBadge version="6.2.1"/> |
+| Property        | Type<br/>(default)               | Description                                                                            |
+|-----------------|----------------------------------|----------------------------------------------------------------------------------------|
+| `customRoutes`  | <pre>object</pre><br/>(`{}`)     | Add custom routes <SinceBadge version="6.2.0"/>                                        |
+| `headers`       | <pre>object</pre><br/>(`{}`)     | Default headers sent with each HTTP request <SinceBadge version="auto-version"/>       |
+| `port`          | <pre>number</pre><br/>(`7512`)   | Kuzzle server port                                                                     |
+| `sslConnection` | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server <DeprecatedBadge version="7.4.0"/>               |
+| `ssl`           | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server. Defaults to `true` for ports 443 and 7443.        |
+| `timeout`       | <pre>number</pre><br/>(`0`)      | Connection timeout in milliseconds (`0` means no timeout) <SinceBadge version="6.2.1"/> |
 
 **Note:**
 

--- a/doc/7/protocols/http/constructor/snippets/constructor.js
+++ b/doc/7/protocols/http/constructor/snippets/constructor.js
@@ -12,8 +12,13 @@ const customRoutes = {
   }
 };
 
+const headers = {
+  'Accept-Encoding': 'gzip, deflate'
+};
+
 const options = {
   customRoutes,
+  headers,
   sslConnection: false
 };
 

--- a/test/protocol/Http.test.js
+++ b/test/protocol/Http.test.js
@@ -828,6 +828,28 @@ describe('HTTP networking module', () => {
     });
   });
 
+  describe('#_formatRequest', () => {
+    it('should inject default headers', () => {
+      protocol._routes = {
+        server: {
+          now: { verb: 'get', url: '/_now' }
+        }
+      };
+      protocol._defaultHeaders = {
+        'Accept-Encoding': 'gzip, deflate',
+      };
+      const request = { controller: 'server', action: 'now' };
+      const formattedRequest = protocol.formatRequest(request);
+
+      should(formattedRequest.payload).match({
+        headers: {
+          'Accept-Encoding': 'gzip, deflate',
+          'Content-Type': 'application/json',
+        }
+      });
+    });
+  });
+
   describe('#isReady', () => {
     it('should be ready if the instance is ready', () => {
       protocol.state = 'ready';


### PR DESCRIPTION
## What does this PR do ?

This PR allows to define custom HTTP headers that will be send with every request made by the SDK.

Those headers are defined when instantiating the HTTP protocol:
```js
const kuzzle = new Kuzzle(new Http('localhost', { 
  headers: {
    'Accept-Encoding': 'gzip, deflate'
  }
}));
```

For example, this allows to use a different `Accept-Encoding` header to use gzip or deflate compression with Kuzzle


