### PR TITLE
Propagates every arguments to Kuzzle

### DIFF
--- a/ast-refactor/inline-options-to-interface.ts
+++ b/ast-refactor/inline-options-to-interface.ts
@@ -1,0 +1,111 @@
+/**
+ * Script to refactor inline options declaration into external interfaces
+ * inheriting from the default "ArgsDefault" interface.
+ * 
+ * @example
+ * 
+export class SomeController {
+  helloWorld (
+    name: string,
+    options: {
+      queuable?: boolean,
+      timeout?: number,
+      age?: number;
+    } = {}
+  ): string {
+    return name;
+  }
+}
+
+ * This code will became 
+
+export class SomeController {
+  helloWorld (
+    name: string,
+    options: SomeControllerHelloWorldArgs = {}
+  ): string {
+    return name;
+  }
+}
+
+interface SomeControllerHelloWorldArgs extends ArgsDefault {
+  age?: number;
+}
+
+ */
+
+/* Script Arguments ==================================================== */
+
+const filePath = process.argv[2];
+const className = process.argv[3];
+
+if (! filePath || ! className) {
+  console.log(`Usage: node ${process.argv[1]} <file path> <class name>`);
+}
+
+/* ===================================================================== */
+
+import { Project, SyntaxKind, ParameterDeclaration } from 'ts-morph';
+
+function upFirst (string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+// initialize
+const project = new Project({});
+
+const file = project.addSourceFileAtPath(filePath);
+const loadedClass = file.getClassOrThrow(className);
+
+for (const method of loadedClass.getMethods()) {
+  if (method.getScope() !== 'public') {
+    continue;
+  }
+  const options = method.getParameter('options');
+
+  if (options) {
+    const argsInterface = createArgsInterface(method.getName(), options);
+    options.setType(argsInterface.getName())
+  }
+}
+
+
+function createArgsInterface (methodName: string, options: ParameterDeclaration) {
+  const argsInterface = file.addInterface({
+    name: `Args${loadedClass.getName()}${upFirst(methodName)}`,
+    extends: ['ArgsDefault'],
+    isExported: true,
+  });
+
+  const optionsType = options.getTypeNode()
+
+  if (optionsType) {
+    const syntaxList = optionsType.getChildSyntaxList();
+
+    for (const child of syntaxList.getChildren()) {
+  
+      const name = child.getChildrenOfKind(SyntaxKind.Identifier)[0].getText();
+      // Ignore common arguments
+      if (['queuable', 'timeout'].includes(name)) {
+        continue;
+      }
+  
+      const hasQuestionToken = Boolean(child.getChildrenOfKind(SyntaxKind.QuestionToken)[0]);
+      const type = child.getChildrenOfKind(SyntaxKind.ColonToken)[0].getNextSibling().getText();
+    
+      argsInterface.addProperty({ name, type, hasQuestionToken });
+    }  
+  }
+
+  console.log(argsInterface.getText());
+
+  return argsInterface;
+}
+
+
+
+async function run () {
+  await project.save();
+}
+
+run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1601,6 +1601,64 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@ts-morph/common": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.0.tgz",
+      "integrity": "sha512-Ti2tpROSVHlBoNiJKVUYPNk/yCPb1Bcly4RsSwC2F9a8PMMYfEYovRcghTu6N5o66Jq0yvPXN3uNaO4a3zskTA==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "fast-glob": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+          "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.7.tgz",
@@ -2864,6 +2922,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/coalescy/-/coalescy-1.0.0.tgz",
       "integrity": "sha1-SwZYRrg2NhrabEtKSr9LwcrDG/E=",
+      "dev": true
+    },
+    "code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
       "dev": true
     },
     "code-point-at": {
@@ -4751,7 +4815,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
@@ -6635,6 +6699,12 @@
         }
       }
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7466,7 +7536,7 @@
     },
     "should-util": {
       "version": "1.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
       "dev": true
     },
@@ -8045,6 +8115,16 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
+    },
+    "ts-morph": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.0.0.tgz",
+      "integrity": "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==",
+      "dev": true,
+      "requires": {
+        "@ts-morph/common": "~0.11.0",
+        "code-block-writer": "^10.1.1"
+      }
     },
     "ts-node": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "should-sinon": "0.0.6",
     "sinon": "^11.1.1",
     "stream-http": "^3.2.0",
+    "ts-morph": "^12.0.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2",
     "url": "^0.11.0",

--- a/src/controllers/Auth.ts
+++ b/src/controllers/Auth.ts
@@ -1,9 +1,8 @@
 import { Jwt } from '../core/Jwt';
 import { BaseController } from './Base';
 import { User } from '../core/security/User';
-import { JSONObject, ApiKey } from '../types';
+import { JSONObject, ApiKey, ArgsDefault } from '../types';
 import { RequestPayload } from '../types/RequestPayload';
-
 /**
  * Auth controller
  *
@@ -81,12 +80,7 @@ export class AuthController extends BaseController {
    */
   createApiKey(
     description: string,
-    options: {
-      _id?: string,
-      expiresIn?: number,
-      refresh?: 'wait_for',
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerCreateApiKey = {}
   ): Promise<ApiKey> {
     const request = {
       action: 'createApiKey',
@@ -98,7 +92,7 @@ export class AuthController extends BaseController {
       }
     };
 
-    return this.query(request)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -113,9 +107,7 @@ export class AuthController extends BaseController {
    */
   checkRights (
     requestPayload: RequestPayload,
-    options: {
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerCheckRights = {}
   ): Promise<boolean> {
     const request = {
       body: requestPayload,
@@ -138,10 +130,7 @@ export class AuthController extends BaseController {
    */
   deleteApiKey(
     id: string,
-    options: {
-      refresh?: 'wait_for',
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerDeleteApiKey = {}
   ): Promise<null> {
     const request = {
       action: 'deleteApiKey',
@@ -149,7 +138,7 @@ export class AuthController extends BaseController {
       refresh: options.refresh
     };
 
-    return this.query(request)
+    return this.query(request, options)
       .then(() => null);
   }
 
@@ -168,12 +157,7 @@ export class AuthController extends BaseController {
    */
   searchApiKeys(
     query: JSONObject = {},
-    options: {
-      from?: number,
-      size?: number,
-      lang?: string,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerSearchApiKeys = {}
   ): Promise<{
     /**
      * Array of found ApiKeys
@@ -192,7 +176,7 @@ export class AuthController extends BaseController {
       body: query
     };
 
-    return this.query(request)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -209,9 +193,7 @@ export class AuthController extends BaseController {
    */
   checkToken (
     token?: string,
-    options: {
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerCheckToken = {}
   ): Promise<{
     /**
      * Tell if the token is valid or not
@@ -260,10 +242,7 @@ export class AuthController extends BaseController {
   createMyCredentials (
     strategy: string,
     credentials: JSONObject,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerCreateMyCredentials = {}
   ): Promise<JSONObject> {
     return this.query({
       strategy,
@@ -287,10 +266,7 @@ export class AuthController extends BaseController {
    */
   credentialsExist (
     strategy: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerCredentialsExist = {}
   ): Promise<boolean> {
     return this.query({
       strategy,
@@ -311,10 +287,7 @@ export class AuthController extends BaseController {
    */
   deleteMyCredentials (
     strategy: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerDeleteMyCredentials = {}
   ): Promise<boolean> {
     return this.query({
       strategy,
@@ -334,7 +307,7 @@ export class AuthController extends BaseController {
    *
    * @returns Currently logged User
    */
-  getCurrentUser (options: {queuable?: boolean, timeout?: number } = {}): Promise<User> {
+  getCurrentUser (options: ArgsAuthControllerGetCurrentUser = {}): Promise<User> {
     return this.query({
       action: 'getCurrentUser'
     }, options)
@@ -359,10 +332,7 @@ export class AuthController extends BaseController {
    */
   getMyCredentials(
     strategy: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerGetMyCredentials = {}
   ): Promise<JSONObject> {
     return this.query({
       strategy,
@@ -383,10 +353,7 @@ export class AuthController extends BaseController {
    * @returns An array containing user rights objects
    */
   getMyRights (
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerGetMyRights = {}
   ): Promise<Array<{
     /**
      * Controller on wich the rights are applied
@@ -427,10 +394,7 @@ export class AuthController extends BaseController {
    * @returns An array of available strategies names
    */
   getStrategies (
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerGetStrategies = {}
   ): Promise<Array<string>> {
     return this.query({
       action: 'getStrategies'
@@ -522,10 +486,7 @@ export class AuthController extends BaseController {
   updateMyCredentials (
     strategy: string,
     credentials: JSONObject,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerUpdateMyCredentials = {}
   ): Promise<JSONObject> {
     return this.query({
       strategy,
@@ -550,10 +511,7 @@ export class AuthController extends BaseController {
    */
   updateSelf (
     content: JSONObject,
-    options: {
-      queuable?: boolean, 
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerUpdateSelf = {}
   ): Promise<User> {
     return this.query({
       body: content,
@@ -579,10 +537,7 @@ export class AuthController extends BaseController {
   validateMyCredentials (
     strategy: string,
     credentials: JSONObject,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerValidateMyCredentials = {}
   ): Promise<boolean> {
     return this.query({
       strategy,
@@ -605,11 +560,7 @@ export class AuthController extends BaseController {
    * @returns The refreshed token
    */
   refreshToken(
-    options: { 
-      queuable?: boolean,
-      expiresIn?: number | string,
-      timeout?: number
-    } = {}
+    options: ArgsAuthControllerRefreshToken = {}
   ): Promise<{
     /**
      * Token unique ID
@@ -643,4 +594,60 @@ export class AuthController extends BaseController {
         return response.result;
       });
   }
+}
+
+export interface ArgsAuthControllerCreateApiKey extends ArgsDefault {
+    _id?: string;
+    expiresIn?: number;
+    refresh?: 'wait_for';
+}
+
+export interface ArgsAuthControllerCheckRights extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerDeleteApiKey extends ArgsDefault {
+    refresh?: 'wait_for';
+}
+
+export interface ArgsAuthControllerSearchApiKeys extends ArgsDefault {
+    from?: number;
+    size?: number;
+    lang?: string;
+}
+
+export interface ArgsAuthControllerCheckToken extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerCreateMyCredentials extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerCredentialsExist extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerDeleteMyCredentials extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerGetCurrentUser extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerGetMyCredentials extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerGetMyRights extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerGetStrategies extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerUpdateMyCredentials extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerUpdateSelf extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerValidateMyCredentials extends ArgsDefault {
+}
+
+export interface ArgsAuthControllerRefreshToken extends ArgsDefault {
+    expiresIn?: number | string;
 }

--- a/src/controllers/Bulk.ts
+++ b/src/controllers/Bulk.ts
@@ -1,5 +1,5 @@
 import { BaseController } from './Base';
-import { JSONObject } from '../types';
+import { JSONObject, ArgsDefault } from '../types';
 
 export class BulkController extends BaseController {
   constructor (kuzzle) {
@@ -28,11 +28,7 @@ export class BulkController extends BaseController {
     index: string,
     collection: string,
     query: JSONObject = {},
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      timeout?: number
-    } = {}
+    options: ArgsBulkControllerDeleteByQuery = {}
   ): Promise<number> {
     const request = {
       index,
@@ -63,10 +59,7 @@ export class BulkController extends BaseController {
     index: string,
     collection: string,
     bulkData: Array<JSONObject>,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsBulkControllerImport = {}
   ): Promise<{
     /**
      * Array of successfully executed actions
@@ -144,10 +137,7 @@ export class BulkController extends BaseController {
     collection: string,
     query: JSONObject,
     changes: JSONObject,
-    options: {
-      refresh?: 'wait_for',
-      timeout?: number
-    } = {}
+    options: ArgsBulkControllerUpdateByQuery = {}
   ): Promise<number> {
     const request = {
       index,
@@ -182,12 +172,7 @@ export class BulkController extends BaseController {
     collection: string,
     document: JSONObject,
     id?: string,
-    options: {
-      queuable?: boolean,
-      notify?: boolean,
-      refresh?: 'wait_for',
-      timeout?: number
-    } = {}
+    options: ArgsBulkControllerWrite = {}
   ): Promise<Document> {
     return this.query({
       index,
@@ -229,12 +214,7 @@ export class BulkController extends BaseController {
        */
       _source: JSONObject;
     }>,
-    options: { 
-      queuable?: boolean,
-      notify?: boolean,
-      refresh?: 'wait_for',
-      timeout?: number
-    } = {}
+    options: ArgsBulkControllerMWrite = {}
   ): Promise<{
     /**
      * Array of successfully created/replaced documents
@@ -267,4 +247,25 @@ export class BulkController extends BaseController {
     }, options)
       .then(response => response.result);
   }
+}
+
+export interface ArgsBulkControllerDeleteByQuery extends ArgsDefault {
+    refresh?: 'wait_for';
+}
+
+export interface ArgsBulkControllerImport extends ArgsDefault {
+}
+
+export interface ArgsBulkControllerUpdateByQuery extends ArgsDefault {
+    refresh?: 'wait_for';
+}
+
+export interface ArgsBulkControllerWrite extends ArgsDefault {
+    notify?: boolean;
+    refresh?: 'wait_for';
+}
+
+export interface ArgsBulkControllerMWrite extends ArgsDefault {
+    notify?: boolean;
+    refresh?: 'wait_for';
 }

--- a/src/controllers/Collection.ts
+++ b/src/controllers/Collection.ts
@@ -1,6 +1,6 @@
 import { BaseController } from './Base';
 import { SpecificationsSearchResult } from '../core/searchResult/Specifications';
-import { CollectionMappings, JSONObject } from '../types';
+import { CollectionMappings, JSONObject, ArgsDefault } from '../types';
 
 export class CollectionController extends BaseController {
   constructor (kuzzle) {
@@ -36,10 +36,7 @@ export class CollectionController extends BaseController {
        */
       settings?: JSONObject
     } | CollectionMappings,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerCreate = {}
   ): Promise<void> {
     const request = {
       index,
@@ -66,10 +63,7 @@ export class CollectionController extends BaseController {
   deleteSpecifications (
     index: string,
     collection: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerDeleteSpecifications = {}
   ): Promise<void> {
     const request = {
       index,
@@ -94,10 +88,7 @@ export class CollectionController extends BaseController {
   exists (
     index: string,
     collection: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerExists = {}
   ): Promise<boolean> {
     return this.query({
       index,
@@ -122,10 +113,7 @@ export class CollectionController extends BaseController {
   refresh (
     index: string,
     collection: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerRefresh = {}
   ): Promise<void> {
     return this.query({
       index,
@@ -150,11 +138,7 @@ export class CollectionController extends BaseController {
   getMapping (
     index: string,
     collection: string,
-    options: {
-      includeKuzzleMeta?: boolean,
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerGetMapping = {}
   ): Promise<CollectionMappings> {
     const request = {
       index,
@@ -183,10 +167,7 @@ export class CollectionController extends BaseController {
   getSpecifications (
     index: string,
     collection: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerGetSpecifications = {}
   ): Promise<JSONObject> {
     return this.query({
       index,
@@ -210,18 +191,7 @@ export class CollectionController extends BaseController {
    */
   list (
     index: string,
-    options: {
-      queuable?: boolean;
-      timeout?: number
-      /**
-       * @deprecated
-       */
-      from?: number;
-      /**
-       * @deprecated
-       */
-      size?: number;
-    } = {}
+    options: ArgsCollectionControllerList = {}
   ): Promise<{
     /**
      *  Types of returned collections.
@@ -267,13 +237,7 @@ export class CollectionController extends BaseController {
    */
   searchSpecifications (
     query: JSONObject = {},
-    options: {
-      queuable?: boolean;
-      from?: number;
-      size?: number;
-      scroll?: string;
-      timeout?: number;
-    } = {}
+    options: ArgsCollectionControllerSearchSpecifications = {}
   ): Promise<SpecificationsSearchResult> {
     const request = {
       body: query,
@@ -305,10 +269,7 @@ export class CollectionController extends BaseController {
   truncate (
     index: string,
     collection: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerTruncate = {}
   ): Promise<void> {
     const request = {
       index,
@@ -348,10 +309,7 @@ export class CollectionController extends BaseController {
        */
       settings?: JSONObject
     } | CollectionMappings,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerUpdate = {}
   ): Promise<void> {
     return this.query({
       index,
@@ -369,9 +327,7 @@ export class CollectionController extends BaseController {
     index: string,
     collection: string,
     mappings: CollectionMappings,
-    options: {
-      queuable?: boolean,
-    } = {}
+    options: ArgsCollectionControllerUpdateMapping = {}
   ): Promise<JSONObject> {
     return this.query({
       index,
@@ -400,10 +356,7 @@ export class CollectionController extends BaseController {
     index: string,
     collection: string,
     specifications: JSONObject,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerUpdateSpecifications = {}
   ): Promise<JSONObject> {
     return this.query({
       index,
@@ -433,10 +386,7 @@ export class CollectionController extends BaseController {
     index: string,
     collection: string,
     specifications: JSONObject,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerValidateSpecifications = {}
   ): Promise<{
     valid: boolean;
     details: Array<string>;
@@ -464,9 +414,7 @@ export class CollectionController extends BaseController {
   delete (
     index: string,
     collection: string,
-    options: {
-      timeout?: number
-    } = {}
+    options: ArgsCollectionControllerDelete = {}
   ): Promise<void> {
     const request = {
       index,
@@ -477,4 +425,52 @@ export class CollectionController extends BaseController {
     return this.query(request, options)
       .then(() => undefined);
   }
+}
+
+export interface ArgsCollectionControllerCreate extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerDeleteSpecifications extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerExists extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerRefresh extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerGetMapping extends ArgsDefault {
+    includeKuzzleMeta?: boolean;
+}
+
+export interface ArgsCollectionControllerGetSpecifications extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerList extends ArgsDefault {
+    from?: number;
+    size?: number;
+}
+
+export interface ArgsCollectionControllerSearchSpecifications extends ArgsDefault {
+    from?: number;
+    size?: number;
+    scroll?: string;
+}
+
+export interface ArgsCollectionControllerTruncate extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerUpdate extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerUpdateMapping extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerUpdateSpecifications extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerValidateSpecifications extends ArgsDefault {
+}
+
+export interface ArgsCollectionControllerDelete extends ArgsDefault {
 }

--- a/src/controllers/Document.ts
+++ b/src/controllers/Document.ts
@@ -1,7 +1,7 @@
 import { BaseController } from './Base';
 import { SearchResult } from '../core/searchResult/SearchResultBase';
 import { DocumentSearchResult } from '../core/searchResult/Document';
-import { JSONObject, Document, DocumentHit } from '../types';
+import { JSONObject, Document, DocumentHit, ArgsDefault } from '../types';
 
 export class DocumentController extends BaseController {
   constructor (kuzzle) {
@@ -29,10 +29,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     body?: JSONObject,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerCount = {}
   ): Promise<number> {
     const request = {
       index,
@@ -67,12 +64,7 @@ export class DocumentController extends BaseController {
     collection: string,
     content: JSONObject,
     _id: string = null,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerCreate = {}
   ): Promise<Document> {
     const request = {
       index,
@@ -110,12 +102,7 @@ export class DocumentController extends BaseController {
     collection: string,
     _id: string,
     content: JSONObject,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerCreateOrReplace = {}
   ): Promise<Document> {
     const request = {
       index,
@@ -150,12 +137,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     _id: string,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerDelete = {}
   ): Promise<number> {
     const request = {
       index,
@@ -190,13 +172,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     query: JSONObject = {},
-    options: {
-      queuable?: boolean,
-      refresh?: string,
-      silent?: boolean,
-      lang?: string,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerDeleteByQuery = {}
   ): Promise<Array<string>> {
     const request = {
       index,
@@ -233,13 +209,7 @@ export class DocumentController extends BaseController {
     collection: string,
     _id: string,
     fields: string[],
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      source?: boolean,
-      timeout?: number,
-    } = {}
+    options: ArgsDocumentControllerDeleteFields = {}
   ): Promise<Document> {
     const request = {
       index,
@@ -275,12 +245,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     _id: string,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerExists = {}
   ): Promise<boolean> {
     const request = {
       index,
@@ -313,12 +278,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     _id: string,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerGet = {}
   ): Promise<Document> {
     const request = {
       index,
@@ -361,13 +321,7 @@ export class DocumentController extends BaseController {
        */
       body: JSONObject;
     }>,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number,
-      strict?: boolean
-    } = {}
+    options: ArgsDocumentControllerMCreate = {}
   ): Promise<{
     /**
      * Array of successfully created documents
@@ -434,13 +388,7 @@ export class DocumentController extends BaseController {
        */
       body: JSONObject;
     }>,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number,
-      strict?: boolean
-    } = {}
+    options: ArgsDocumentControllerMCreateOrReplace = {}
   ): Promise<{
     /**
      * Array of successfully created documents
@@ -498,13 +446,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     ids: Array<string>,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number,
-      strict?: boolean
-    } = {}
+    options: ArgsDocumentControllerMDelete = {}
   ): Promise<{
     /**
      * Array of successfully deleted documents IDS
@@ -556,11 +498,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     ids: Array<string>,
-    options: {
-      queuable?: boolean,
-      verb?: string,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerMGet = {}
   ): Promise<{
     /**
      * Array of successfully retrieved documents
@@ -612,13 +550,7 @@ export class DocumentController extends BaseController {
        */
       body: JSONObject;
     }>,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number,
-      strict?: boolean
-    } = {}
+    options: ArgsDocumentControllerMReplace = {}
   ): Promise<{
     /**
      * Array of successfully replaced documents
@@ -689,14 +621,7 @@ export class DocumentController extends BaseController {
        */
       body: JSONObject;
     }>,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      retryOnConflict?: number,
-      timeout?: number
-      strict?: boolean,
-    } = {}
+    options: ArgsDocumentControllerMUpdate = {}
   ): Promise<{
     /**
      * Array of successfully updated documents
@@ -768,13 +693,7 @@ export class DocumentController extends BaseController {
        */
       default: JSONObject
     }>,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      retryOnConflict?: number,
-      strict?: boolean
-    } = {}
+    options: ArgsDocumentControllerMUpsert = {}
   ): Promise<{
     /**
      * Array of successfully updated documents
@@ -833,12 +752,7 @@ export class DocumentController extends BaseController {
     collection: string,
     _id: string,
     content: JSONObject,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerReplace = {}
   ): Promise<Document> {
     const request = {
       index,
@@ -875,15 +789,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     query: JSONObject = {},
-    options: {
-      queuable?: boolean;
-      from?: number;
-      size?: number;
-      scroll?: string;
-      lang?: string;
-      verb?: string;
-      timeout?: number;
-    } = {}
+    options: ArgsDocumentControllerSearch = {}
   ): Promise<SearchResult<DocumentHit>> {
     return this._search(index, collection, query, options)
       .then(({ response, request, opts }) => (
@@ -945,14 +851,7 @@ export class DocumentController extends BaseController {
     collection: string,
     _id: string,
     content: JSONObject,
-    options: {
-      queuable?: boolean,
-      refresh?: 'wait_for',
-      silent?: boolean,
-      retryOnConflict?: number,
-      source?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerUpdate = {}
   ): Promise<Document> {
     const request = {
       index,
@@ -992,13 +891,7 @@ export class DocumentController extends BaseController {
     collection: string,
     query: JSONObject,
     changes: JSONObject,
-    options: {
-      refresh?: 'wait_for',
-      silent?: boolean,
-      source?: boolean,
-      lang?: string,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerUpdateByQuery = {}
   ): Promise<{
     /**
      * Array of successfully updated documents
@@ -1059,14 +952,7 @@ export class DocumentController extends BaseController {
     collection: string,
     _id: string,
     changes: JSONObject,
-    options: {
-      default?: JSONObject;
-      refresh?: string,
-      silent?: boolean,
-      retryOnConflict?: boolean,
-      source?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerUpsert = {}
   ): Promise<Document> {
     const request = {
       index,
@@ -1100,10 +986,7 @@ export class DocumentController extends BaseController {
     index: string,
     collection: string,
     content: JSONObject,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsDocumentControllerValidate = {}
   ): Promise<boolean> {
     return this.query({
       index,
@@ -1113,4 +996,124 @@ export class DocumentController extends BaseController {
     }, options)
       .then(response => response.result);
   }
+}
+
+export interface ArgsDocumentControllerCount extends ArgsDefault {
+}
+
+export interface ArgsDocumentControllerCreate extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+}
+
+export interface ArgsDocumentControllerCreateOrReplace extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+}
+
+export interface ArgsDocumentControllerDelete extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+}
+
+export interface ArgsDocumentControllerDeleteByQuery extends ArgsDefault {
+    refresh?: string;
+    silent?: boolean;
+    lang?: string;
+}
+
+export interface ArgsDocumentControllerDeleteFields extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    source?: boolean;
+}
+
+export interface ArgsDocumentControllerExists extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+}
+
+export interface ArgsDocumentControllerGet extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+}
+
+export interface ArgsDocumentControllerMCreate extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    strict?: boolean;
+}
+
+export interface ArgsDocumentControllerMCreateOrReplace extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    strict?: boolean;
+}
+
+export interface ArgsDocumentControllerMDelete extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    strict?: boolean;
+}
+
+export interface ArgsDocumentControllerMGet extends ArgsDefault {
+    verb?: string;
+}
+
+export interface ArgsDocumentControllerMReplace extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    strict?: boolean;
+}
+
+export interface ArgsDocumentControllerMUpdate extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    retryOnConflict?: number;
+    strict?: boolean;
+}
+
+export interface ArgsDocumentControllerMUpsert extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    retryOnConflict?: number;
+    strict?: boolean;
+}
+
+export interface ArgsDocumentControllerReplace extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+}
+
+export interface ArgsDocumentControllerSearch extends ArgsDefault {
+    from?: number;
+    size?: number;
+    scroll?: string;
+    lang?: string;
+    verb?: string;
+}
+
+export interface ArgsDocumentControllerUpdate extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    retryOnConflict?: number;
+    source?: boolean;
+}
+
+export interface ArgsDocumentControllerUpdateByQuery extends ArgsDefault {
+    refresh?: 'wait_for';
+    silent?: boolean;
+    source?: boolean;
+    lang?: string;
+}
+
+export interface ArgsDocumentControllerUpsert extends ArgsDefault {
+    default?: JSONObject;
+    refresh?: string;
+    silent?: boolean;
+    retryOnConflict?: boolean;
+    source?: boolean;
+}
+
+export interface ArgsDocumentControllerValidate extends ArgsDefault {
 }

--- a/src/controllers/Index.ts
+++ b/src/controllers/Index.ts
@@ -1,5 +1,5 @@
 import { BaseController } from './Base';
-import { JSONObject } from '../types';
+import { JSONObject, ArgsDefault } from '../types';
 
 export class IndexController extends BaseController {
 
@@ -19,10 +19,7 @@ export class IndexController extends BaseController {
    */
   create (
     index: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsIndexControllerCreate = {}
   ): Promise<void> {
     const request = {
       index,
@@ -44,10 +41,7 @@ export class IndexController extends BaseController {
    */
   delete (
     index: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsIndexControllerDelete = {}
   ): Promise<void> {
     const request = {
       index,
@@ -69,10 +63,7 @@ export class IndexController extends BaseController {
    */
   exists (
     index: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsIndexControllerExists = {}
   ): Promise<boolean> {
     return this.query({
       index,
@@ -91,10 +82,7 @@ export class IndexController extends BaseController {
    *    - `timeout` Request Timeout in ms, after the delay if not resolved the promise will be rejected
    */
   list (
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsIndexControllerList = {}
   ): Promise<Array<string>> {
     return this.query({
       action: 'list'
@@ -116,10 +104,7 @@ export class IndexController extends BaseController {
    */
   mDelete (
     indexes: Array<string>,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsIndexControllerMDelete = {}
   ): Promise<Array<string>> {
     const request = {
       action: 'mDelete',
@@ -142,14 +127,29 @@ export class IndexController extends BaseController {
    *    - `timeout` Request Timeout in ms, after the delay if not resolved the promise will be rejected
    */
   stats (
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsIndexControllerStats = {}
   ): Promise<JSONObject> {
     return this.query({
       action: 'stats'
     }, options)
       .then(response => response.result);
   }
+}
+
+export interface ArgsIndexControllerCreate extends ArgsDefault {
+}
+
+export interface ArgsIndexControllerDelete extends ArgsDefault {
+}
+
+export interface ArgsIndexControllerExists extends ArgsDefault {
+}
+
+export interface ArgsIndexControllerList extends ArgsDefault {
+}
+
+export interface ArgsIndexControllerMDelete extends ArgsDefault {
+}
+
+export interface ArgsIndexControllerStats extends ArgsDefault {
 }

--- a/src/controllers/Realtime.ts
+++ b/src/controllers/Realtime.ts
@@ -1,6 +1,6 @@
 import { BaseController } from './Base';
 import Room from '../core/Room';
-import { Notification, JSONObject } from '../types';
+import { Notification, JSONObject, ArgsDefault } from '../types';
 
 /**
  * Enum for `scope` option of realtime.subscribe method
@@ -80,10 +80,7 @@ export class RealtimeController extends BaseController {
    */
   count (
     roomId: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsRealtimeControllerCount = {}
   ): Promise<number> {
     return this.query({
       action: 'count',
@@ -112,11 +109,7 @@ export class RealtimeController extends BaseController {
     index: string,
     collection: string,
     message: JSONObject,
-    options: {
-      queuable?: boolean,
-      _id?: string,
-      timeout?: number
-    } = {}
+    options: ArgsRealtimeControllerPublish = {}
   ): Promise<boolean> {
     const request = {
       index,
@@ -156,25 +149,7 @@ export class RealtimeController extends BaseController {
     collection: string,
     filters: JSONObject,
     callback: (notification: Notification) => void | Promise<void>,
-    options: {
-      /**
-       * Subscribe to document entering or leaving the scope. (default: 'all')
-       */
-      scope?: ScopeOption;
-      /**
-       * Subscribe to users entering or leaving the room. (default: 'none')
-       */
-      users?: UserOption;
-      /**
-       * Subscribe to notifications fired by our own queries. (default: true)
-       */
-      subscribeToSelf?: boolean;
-      /**
-       * Subscription information sent alongside notifications
-       */
-      volatile?: JSONObject;
-      timeout?: number;
-    } = {}
+    options: ArgsRealtimeControllerSubscribe = {}
   ): Promise<string> {
     const room = new Room(this, index, collection, filters, callback, options);
 
@@ -198,10 +173,7 @@ export class RealtimeController extends BaseController {
    */
   unsubscribe (
     roomId: string,
-    options: {
-      queuable?: boolean,
-      timeout?: number
-    } = {}
+    options: ArgsRealtimeControllerUnsubscribe = {}
   ): Promise<void> {
     const request = {
       action: 'unsubscribe',
@@ -288,4 +260,21 @@ export class RealtimeController extends BaseController {
     this._subscriptions = new Map();
     this._subscriptionsOff = new Map();
   }
+}
+
+export interface ArgsRealtimeControllerCount extends ArgsDefault {
+}
+
+export interface ArgsRealtimeControllerPublish extends ArgsDefault {
+    _id?: string;
+}
+
+export interface ArgsRealtimeControllerSubscribe extends ArgsDefault {
+    scope?: ScopeOption;
+    users?: UserOption;
+    subscribeToSelf?: boolean;
+    volatile?: JSONObject;
+}
+
+export interface ArgsRealtimeControllerUnsubscribe extends ArgsDefault {
 }

--- a/src/controllers/Security.ts
+++ b/src/controllers/Security.ts
@@ -5,6 +5,7 @@ import { Profile } from '../core/security/Profile';
 import { ProfileSearchResult } from '../core/searchResult/Profile';
 import { User } from '../core/security/User';
 import { UserSearchResult } from '../core/searchResult/User';
+import { ArgsDefault } from '../types';
 
 export class SecurityController extends BaseController {
   /**
@@ -26,11 +27,7 @@ export class SecurityController extends BaseController {
   createApiKey(
     userId,
     description,
-    options: {
-      expiresIn?: string | number,
-      _id?: string,
-      refresh?: 'wait_for',
-    } = {}) {
+    options: ArgsSecurityControllerCreateApiKey = {}) {
     const request = {
       userId,
       action: 'createApiKey',
@@ -42,7 +39,7 @@ export class SecurityController extends BaseController {
       }
     };
 
-    return this.query(request)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
@@ -52,14 +49,14 @@ export class SecurityController extends BaseController {
    * @param {String} kuid - User kuid
    * @param {Object} requestPayload - Request to check
    */
-  checkRights (kuid, requestPayload) {
+  checkRights (kuid, requestPayload, options: ArgsSecurityControllerCheckRights) {
     const request = {
       userId: kuid,
       body: requestPayload,
       action: 'checkRights'
     };
 
-    return this.query(request)
+    return this.query(request, options)
       .then(response => response.result.allowed);
   }
 
@@ -75,9 +72,7 @@ export class SecurityController extends BaseController {
   deleteApiKey(
     userId,
     id,
-    options: {
-      refresh?: 'wait_for',
-    } = {}) {
+    options: ArgsSecurityControllerDeleteApiKey = {}) {
     const request = {
       userId,
       action: 'deleteApiKey',
@@ -85,7 +80,7 @@ export class SecurityController extends BaseController {
       refresh: options.refresh
     };
 
-    return this.query(request);
+    return this.query(request, options);
   }
 
   /**
@@ -100,11 +95,7 @@ export class SecurityController extends BaseController {
   searchApiKeys(
     userId,
     query = {},
-    options: {
-      from?: number,
-      size?: number,
-      lang?: string,
-    } = {}
+    options: ArgsSecurityControllerSearchApiKeys = {}
   ) {
     const request = {
       userId,
@@ -115,11 +106,11 @@ export class SecurityController extends BaseController {
       body: query
     };
 
-    return this.query(request)
+    return this.query(request, options)
       .then(response => response.result);
   }
 
-  createCredentials (strategy, _id, body, options = {}) {
+  createCredentials (strategy, _id, body, options: ArgsSecurityControllerCreateCredentials = {}) {
     return this.query({
       _id,
       strategy,
@@ -132,9 +123,7 @@ export class SecurityController extends BaseController {
   createFirstAdmin (
     _id,
     body,
-    options: {
-      reset?: boolean,
-    } = {}
+    options: ArgsSecurityControllerCreateFirstAdmin = {}
   ) {
     const request = {
       _id,
@@ -147,7 +136,7 @@ export class SecurityController extends BaseController {
       .then(response => new User(this.kuzzle, response.result._id, response.result._source));
   }
 
-  createOrReplaceProfile (_id, body, options = {}) {
+  createOrReplaceProfile (_id, body, options: ArgsSecurityControllerCreateOrReplaceProfile = {}) {
     const request = {
       _id,
       body,
@@ -164,9 +153,7 @@ export class SecurityController extends BaseController {
   createOrReplaceRole (
     _id,
     body,
-    options: {
-      force?: boolean,
-    } = {}
+    options: ArgsSecurityControllerCreateOrReplaceRole = {}
   ) {
     const request = {
       _id,
@@ -178,7 +165,7 @@ export class SecurityController extends BaseController {
       .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
-  createProfile (_id, body, options = {}) {
+  createProfile (_id, body, options: ArgsSecurityControllerCreateProfile = {}) {
     const request = {
       _id,
       body,
@@ -192,7 +179,7 @@ export class SecurityController extends BaseController {
         response.result._source));
   }
 
-  createRestrictedUser (body, _id = null, options = {}) {
+  createRestrictedUser (body, _id = null, options: ArgsSecurityControllerCreateRestrictedUser = {}) {
     if (!body.content) {
       body.content = {};
     }
@@ -207,7 +194,7 @@ export class SecurityController extends BaseController {
       .then(response => new User(this.kuzzle, response.result._id, response.result._source));
   }
 
-  createRole (_id, body, options: { force?: boolean, } = {}) {
+  createRole (_id, body, options: ArgsSecurityControllerCreateRole = {}) {
     const request = {
       _id,
       body,
@@ -218,7 +205,7 @@ export class SecurityController extends BaseController {
       .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
-  createUser (_id, body, options = {}) {
+  createUser (_id, body, options: ArgsSecurityControllerCreateUser = {}) {
     const request = {
       _id,
       body,
@@ -229,7 +216,7 @@ export class SecurityController extends BaseController {
       .then(response => new User(this.kuzzle, response.result._id, response.result._source));
   }
 
-  deleteCredentials (strategy, _id, options = {}) {
+  deleteCredentials (strategy, _id, options: ArgsSecurityControllerDeleteCredentials = {}) {
     const request = {
       strategy,
       _id,
@@ -240,7 +227,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  deleteProfile (_id, options = {}) {
+  deleteProfile (_id, options: ArgsSecurityControllerDeleteProfile = {}) {
     const request = {
       _id,
       action: 'deleteProfile'
@@ -249,7 +236,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  deleteRole (_id, options = {}) {
+  deleteRole (_id, options: ArgsSecurityControllerDeleteRole = {}) {
     const request = {
       _id,
       action: 'deleteRole'
@@ -258,7 +245,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  deleteUser (_id, options = {}) {
+  deleteUser (_id, options: ArgsSecurityControllerDeleteUser = {}) {
     const request = {
       _id,
       action: 'deleteUser'
@@ -267,14 +254,14 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  getAllCredentialFields (options = {}) {
+  getAllCredentialFields (options: ArgsSecurityControllerGetAllCredentialFields = {}) {
     return this.query({
       action: 'getAllCredentialFields'
     }, options)
       .then(response => response.result);
   }
 
-  getCredentialFields (strategy, options = {}) {
+  getCredentialFields (strategy, options: ArgsSecurityControllerGetCredentialFields = {}) {
     return this.query({
       strategy,
       action: 'getCredentialFields'
@@ -282,7 +269,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  getCredentials (strategy, _id, options = {}) {
+  getCredentials (strategy, _id, options: ArgsSecurityControllerGetCredentials = {}) {
     return this.query({
       strategy,
       _id,
@@ -291,7 +278,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  getCredentialsById (strategy, _id, options = {}) {
+  getCredentialsById (strategy, _id, options: ArgsSecurityControllerGetCredentialsById = {}) {
     return this.query({
       strategy,
       _id,
@@ -300,7 +287,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  getProfile (_id, options = {}) {
+  getProfile (_id, options: ArgsSecurityControllerGetProfile = {}) {
     return this.query({_id, action: 'getProfile'}, options)
       .then(response => new Profile(
         this.kuzzle,
@@ -308,14 +295,14 @@ export class SecurityController extends BaseController {
         response.result._source));
   }
 
-  getProfileMapping (options = {}) {
+  getProfileMapping (options: ArgsSecurityControllerGetProfileMapping = {}) {
     return this.query({
       action: 'getProfileMapping'
     }, options)
       .then(response => response.result);
   }
 
-  getProfileRights (_id, options = {}) {
+  getProfileRights (_id, options: ArgsSecurityControllerGetProfileRights = {}) {
     return this.query({
       _id,
       action: 'getProfileRights'
@@ -323,7 +310,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result.hits);
   }
 
-  getRole (_id, options = {}) {
+  getRole (_id, options: ArgsSecurityControllerGetRole = {}) {
     return this.query({
       _id,
       action: 'getRole'
@@ -331,14 +318,14 @@ export class SecurityController extends BaseController {
       .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
-  getRoleMapping (options = {}) {
+  getRoleMapping (options: ArgsSecurityControllerGetRoleMapping = {}) {
     return this.query({
       action: 'getRoleMapping'
     }, options)
       .then(response => response.result);
   }
 
-  getUser (_id, options = {}) {
+  getUser (_id, options: ArgsSecurityControllerGetUser = {}) {
     return this.query({
       _id,
       action: 'getUser'
@@ -346,14 +333,14 @@ export class SecurityController extends BaseController {
       .then(response => new User(this.kuzzle, response.result._id, response.result._source));
   }
 
-  getUserMapping (options = {}) {
+  getUserMapping (options: ArgsSecurityControllerGetUserMapping = {}) {
     return this.query({
       action: 'getUserMapping'
     }, options)
       .then(response => response.result);
   }
 
-  getUserRights (_id, options = {}) {
+  getUserRights (_id, options: ArgsSecurityControllerGetUserRights = {}) {
     return this.query({
       _id,
       action: 'getUserRights'
@@ -361,7 +348,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result.hits);
   }
 
-  getUserStrategies (_id, options = {}) {
+  getUserStrategies (_id, options: ArgsSecurityControllerGetUserStrategies = {}) {
     return this.query({
       _id,
       action: 'getUserStrategies'
@@ -369,7 +356,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result.strategies);
   }
 
-  hasCredentials (strategy, _id, options = {}) {
+  hasCredentials (strategy, _id, options: ArgsSecurityControllerHasCredentials = {}) {
     return this.query({
       strategy,
       _id,
@@ -378,7 +365,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  mDeleteProfiles (ids, options = {}) {
+  mDeleteProfiles (ids, options: ArgsSecurityControllerMDeleteProfiles = {}) {
     const request = {
       action: 'mDeleteProfiles',
       body: {ids}
@@ -388,7 +375,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  mDeleteRoles (ids, options = {}) {
+  mDeleteRoles (ids, options: ArgsSecurityControllerMDeleteRoles = {}) {
     const request = {
       action: 'mDeleteRoles',
       body: {ids}
@@ -398,7 +385,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  mDeleteUsers (ids, options = {}) {
+  mDeleteUsers (ids, options: ArgsSecurityControllerMDeleteUsers = {}) {
     const request = {
       action: 'mDeleteUsers',
       body: {ids}
@@ -408,13 +395,13 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  mGetProfiles (ids, options = {}) {
+  mGetProfiles (ids, options: ArgsSecurityControllerMGetProfiles = {}) {
     return this.query({action: 'mGetProfiles', body: {ids}}, options)
       .then(response => response.result.hits.map(
         hit => new Profile(this.kuzzle, hit._id, hit._source)));
   }
 
-  mGetUsers (ids, options = {}) {
+  mGetUsers (ids, options: ArgsSecurityControllerMGetUsers = {}) {
     const request = {
       action: 'mGetUsers',
       body: {ids}
@@ -424,7 +411,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result.hits.map(hit => new User(this.kuzzle, hit._id, hit._source)));
   }
 
-  mGetRoles (ids, options = {}) {
+  mGetRoles (ids, options: ArgsSecurityControllerMGetRoles = {}) {
     return this.query({
       action: 'mGetRoles',
       body: {ids}
@@ -439,7 +426,7 @@ export class SecurityController extends BaseController {
     });
   }
 
-  replaceUser (_id, body, options = {}) {
+  replaceUser (_id, body, options: ArgsSecurityControllerReplaceUser = {}) {
     const request = {
       _id,
       body,
@@ -449,7 +436,7 @@ export class SecurityController extends BaseController {
       .then(response => new User(this.kuzzle, response.result._id, response.result._source));
   }
 
-  searchProfiles (body, options= {}) {
+  searchProfiles (body, options: ArgsSecurityControllerSearchProfiles= {}) {
     const request = {
       body,
       action: 'searchProfiles'
@@ -462,7 +449,7 @@ export class SecurityController extends BaseController {
       .then(response => new ProfileSearchResult(this.kuzzle, request, options, response.result));
   }
 
-  searchRoles (body, options = {}) {
+  searchRoles (body, options: ArgsSecurityControllerSearchRoles = {}) {
     const request = {
       body,
       action: 'searchRoles'
@@ -475,7 +462,7 @@ export class SecurityController extends BaseController {
       .then(response => new RoleSearchResult(this.kuzzle, request, options, response.result));
   }
 
-  searchUsers (body, options = {}) {
+  searchUsers (body, options: ArgsSecurityControllerSearchUsers = {}) {
     const request = {
       body,
       action: 'searchUsers'
@@ -488,7 +475,7 @@ export class SecurityController extends BaseController {
       .then(response => new UserSearchResult(this.kuzzle, request, options, response.result));
   }
 
-  updateCredentials (strategy, _id, body, options = {}) {
+  updateCredentials (strategy, _id, body, options: ArgsSecurityControllerUpdateCredentials = {}) {
     return this.query({
       strategy,
       _id,
@@ -498,7 +485,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  updateProfile (_id, body, options = {}) {
+  updateProfile (_id, body, options: ArgsSecurityControllerUpdateProfile = {}) {
     const request = {
       _id,
       body,
@@ -512,7 +499,7 @@ export class SecurityController extends BaseController {
         response.result._source));
   }
 
-  updateProfileMapping (body, options = {}) {
+  updateProfileMapping (body, options: ArgsSecurityControllerUpdateProfileMapping = {}) {
     return this.query({
       body,
       action: 'updateProfileMapping'
@@ -520,7 +507,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  updateRole (_id, body, options: { force?: boolean, } = {}) {
+  updateRole (_id, body, options: ArgsSecurityControllerUpdateRole = {}) {
     const request = {
       _id,
       body,
@@ -532,7 +519,7 @@ export class SecurityController extends BaseController {
       .then(response => new Role(this.kuzzle, response.result._id, response.result._source.controllers));
   }
 
-  updateRoleMapping (body, options = {}) {
+  updateRoleMapping (body, options: ArgsSecurityControllerUpdateRoleMapping = {}) {
     return this.query({
       body,
       action: 'updateRoleMapping'
@@ -540,7 +527,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  updateUser (_id, body, options = {}) {
+  updateUser (_id, body, options: ArgsSecurityControllerUpdateUser = {}) {
     const request = {
       _id,
       body,
@@ -550,7 +537,7 @@ export class SecurityController extends BaseController {
       .then(response => new User(this.kuzzle, response.result._id, response.result._source));
   }
 
-  updateUserMapping (body, options = {}) {
+  updateUserMapping (body, options: ArgsSecurityControllerUpdateUserMapping = {}) {
     return this.query({
       body,
       action: 'updateUserMapping'
@@ -558,7 +545,7 @@ export class SecurityController extends BaseController {
       .then(response => response.result);
   }
 
-  validateCredentials (strategy, _id, body, options = {}) {
+  validateCredentials (strategy, _id, body, options: ArgsSecurityControllerValidateCredentials = {}) {
     return this.query({
       _id,
       strategy,
@@ -567,4 +554,159 @@ export class SecurityController extends BaseController {
     }, options)
       .then(response => response.result);
   }
+}
+
+export interface ArgsSecurityControllerCreateApiKey extends ArgsDefault {
+    expiresIn?: string | number;
+    _id?: string;
+    refresh?: 'wait_for';
+}
+
+export interface ArgsSecurityControllerCheckRights extends ArgsDefault {    
+}
+
+export interface ArgsSecurityControllerDeleteApiKey extends ArgsDefault {
+    refresh?: 'wait_for';
+}
+
+export interface ArgsSecurityControllerSearchApiKeys extends ArgsDefault {
+    from?: number;
+    size?: number;
+    lang?: string;
+}
+
+export interface ArgsSecurityControllerCreateCredentials extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerCreateFirstAdmin extends ArgsDefault {
+    reset?: boolean;
+}
+
+export interface ArgsSecurityControllerCreateOrReplaceProfile extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerCreateOrReplaceRole extends ArgsDefault {
+    force?: boolean;
+}
+
+export interface ArgsSecurityControllerCreateProfile extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerCreateRestrictedUser extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerCreateRole extends ArgsDefault {
+    force?: boolean;
+}
+
+export interface ArgsSecurityControllerCreateUser extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerDeleteCredentials extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerDeleteProfile extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerDeleteRole extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerDeleteUser extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetAllCredentialFields extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetCredentialFields extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetCredentials extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetCredentialsById extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetProfile extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetProfileMapping extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetProfileRights extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetRole extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetRoleMapping extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetUser extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetUserMapping extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetUserRights extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerGetUserStrategies extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerHasCredentials extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerMDeleteProfiles extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerMDeleteRoles extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerMDeleteUsers extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerMGetProfiles extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerMGetUsers extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerMGetRoles extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerReplaceUser extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerSearchProfiles extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerSearchRoles extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerSearchUsers extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerUpdateCredentials extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerUpdateProfile extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerUpdateProfileMapping extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerUpdateRole extends ArgsDefault {
+    force?: boolean;
+}
+
+export interface ArgsSecurityControllerUpdateRoleMapping extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerUpdateUser extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerUpdateUserMapping extends ArgsDefault {
+}
+
+export interface ArgsSecurityControllerValidateCredentials extends ArgsDefault {
 }

--- a/src/controllers/Server.ts
+++ b/src/controllers/Server.ts
@@ -1,10 +1,11 @@
-const { BaseController } = require('./Base');
+import { BaseController } from './Base';
+import { ArgsDefault } from '../types';
 
 /**
  * @class ServerController
  * @property {Kuzzle} kuzzle - The Kuzzle SDK Instance
  */
-class ServerController extends BaseController {
+export class ServerController extends BaseController {
 
   /**
    * @param {Kuzzle} kuzzle - The Kuzzle SDK Instance
@@ -19,7 +20,7 @@ class ServerController extends BaseController {
    * @param {Object} options - {queuable: Boolean(true)}
    * @returns {Promise<Boolean>}
    */
-  adminExists (options) {
+  adminExists (options: ArgsServerControllerAdminExists) {
     return this.query({
       action: 'adminExists'
     }, options)
@@ -33,7 +34,7 @@ class ServerController extends BaseController {
    * @param {Object} options - {queuable: Boolean(true)}
    * @returns {Promise<Object>}
    */
-  getAllStats (options) {
+  getAllStats (options: ArgsServerControllerGetAllStats) {
     return this.query({
       action: 'getAllStats'
     }, options)
@@ -46,7 +47,7 @@ class ServerController extends BaseController {
    * @param {Object} options - {queuable: Boolean(true)}
    * @returns {Promise<Object>}
    */
-  getConfig (options) {
+  getConfig (options: ArgsServerControllerGetConfig) {
     return this.query({
       action: 'getConfig'
     }, options)
@@ -59,7 +60,7 @@ class ServerController extends BaseController {
    * @param {Object} options - {queuable: Boolean(true)}
    * @returns {Promise<Object>}
    */
-  getLastStats (options) {
+  getLastStats (options: ArgsServerControllerGetLastStats) {
     return this.query({
       action: 'getLastStats'
     }, options)
@@ -74,7 +75,7 @@ class ServerController extends BaseController {
    * @param {Object} options - {queuable: Boolean(true)}
    * @returns {Promise<Object>}
    */
-  getStats(startTime, stopTime, options) {
+  getStats (startTime: number | string, stopTime: number | string, options: ArgsServerControllerGetStats) {
     return this.query({
       action: 'getStats',
       startTime,
@@ -89,7 +90,7 @@ class ServerController extends BaseController {
    * @param {Object} options - {queuable: Boolean(true)}
    * @returns {Promise<Object>}
    */
-  info (options) {
+  info (options: ArgsServerControllerInfo) {
     return this.query({
       action: 'info'
     }, options)
@@ -102,7 +103,7 @@ class ServerController extends BaseController {
    * @param {Object} options - {queuable: Boolean(true)}
    * @returns {Promise<Number>}
    */
-  now (options) {
+  now (options: ArgsServerControllerNow) {
     return this.query({
       action: 'now'
     }, options)
@@ -110,4 +111,23 @@ class ServerController extends BaseController {
   }
 }
 
-module.exports = { ServerController };
+export interface ArgsServerControllerAdminExists extends ArgsDefault {
+}
+
+export interface ArgsServerControllerGetAllStats extends ArgsDefault {
+}
+
+export interface ArgsServerControllerGetConfig extends ArgsDefault {
+}
+
+export interface ArgsServerControllerGetLastStats extends ArgsDefault {
+}
+
+export interface ArgsServerControllerGetStats extends ArgsDefault {
+}
+
+export interface ArgsServerControllerInfo extends ArgsDefault {
+}
+
+export interface ArgsServerControllerNow extends ArgsDefault {
+}

--- a/src/types/ArgsDefault.ts
+++ b/src/types/ArgsDefault.ts
@@ -1,0 +1,10 @@
+/**
+ * Generic API action arguments
+ */
+export interface ArgsDefault {
+  queuable?: boolean;
+
+  timeout?: number;
+
+  [name: string]: any;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,3 +13,5 @@ export * from './Notification';
 export * from './ProfilePolicy';
 
 export * from './RoleRightsDefinition';
+
+export * from './ArgsDefault';

--- a/test/kuzzle/query.test.js
+++ b/test/kuzzle/query.test.js
@@ -102,7 +102,10 @@ describe('Kuzzle query management', () => {
           controller: 'controller',
           index: 'index',
           volatile: {sdkInstanceId: kuzzle.protocol.id, sdkName: kuzzle.sdkName},
-          requestId: sinon.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+          requestId: sinon.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
+          // propagated arguments
+          foo: 'bar',
+          baz: 'yolo'
         },
         {foo: 'bar', baz: 'yolo'}
       );


### PR DESCRIPTION
## What does this PR do ?

This PR allows the SDK to propagate every arguments passed to a method to Kuzzle even if this one is not explicitly declared.

Example
```js
await sdk.document.get('index', 'collection', 'document-id', { myCustomArg: 'foobar' });

// Generated query for Kuzzle API
{
  controller: 'document', 
  action: 'get',
  index: 'index',
  collection: 'collection',
  _id: 'document-id',
  myCustomArg: 'foobar',
}
```

### How the code has been modified

Since I'm lazy and I didn't wanted to modify every methods one by one to extract an interface from the inline type definition, I used the [ts-morph](https://ts-morph.com/) package who allows to directly manipulate Typescript AST.

You can check the `ast-refactor/inline-options-to-interface.ts` if you are curious about how it has been made.

