### PR TITLE
Add `server:capabilities` method

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,3 +31,4 @@ export * from './src/controllers/Collection';
 export * from './src/controllers/Document';
 export * from './src/controllers/Index';
 export * from './src/controllers/Realtime';
+export * from './src/controllers/Server';

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -96,7 +96,7 @@ export class Kuzzle extends KuzzleEventEmitter {
   public ms: any;
   public realtime: RealtimeController;
   public security: SecurityController;
-  public server: any;
+  public server: ServerController;
 
   private _protectedEvents: any;
   private _offlineQueue: any;

--- a/src/controllers/Server.ts
+++ b/src/controllers/Server.ts
@@ -27,6 +27,17 @@ export class ServerController extends BaseController {
       .then(response => response.result.exists);
   }
 
+  /**
+   * Returns the Kuzzle capabilities
+   * @param {Object} options - {queuable: Boolean(true)}
+   * @returns {Promise<Object>}
+   */
+  capabilities (options: ArgsServerControllerGetAllStats) {
+    return this.query({
+      action: 'capabilities'
+    }, options)
+      .then(response => response.result);
+  }
 
   /**
    * Returns all stored statistics frames

--- a/src/controllers/Server.ts
+++ b/src/controllers/Server.ts
@@ -30,6 +30,7 @@ export class ServerController extends BaseController {
   /**
    * Returns the Kuzzle capabilities
    * @param {Object} options - {queuable: Boolean(true)}
+   * @example https://docs.kuzzle.io/core/2/api/controllers/server/capabilities/#response
    * @returns {Promise<Object>}
    */
   capabilities (options: ArgsServerControllerGetAllStats) {

--- a/test/controllers/server.test.js
+++ b/test/controllers/server.test.js
@@ -135,7 +135,7 @@ describe('Server Controller', () => {
         version: '<current kuzzle version>',
       };
     
-    it('should call query with the right arguments and return Promise which resolves the capabilities', () => {
+    it('should call query with the right arguments and return Promise which resolves the capabilities', async () => {
       kuzzle.query.resolves({ result });
 
       return kuzzle.server.capabilities()
@@ -155,7 +155,7 @@ describe('Server Controller', () => {
         });
     });
 
-    it('should reject the promise if an error occurs', () => {
+    it('should reject the promise if an error occurs', async () => {
       const error = new Error('foobar error');
       error.status = 412;
       kuzzle.query.rejects(error);

--- a/test/controllers/server.test.js
+++ b/test/controllers/server.test.js
@@ -138,28 +138,31 @@ describe('Server Controller', () => {
     it('should call query with the right arguments and return Promise which resolves the capabilities', async () => {
       kuzzle.query.resolves({ result });
 
-      return kuzzle.server.capabilities()
-        .then(res => {
-          should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectQuery, {});
-          should(res).match(result);
-        })
-        .then(() => {
-          kuzzle.query.resetHistory();
-          return kuzzle.server.capabilities({queuable: false});
-        })
-        .then(res => {
-          should(kuzzle.query).be.calledOnce();
-          should(kuzzle.query).be.calledWith(expectQuery, {queuable: false});
-          should(res).match(result);
-        });
+      let res = await kuzzle.server.capabilities();
+
+      should(kuzzle.query).be.calledOnce();
+      should(kuzzle.query).be.calledWith(expectQuery, {});
+      should(res).match(result);
+
+      kuzzle.query.resetHistory();
+      res = await kuzzle.server.capabilities({queuable: false});
+
+      should(kuzzle.query).be.calledOnce();
+      should(kuzzle.query).be.calledWith(expectQuery, {queuable: false});
+      should(res).match(result);
     });
 
     it('should reject the promise if an error occurs', async () => {
       const error = new Error('foobar error');
       error.status = 412;
       kuzzle.query.rejects(error);
-      return should(kuzzle.server.capabilities()).be.rejectedWith({status: 412, message: 'foobar error'});
+
+      try {
+        await kuzzle.server.capabilities();
+      }
+      catch (err) {
+        should(err).be.match({status: 412, message: 'foobar error'});
+      }
     });
   });
 


### PR DESCRIPTION
## What does this PR do ?

add the following action `server:capabilities`

### How should this be manually tested?

with unit tests: `npm run test:unit`

or with a Kuzzle app:

```ts
import { Backend } from 'kuzzle'

const app = new Backend('app-sample')

app.start()
  .then(() => {
    app.log.info('Application started')
    app.sdk.server.capabilities()
  })
  .catch(console.error)
```

### Other changes

export Server controller
