### PR TITLE
Make document metadata optional in KDocumentContent

### DIFF
--- a/doc/7/core-classes/base-controller/introduction/index.md
+++ b/doc/7/core-classes/base-controller/introduction/index.md
@@ -8,6 +8,8 @@ order: 0
 
 # BaseController
 
-Base class for a [custom SDK controller](/sdk/js/7/essentials/extend-sdk#define-a-custom-sdk-controller).  
+<SinceBadge version="7.9.0"/>
+
+Base class for a [custom SDK controller](/sdk/js/7/essentials/extend-sdk#define-a-custom-sdk-controller).
 
 Custom SDK controllers have to extend the `BaseController` class to be added with the [Kuzzle.useController](/sdk/js/7/core-classes/kuzzle/use-controller) method.

--- a/doc/7/core-classes/base-controller/properties/index.md
+++ b/doc/7/core-classes/base-controller/properties/index.md
@@ -7,6 +7,8 @@ description: BaseController Properties
 
 # Properties
 
+<SinceBadge version="7.9.0"/>
+
 | Property name        | Type     | Description          |
 | -------------------- | -------- | --------------------------------------- |
 | `name`               | <pre>string</pre> | Controller name    |

--- a/doc/7/core-classes/base-controller/query/index.md
+++ b/doc/7/core-classes/base-controller/query/index.md
@@ -7,7 +7,9 @@ description: Wrapper around the Kuzzle.query method
 
 # query
 
-Base method used to send queries to a Kuzzle controller, following the [API Documentation](/core/2/api).  
+<SinceBadge version="7.9.0"/>
+
+Base method used to send queries to a Kuzzle controller, following the [API Documentation](/core/2/api).
 
 This method injects the controller name into the the request and forwards it to the original [Kuzzle.query](/sdk/js/7/core-classes/kuzzle/query) method.
 

--- a/doc/7/essentials/batch-processing/index.md
+++ b/doc/7/essentials/batch-processing/index.md
@@ -8,6 +8,8 @@ order: 600
 
 # Batch Processing
 
+<SinceBadge version="7.9.0"/>
+
 Most of the methods of the Document controller have a batch alternative:
  - create => mCreate
  - replace => mReplace
@@ -35,7 +37,6 @@ The BatchController can be used with [strong typing](/sdk/js/7/essentials/strong
 ```js
 const doc = await batch.get<DeviceContent>('nyc-open-data', 'yellow-taxi', 'aschen');
 ```
-
 :::
 
 

--- a/doc/7/essentials/strong-typing/index.md
+++ b/doc/7/essentials/strong-typing/index.md
@@ -12,6 +12,8 @@ The SDK exposes numerous types to help Typescript developer to maintain a safer 
 
 ## Kuzzle Document (KDocument)
 
+<SinceBadge version="7.9.0"/>
+
 The Document controller methods can be used with an explicit type that represents the content of the manipulated document.
 
 Document content must be defined by extending the `KDocumentContent` interface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/types/KDocument.ts
+++ b/src/types/KDocument.ts
@@ -29,7 +29,7 @@ export interface KDocumentKuzzleInfo {
  * Base interface for a Kuzzle document content
  */
 export interface KDocumentContent {
-  _kuzzle_info: KDocumentKuzzleInfo;
+  _kuzzle_info?: KDocumentKuzzleInfo;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do ?

Make document metadata optional in KDocumentContent so users can instantiate their own document content without having to fill the `_kuzzle_info` field.

### Other changes

 - add missing sincebadge