### PR TITLE
Fix reconnectionError not emittend when authenticator is missing

### DIFF
--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -640,6 +640,9 @@ export class Kuzzle extends KuzzleEventEmitter {
        * like so API Keys can be used even if there is no authenticator since they will be still valid.
        */
       if (! this.authenticator) {
+        this.emit('reconnectionError', {
+          error: new Error('Could not reauthenticate: undefined authenticator property')
+        });
         return false;
       }
 

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -641,7 +641,7 @@ export class Kuzzle extends KuzzleEventEmitter {
        */
       if (! this.authenticator) {
         this.emit('reconnectionError', {
-          error: new Error('Could not reauthenticate: undefined authenticator property')
+          error: new Error('Could not re-authenticate: "authenticator" property is not set.')
         });
         return false;
       }

--- a/test/kuzzle/authenticator.test.js
+++ b/test/kuzzle/authenticator.test.js
@@ -245,7 +245,7 @@ describe('Kuzzle authenticator function mecanisms', () => {
       should(reconnectionErrorSpy).not.be.called();
     });
 
-    it('should returns false if the token is not valid and there is no authenticator', async () => {
+    it('should returns false if the token is not valid and there is no authenticator and emit a reconnectionError', async () => {
       kuzzle.auth.checkToken.resolves({ valid: false });
       kuzzle.authenticator = null;
 
@@ -253,7 +253,7 @@ describe('Kuzzle authenticator function mecanisms', () => {
 
       should(ret).be.false();
       should(kuzzle.authenticate).not.be.called();
-      should(reconnectionErrorSpy).not.be.called();
+      should(reconnectionErrorSpy).be.called();
     });
 
     it('should call "authenticate" if the token is not valid', async () => {


### PR DESCRIPTION
## What does this PR do ?

Emit a reconnectionError when there is no authenticator set.
