### PR TITLE
Release 7.8.2: Fix multiple errors error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.8.1",
+  "version": "7.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.8.1",
+  "version": "7.8.2",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -69,7 +69,7 @@ export class KuzzleError extends Error {
     this.code = apiError.code;
 
     // PartialError
-    if (this.status === 206) {
+    if (apiError.errors) {
       this.errors = apiError.errors;
       this.count = apiError.count;
     }


### PR DESCRIPTION
## What does this PR do ?

`MultipleErrorsError` includes the detailed list of errors returned by Kuzzle in the `errors` property but it was not correctly handled by the SDK