### PR TITLE
Add `props` in KuzzleError

### DIFF
--- a/doc/7/core-classes/kuzzle-error/properties/index.md
+++ b/doc/7/core-classes/kuzzle-error/properties/index.md
@@ -9,19 +9,20 @@ order: 10
 
 # Properties
 
-| Property name | Type              | Description                                                                                          |
-|---------------|-------------------|------------------------------------------------------------------------------------------------------|
-| `kuzzleStack` | <pre>string</pre> | Kuzzle stacktrace (only in development mode)                                                         |
-| `message`     | <pre>string</pre> | Error message                                                                                        |
-| `status`      | <pre>number</pre> | Error status code                                                                                    |
-| `stack`       | <pre>string</pre> | Complete error stacktrace (Kuzzle + SDK) (only in development mode)                                  |
-| `id`          | <pre>string</pre> | Error unique identifier                                                                              |
-| `code`        | <pre>string</pre> | Error unique code                                                                                    |
-| `controller`  | <pre>string</pre> | API controller name                                                                                  |
-| `action`      | <pre>string</pre> | API action name                                                                                      |
-| `volatile`    | <pre>object</pre> | KuzzleRequest [volatile data](https://docs.kuzzle.io/core/2/guides/main-concepts/api/#volatile-data) |
-| `index`       | <pre>string</pre> | Index name                                                                                           |
-| `collection`  | <pre>string</pre> | Collection name name                                                                                 |
-| `requestId`   | <pre>string</pre> | request id name                                                                                      |
-| `_id`         | <pre>string</pre> | Document unique identifier                                                                           |
-| `count`       | <pre>number</pre> | Number of associated errors (PartialError only)                                                      |
+| Property name | Type                | Description                                                                                          |
+| ------------- | ------------------- | ---------------------------------------------------------------------------------------------------- |
+| `kuzzleStack` | <pre>string</pre>   | Kuzzle stacktrace (only in development mode)                                                         |
+| `message`     | <pre>string</pre>   | Error message                                                                                        |
+| `props`       | <pre>string[]</pre> | Placeholders used to construct the error message                                                     |
+| `status`      | <pre>number</pre>   | Error status code                                                                                    |
+| `stack`       | <pre>string</pre>   | Complete error stacktrace (Kuzzle + SDK) (only in development mode)                                  |
+| `id`          | <pre>string</pre>   | Error unique identifier                                                                              |
+| `code`        | <pre>string</pre>   | Error unique code                                                                                    |
+| `controller`  | <pre>string</pre>   | API controller name                                                                                  |
+| `action`      | <pre>string</pre>   | API action name                                                                                      |
+| `volatile`    | <pre>object</pre>   | KuzzleRequest [volatile data](https://docs.kuzzle.io/core/2/guides/main-concepts/api/#volatile-data) |
+| `index`       | <pre>string</pre>   | Index name                                                                                           |
+| `collection`  | <pre>string</pre>   | Collection name name                                                                                 |
+| `requestId`   | <pre>string</pre>   | request id name                                                                                      |
+| `_id`         | <pre>string</pre>   | Document unique identifier                                                                           |
+| `count`       | <pre>number</pre>   | Number of associated errors (PartialError only)                                                      |

--- a/src/KuzzleError.ts
+++ b/src/KuzzleError.ts
@@ -78,6 +78,11 @@ export class KuzzleError extends Error {
   public count?: number;
 
   /**
+   * Placeholders used to construct the error message
+   */
+  public props?: string[];
+
+  /**
    * This class represents a Kuzzle API error.
    * The SDK stack is needed alongside the protocol used.
    * Those information will allow to construct a enhanced stacktrace:
@@ -98,7 +103,7 @@ export class KuzzleError extends Error {
           at processTicksAndRejections (internal/process/task_queues.js:97:5)
    */
   constructor (
-    apiError: { message: string, status?: number, id?: string, code?: number, errors?: JSONObject[], count?: number, stack?: string },
+    apiError: { message: string, status?: number, id?: string, code?: number, errors?: JSONObject[], count?: number, stack?: string, props?: string[] },
     sdkStack?: string,
     protocol?: string,
     request?: RequestPayload,
@@ -108,6 +113,7 @@ export class KuzzleError extends Error {
     this.status = apiError.status;
     this.id = apiError.id;
     this.code = apiError.code;
+    this.props = apiError.props;
 
     if (request) {
       this.controller = request.controller;

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -152,7 +152,6 @@ Discarded request: ${JSON.stringify(request)}`));
       this._pendingRequests.delete(request.requestId);
 
       if (response.error) {
-        console.log(response.error)
         let error: KuzzleError;
 
         // Wrap API error but directly throw errors that comes from SDK

--- a/src/protocols/abstract/Base.ts
+++ b/src/protocols/abstract/Base.ts
@@ -152,6 +152,7 @@ Discarded request: ${JSON.stringify(request)}`));
       this._pendingRequests.delete(request.requestId);
 
       if (response.error) {
+        console.log(response.error)
         let error: KuzzleError;
 
         // Wrap API error but directly throw errors that comes from SDK


### PR DESCRIPTION
## What does this PR do ?

Kuzzle returns a `props` property with error, this property contains all the string used to build the error message.

Those string can be used by the application layer to build other error messages.

This PR expose this property