### PR TITLE
Add more context to errors

### DIFF
--- a/doc/7/core-classes/kuzzle-error/properties/index.md
+++ b/doc/7/core-classes/kuzzle-error/properties/index.md
@@ -9,12 +9,19 @@ order: 10
 
 # Properties
 
-| Property name | Type              | Description                                                         |
-|---------------|-------------------|---------------------------------------------------------------------|
-| `kuzzleStack` | <pre>string</pre> | Kuzzle stacktrace (only in development mode)                        |
-| `message`     | <pre>string</pre> | Error message                                                       |
-| `status`      | <pre>number</pre> | Error status code                                                   |
-| `stack`       | <pre>string</pre> | Complete error stacktrace (Kuzzle + SDK) (only in development mode) |
-| `id`          | <pre>string</pre> | Error unique identifier                                             |
-| `code`        | <pre>string</pre> | Error unique code                                                   |
-
+| Property name | Type              | Description                                                                                          |
+|---------------|-------------------|------------------------------------------------------------------------------------------------------|
+| `kuzzleStack` | <pre>string</pre> | Kuzzle stacktrace (only in development mode)                                                         |
+| `message`     | <pre>string</pre> | Error message                                                                                        |
+| `status`      | <pre>number</pre> | Error status code                                                                                    |
+| `stack`       | <pre>string</pre> | Complete error stacktrace (Kuzzle + SDK) (only in development mode)                                  |
+| `id`          | <pre>string</pre> | Error unique identifier                                                                              |
+| `code`        | <pre>string</pre> | Error unique code                                                                                    |
+| `controller`  | <pre>string</pre> | API controller name                                                                                  |
+| `action`      | <pre>string</pre> | API action name                                                                                      |
+| `volatile`    | <pre>object</pre> | KuzzleRequest [volatile data](https://docs.kuzzle.io/core/2/guides/main-concepts/api/#volatile-data) |
+| `index`       | <pre>string</pre> | Index name                                                                                           |
+| `collection`  | <pre>string</pre> | Collection name name                                                                                 |
+| `requestId`   | <pre>string</pre> | request id name                                                                                      |
+| `_id`         | <pre>string</pre> | Document unique identifier                                                                           |
+| `count`       | <pre>number</pre> | Number of associated errors (PartialError only)                                                      |

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -88,7 +88,6 @@ export class KuzzleError extends Error {
           at Funnel.processRequest (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:423:34)
               |
               |
-              Http: foo:bar
               HttpProtocol
               |
               |

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -126,7 +126,6 @@ export class KuzzleError extends Error {
       this.stack = apiError.stack + '\n';
       this.stack += '          |\n';
       this.stack += '          |\n';
-      this.stack += `          Status: ${this.status}\n`;
 
       this.stack += !this.controller && !this.action ? '' : `          Http: ${this.controller}:${this.action}\n`;
 

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { hilightUserCode } from './utils/stackTrace';
+import { RequestPayload } from './types/RequestPayload';
 
 /**
  * Standard Kuzzle error.
@@ -58,6 +59,12 @@ export class KuzzleError extends Error {
    * request id
    */
   public requestId?: string;
+
+  /**
+   * Document unique identifier
+   */
+  public _id?: string;
+
   /**
    * Associated errors
    * (PartialError only)
@@ -89,7 +96,7 @@ export class KuzzleError extends Error {
     >    at /home/aschen/projets/kuzzleio/sdk-javascript/test.js:8:18
           at processTicksAndRejections (internal/process/task_queues.js:97:5)
    */
-  constructor (apiError, sdkStack: string, protocol: string, request?) {
+  constructor (apiError, sdkStack: string, protocol: string, request?: RequestPayload) {
     super(apiError.message);
     this.status = apiError.status;
 
@@ -103,6 +110,7 @@ export class KuzzleError extends Error {
       this.index = request.index;
       this.volatile = request.volatile;
       this.requestId = request.requestId;
+      this._id = request._id;
     }
 
     // PartialError
@@ -120,8 +128,7 @@ export class KuzzleError extends Error {
       this.stack += '          |\n';
       this.stack += `          Status: ${this.status}\n`;
 
-      this.stack += !this.controller ? '' : `          Controller: ${this.controller}\n`;
-      this.stack += !this.action ? '' : `          Action: ${this.action}\n`;
+      this.stack += !this.controller && !this.action ? '' : `          Http: ${this.controller}:${this.action}\n`;
 
       this.stack += `          ${protocol}\n`;
       this.stack += '          |\n';

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -42,7 +42,7 @@ export class KuzzleError extends Error {
   /**
    * KuzzleRequest volatile data
    */
-  public volatile?: Object;
+  public volatile?: Record<string, unknown>;
 
   /**
    * Index name
@@ -99,7 +99,7 @@ export class KuzzleError extends Error {
     if (request) {
       this.controller = request.controller;
       this.collection = request.collection;
-      this.action  = request.action;
+      this.action = request.action;
       this.index = request.index;
       this.volatile = request.volatile;
       this.requestId = request.requestId;
@@ -118,6 +118,11 @@ export class KuzzleError extends Error {
       this.stack = apiError.stack + '\n';
       this.stack += '          |\n';
       this.stack += '          |\n';
+      this.stack += `          Status: ${this.status}\n`;
+
+      this.stack += !this.controller ? '' : `          Controller: ${this.controller}\n`;
+      this.stack += !this.action ? '' : `          Action: ${this.action}\n`;
+
       this.stack += `          ${protocol}\n`;
       this.stack += '          |\n';
       this.stack += '          |\n';

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -88,6 +88,7 @@ export class KuzzleError extends Error {
           at Funnel.processRequest (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:423:34)
               |
               |
+              Http: foo:bar
               HttpProtocol
               |
               |

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -30,6 +30,35 @@ export class KuzzleError extends Error {
   public code: number;
 
   /**
+   * API controller name
+   */
+  public controller?: string;
+
+  /**
+   * API action name
+   */
+  public action?: string;
+
+  /**
+   * KuzzleRequest volatile data
+   */
+  public volatile?: Object;
+
+  /**
+   * Index name
+   */
+  public index?: string;
+
+  /**
+   * Collection name
+   */
+  public collection?: string;
+
+  /**
+   * request id
+   */
+  public requestId?: string;
+  /**
    * Associated errors
    * (PartialError only)
    */
@@ -60,13 +89,21 @@ export class KuzzleError extends Error {
     >    at /home/aschen/projets/kuzzleio/sdk-javascript/test.js:8:18
           at processTicksAndRejections (internal/process/task_queues.js:97:5)
    */
-  constructor (apiError, sdkStack: string, protocol: string) {
+  constructor (apiError, sdkStack: string, protocol: string, request?) {
     super(apiError.message);
-
     this.status = apiError.status;
 
     this.id = apiError.id;
     this.code = apiError.code;
+  
+    if (request) {
+      this.controller = request.controller;
+      this.collection = request.collection;
+      this.action  = request.action;
+      this.index = request.index;
+      this.volatile = request.volatile;
+      this.requestId = request.requestId;
+    }
 
     // PartialError
     if (this.status === 206) {

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -126,9 +126,6 @@ export class KuzzleError extends Error {
       this.stack = apiError.stack + '\n';
       this.stack += '          |\n';
       this.stack += '          |\n';
-
-      this.stack += !this.controller && !this.action ? '' : `          Http: ${this.controller}:${this.action}\n`;
-
       this.stack += `          ${protocol}\n`;
       this.stack += '          |\n';
       this.stack += '          |\n';

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -6,6 +6,7 @@ import { KuzzleEventEmitter } from '../../core/KuzzleEventEmitter';
 import { PendingRequest } from './PendingRequest';
 import { JSONObject } from '../../types';
 import { RequestPayload } from '../../types/RequestPayload';
+import { FILE } from 'dns';
 
 export abstract class KuzzleAbstractProtocol extends KuzzleEventEmitter {
   private _pendingRequests: Map<string, PendingRequest>;
@@ -148,11 +149,11 @@ Discarded request: ${JSON.stringify(request)}`));
       this._pendingRequests.delete(request.requestId);
 
       if (response.error) {
-        let error;
+        let error: KuzzleError;
 
         // Wrap API error but directly throw errors that comes from SDK
         if (response.error.status) {
-          error = new KuzzleError(response.error, stack, this.constructor.name);
+          error = new KuzzleError(response.error, stack, this.constructor.name, request);
         }
         else {
           // Keep both stacktrace because the one we captured in "stack" will give

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -132,7 +132,7 @@ export abstract class KuzzleAbstractProtocol extends KuzzleEventEmitter {
     this.clear();
   }
 
-  query (request, options) {
+  query (request: RequestPayload, options) {
     if (!this.isReady()) {
       this.emit('discarded', request);
       return Promise.reject(new Error(`Unable to execute request: not connected to a Kuzzle server.

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -6,7 +6,6 @@ import { KuzzleEventEmitter } from '../../core/KuzzleEventEmitter';
 import { PendingRequest } from './PendingRequest';
 import { JSONObject } from '../../types';
 import { RequestPayload } from '../../types/RequestPayload';
-import { FILE } from 'dns';
 
 export abstract class KuzzleAbstractProtocol extends KuzzleEventEmitter {
   private _pendingRequests: Map<string, PendingRequest>;

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -211,26 +211,26 @@ describe('Common Protocol', () => {
         collection: 'toto',
         response: response,
       };
-      try {
-        await protocol.query(request);
-        throw new Error('error protocol query'); 
-      } catch (error) {
-        should(error).be.instanceOf(KuzzleError);
-        should(error.message).be.equal('API action "foo":"bar" not found');
-        should(error.status).be.equal(404);
-        should(error.id).be.equal('api.process.action_not_found');
-        should(error.code).be.equal(33685509);
-        should(error.kuzzleStack).be.equal('NotFoundError: API action "foo":"bar" not found');
-        should(error.controller).be.equal('foo');
-        should(error.action).be.equal('bar');
-        should(error.volatile).be.a.Object();
-        should(error.index).be.equal('test');
-        should(error.collection).be.equal('toto');
-        should(error.requestId).be.equal('foobar');
-        should(error.stack).match(/NotFoundError: API action "foo":"bar" not found/);
-        should(error.stack).match(/KuzzleAbstractProtocol/);
-        should(error.stack).match(/>\s{4}at Context.<anonymous>/);
-      } 
+
+      return protocol.query(request)
+        .then(() => Promise.reject({ message: 'No error' }))
+        .catch(error => {
+          should(error).be.instanceOf(KuzzleError);
+          should(error.message).be.equal('API action "foo":"bar" not found');
+          should(error.status).be.equal(404);
+          should(error.id).be.equal('api.process.action_not_found');
+          should(error.code).be.equal(33685509);
+          should(error.kuzzleStack).be.equal('NotFoundError: API action "foo":"bar" not found');
+          should(error.controller).be.equal('foo');
+          should(error.action).be.equal('bar');
+          should(error.volatile).be.a.Object();
+          should(error.index).be.equal('test');
+          should(error.collection).be.equal('toto');
+          should(error.requestId).be.equal('foobar');
+          should(error.stack).match(/NotFoundError: API action "foo":"bar" not found/);
+          should(error.stack).match(/KuzzleAbstractProtocol/);
+          should(error.stack).match(/>\s{4}at Context.<anonymous>/);
+        });
     });
 
     it('should keep internal errors on PartialErrors', () => {

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -211,26 +211,26 @@ describe('Common Protocol', () => {
         collection: 'toto',
         response: response,
       };
-
-      return protocol.query(request)
-        .then(() => Promise.reject({ message: 'No error' }))
-        .catch(error => {
-          should(error).be.instanceOf(KuzzleError);
-          should(error.message).be.equal('API action "foo":"bar" not found');
-          should(error.status).be.equal(404);
-          should(error.id).be.equal('api.process.action_not_found');
-          should(error.code).be.equal(33685509);
-          should(error.kuzzleStack).be.equal('NotFoundError: API action "foo":"bar" not found');
-          should(error.controller).be.equal('foo');
-          should(error.action).be.equal('bar');
-          should(error.volatile).be.a.Object();
-          should(error.index).be.equal('test');
-          should(error.collection).be.equal('toto');
-          should(error.requestId).be.equal('foobar');
-          should(error.stack).match(/NotFoundError: API action "foo":"bar" not found/);
-          should(error.stack).match(/KuzzleAbstractProtocol/);
-          should(error.stack).match(/>\s{4}at Context.<anonymous>/);
-        });
+      try {
+        await protocol.query(request);
+        throw new Error('error protocol query'); 
+      } catch (error) {
+        should(error).be.instanceOf(KuzzleError);
+        should(error.message).be.equal('API action "foo":"bar" not found');
+        should(error.status).be.equal(404);
+        should(error.id).be.equal('api.process.action_not_found');
+        should(error.code).be.equal(33685509);
+        should(error.kuzzleStack).be.equal('NotFoundError: API action "foo":"bar" not found');
+        should(error.controller).be.equal('foo');
+        should(error.action).be.equal('bar');
+        should(error.volatile).be.a.Object();
+        should(error.index).be.equal('test');
+        should(error.collection).be.equal('toto');
+        should(error.requestId).be.equal('foobar');
+        should(error.stack).match(/NotFoundError: API action "foo":"bar" not found/);
+        should(error.stack).match(/KuzzleAbstractProtocol/);
+        should(error.stack).match(/>\s{4}at Context.<anonymous>/);
+      } 
     });
 
     it('should keep internal errors on PartialErrors', () => {

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -191,7 +191,7 @@ describe('Common Protocol', () => {
         });
     });
 
-    it.only('should reject an error with more context', () => {
+    it('should reject an error with more context', () => {
       const response = {
         error: {
           status: 404,

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -230,7 +230,6 @@ describe('Common Protocol', () => {
           should(error.stack).match(/NotFoundError: API action "foo":"bar" not found/);
           should(error.stack).match(/KuzzleAbstractProtocol/);
           should(error.stack).match(/>\s{4}at Context.<anonymous>/);
-          should(error.stack).match(/Http: foo:bar/);
         });
     });
 

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -191,7 +191,7 @@ describe('Common Protocol', () => {
         });
     });
 
-    it('should reject an error with more context', () => {
+    it('should reject an error with more context', async () => {
       const response = {
         error: {
           status: 404,
@@ -207,7 +207,7 @@ describe('Common Protocol', () => {
         controller: 'foo',
         action: 'bar',
         index: 'test',
-        volatile: new Object(),
+        volatile: {},
         collection: 'toto',
         response: response,
       };
@@ -230,6 +230,8 @@ describe('Common Protocol', () => {
           should(error.stack).match(/NotFoundError: API action "foo":"bar" not found/);
           should(error.stack).match(/KuzzleAbstractProtocol/);
           should(error.stack).match(/>\s{4}at Context.<anonymous>/);
+          should(error.stack).match(/Http: foo:bar/);
+          should(error.stack).match(/Status: 404/);
         });
     });
 

--- a/test/protocol/Base.test.js
+++ b/test/protocol/Base.test.js
@@ -231,7 +231,6 @@ describe('Common Protocol', () => {
           should(error.stack).match(/KuzzleAbstractProtocol/);
           should(error.stack).match(/>\s{4}at Context.<anonymous>/);
           should(error.stack).match(/Http: foo:bar/);
-          should(error.stack).match(/Status: 404/);
         });
     });
 


### PR DESCRIPTION
⚠️ Depends on #619 

## What does this PR do ?
This PR adds more context from the Kuzzle error response to the error objects (**KuzzleError**): ```controller, action, volatile, index, collection```

New error output example:
```
 NotFoundError: API action "foo":"bar" not found
          |
          |
          Status: 404
          Controller: foo
          Action: bar
          KuzzleAbstractProtocol
          |
          |
       at KuzzleAbstractProtocol.query (/Users/clementbolin/Epitech/Kuzzle/sdk-javascript/src/protocols/abstract/Base.ts:37:6)
>    at Context.<anonymous> (/Users/clementbolin/Epitech/Kuzzle/sdk-javascript/test/protocol/Base.test.js:215:23)
       at callFn (/Users/clementbolin/Epitech/Kuzzle/sdk-javascript/node_modules/mocha/lib/runnable.js:366:21)
       at Test.Runnable.run (/Users/clementbolin/Epitech/Kuzzle/sdk-javascript/node_modules/mocha/lib/runnable.js:354:5)
       ...
```
### How should this be manually tested?
```npm run test:unit```
or
```npm run test```