### PR TITLE
Add event at callback error in subscription

### DIFF
--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -118,13 +118,13 @@ Triggered whenever Kuzzle responds with an error
 
 ## callbackError
 
-Triggered whenever a callback on an event throw an error
+Triggered whenever the notification handler's callback returns a rejected promise
 
 **Callback arguments:**
 
 `@param {Error} error - Error details`
 
-`@param {Room} room - Room containing the callback`
+`@param {Notification} notification - Notification of the handler`
 
 ## reconnected
 

--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -116,6 +116,16 @@ Triggered whenever Kuzzle responds with an error
 
 `@param {object} request - Request that caused the error`
 
+## callbackError
+
+Triggered whenever a callback on an event throw an error
+
+**Callback arguments:**
+
+`@param {Error} error - Error details`
+
+`@param {Room} room - Room containing the callback`
+
 ## reconnected
 
 Triggered when the current session has reconnected to Kuzzle after a disconnection, and only if `autoReconnect` is set to `true`.

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -73,6 +73,7 @@ export class Kuzzle extends KuzzleEventEmitter {
    * List of every events emitted by the SDK.
    */
   public events = [
+    'callbackError',
     'connected',
     'discarded',
     'disconnected',
@@ -86,7 +87,6 @@ export class Kuzzle extends KuzzleEventEmitter {
     'reconnected',
     'reconnectionError',
     'tokenExpired',
-    'callbackError',
   ];
 
   public auth: AuthController;

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -86,6 +86,7 @@ export class Kuzzle extends KuzzleEventEmitter {
     'reconnected',
     'reconnectionError',
     'tokenExpired',
+    'callbackError',
   ];
 
   public auth: AuthController;

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -83,7 +83,7 @@ class Room {
       try {
         const callbackResponse = this.callback(data);
 
-        if (callbackResponse !== null
+        if ( callbackResponse !== null
           && typeof callbackResponse === 'object'
           && typeof callbackResponse.then === 'function'
           && typeof callbackResponse.catch === 'function'

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -80,12 +80,14 @@ class Room {
       data.volatile && data.volatile.sdkInstanceId === this.kuzzle.protocol.id;
 
     if (this.subscribeToSelf || !fromSelf) {
-      try {
-        this.callback(data);
-      }
-      catch (error) {
-        this.kuzzle.emit('callbackError', { error, room: data });
-      }
+      Promise.resolve(this.callback(data))
+        .then(
+          res => {
+            console.log("all good, ", res);
+          },
+          error => {
+            this.kuzzle.emit('callbackError', { error, notification: data })
+          });
     }
   }
 }

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -83,10 +83,8 @@ class Room {
       const result = this.callback(data);
 
       if (typeof result === 'object' && typeof result.then === 'function') {
-        result
-          .catch(error =>
-            this.kuzzle.emit('callbackError', { error, notification: data })
-          );
+        result.catch(error =>
+          this.kuzzle.emit('callbackError', { error, notification: data }));
       }
     }
   }

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -84,7 +84,7 @@ class Room {
         this.callback(data);
       }
       catch (error) {
-        this.emit('callbackError', { error, room: data });
+        this.kuzzle.emit('callbackError', { error, room: data });
       }
     }
   }

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -84,9 +84,9 @@ class Room {
 
       if (typeof result === 'object' && typeof result.then === 'function') {
         result
-          .catch(error => {
+          .catch(error =>
             this.kuzzle.emit('callbackError', { error, notification: data })
-          });
+          );
       }
     }
   }

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -80,10 +80,12 @@ class Room {
       data.volatile && data.volatile.sdkInstanceId === this.kuzzle.protocol.id;
 
     if (this.subscribeToSelf || !fromSelf) {
-      this.callback(data)
-        .catch(error => {
-          this.emit('callbackError', { error, room: data });
-        });
+      try {
+        this.callback(data);
+      }
+      catch (error) {
+        this.emit('callbackError', { error, room: data });
+      }
     }
   }
 }

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -80,14 +80,14 @@ class Room {
       data.volatile && data.volatile.sdkInstanceId === this.kuzzle.protocol.id;
 
     if (this.subscribeToSelf || !fromSelf) {
-      Promise.resolve(this.callback(data))
-        .then(
-          res => {
-            console.log("all good, ", res);
-          },
-          error => {
+      const result = this.callback(data);
+
+      if (typeof result === 'object' && typeof result.then === 'function') {
+        result
+          .catch(error => {
             this.kuzzle.emit('callbackError', { error, notification: data })
           });
+      }
     }
   }
 }

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -80,7 +80,10 @@ class Room {
       data.volatile && data.volatile.sdkInstanceId === this.kuzzle.protocol.id;
 
     if (this.subscribeToSelf || !fromSelf) {
-      this.callback(data);
+      this.callback(data)
+        .catch(error => {
+          this.emit('callbackError', { error, room: data });
+        });
     }
   }
 }

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -80,11 +80,24 @@ class Room {
       data.volatile && data.volatile.sdkInstanceId === this.kuzzle.protocol.id;
 
     if (this.subscribeToSelf || !fromSelf) {
-      const result = this.callback(data);
+      try {
+        const callbackResponse = this.callback(data);
 
-      if (typeof result === 'object' && typeof result.then === 'function') {
-        result.catch(error =>
-          this.kuzzle.emit('callbackError', { error, notification: data }));
+        if (callbackResponse !== null
+          && typeof callbackResponse === 'object'
+          && typeof callbackResponse.then === 'function'
+          && typeof callbackResponse.catch === 'function'
+        ) {
+          callbackResponse
+            .catch(error => {
+              console.log("3");
+              this.kuzzle.emit('callbackError', { error, notification: data })
+            });
+        }
+      }
+      catch (error) {
+        console.log("error");
+        this.kuzzle.emit('callbackError', { error, notification: data })
       }
     }
   }

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -90,14 +90,12 @@ class Room {
         ) {
           callbackResponse
             .catch(error => {
-              console.log("3");
-              this.kuzzle.emit('callbackError', { error, notification: data })
+              this.kuzzle.emit('callbackError', { error, notification: data });
             });
         }
       }
       catch (error) {
-        console.log("error");
-        this.kuzzle.emit('callbackError', { error, notification: data })
+        this.kuzzle.emit('callbackError', { error, notification: data });
       }
     }
   }

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -1,12 +1,12 @@
 const
-Room = require('../../src/core/Room'),
+  Room = require('../../src/core/Room'),
   { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter'),
   sinon = require('sinon'),
   should = require('should');
 
 describe('Room', () => {
   const
-  eventEmitter = new KuzzleEventEmitter(),
+    eventEmitter = new KuzzleEventEmitter(),
     options = {opt: 'in'};
 
   let controller;
@@ -33,7 +33,7 @@ describe('Room', () => {
   describe('constructor', () => {
     it('should create a Room instance with good properties', () => {
       const
-      body = {foo: 'bar'},
+        body = {foo: 'bar'},
         cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
@@ -86,14 +86,14 @@ describe('Room', () => {
 
     it('should handle autoResubscribe option', () => {
       const
-      body = {foo: 'bar'},
+        body = {foo: 'bar'},
         cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
 
       const
-      room1 = new Room(
-        controller, 'index', 'collection', body, cb, {autoResubscribe: true}),
+        room1 = new Room(
+          controller, 'index', 'collection', body, cb, {autoResubscribe: true}),
         room2 = new Room(
           controller, 'index', 'collection', body, cb,
           {autoResubscribe: false}),
@@ -108,12 +108,12 @@ describe('Room', () => {
 
     it('should handle subscribeToSelf option', () => {
       const
-      body = {foo: 'bar'},
+        body = {foo: 'bar'},
         cb = sinon.stub();
 
       const
-      room1 = new Room(
-        controller, 'index', 'collection', body, cb, {subscribeToSelf: true}),
+        room1 = new Room(
+          controller, 'index', 'collection', body, cb, {subscribeToSelf: true}),
         room2 = new Room(
           controller, 'index', 'collection', body, cb,
           {subscribeToSelf: false}),
@@ -141,13 +141,13 @@ describe('Room', () => {
 
     it('should call realtime/subscribe action with subscribe filters and return a promise that resolve the roomId and channel', () => {
       const
-      opts = {
-        opt: 'in',
-        scope: 'in',
-        state: 'done',
-        users: 'all',
-        volatile: {bar: 'foo'}
-      },
+        opts = {
+          opt: 'in',
+          scope: 'in',
+          state: 'done',
+          users: 'all',
+          volatile: {bar: 'foo'}
+        },
         body = {foo: 'bar'},
         cb = sinon.stub(),
         room = new Room(controller, 'index', 'collection', body, cb, opts);
@@ -174,13 +174,13 @@ describe('Room', () => {
 
     it('should set "id" and "channel" properties', () => {
       const
-      opts = {
-        opt: 'in',
-        scope: 'in',
-        state: 'done',
-        users: 'all',
-        volatile: {bar: 'foo'}
-      },
+        opts = {
+          opt: 'in',
+          scope: 'in',
+          state: 'done',
+          users: 'all',
+          volatile: {bar: 'foo'}
+        },
         body = {foo: 'bar'},
         cb = sinon.stub(),
         room = new Room(controller, 'index', 'collection', body, cb, opts);
@@ -194,13 +194,13 @@ describe('Room', () => {
 
     it('should call _channelListener while receiving data on the current channel', () => {
       const
-      opts = {
-        opt: 'in',
-        scope: 'in',
-        state: 'done',
-        users: 'all',
-        volatile: {bar: 'foo'}
-      },
+        opts = {
+          opt: 'in',
+          scope: 'in',
+          state: 'done',
+          users: 'all',
+          volatile: {bar: 'foo'}
+        },
         body = {foo: 'bar'},
         cb = sinon.stub(),
         room = new Room(controller, 'index', 'collection', body, cb, opts);
@@ -249,7 +249,7 @@ describe('Room', () => {
 
   describe('_channelListener', () => {
     let
-    cb,
+      cb,
       room;
 
     beforeEach(() => {
@@ -276,27 +276,6 @@ describe('Room', () => {
       should(cb)
         .be.calledOnce()
         .be.calledWith(data);
-    });
-
-    it('should emit an event on callback error', () => {
-      room.kuzzle.emit = sinon.stub();
-
-      const callbackError = new Error("callbackTestError");
-      cb.throws(callbackError);
-
-      room.subscribeToSelf = true;
-
-      const data = {foo: 'bar'};
-
-      room._channelListener(data);
-
-      should(cb)
-        .be.calledOnce()
-        .be.calledWith(data);
-
-      should(room.kuzzle.emit)
-        .be.calledOnce()
-        .be.calledWithMatch('callbackError');
     });
 
     it('should call the callback if subscribeToSelf option is FALSE and the notification message comes from another user', () => {

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -83,21 +83,19 @@ describe('Room', () => {
     });
 
     it('should handle autoResubscribe option', () => {
-      const
-      body = {foo: 'bar'},
-        cb = sinon.stub();
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
 
-      const
-      room1 = new Room(
-        controller, 'index', 'collection', body, cb, {autoResubscribe: true}),
-        room2 = new Room(
-          controller, 'index', 'collection', body, cb,
-          {autoResubscribe: false}),
-        room3 = new Room(
-          controller, 'index', 'collection', body, cb,
-          {autoResubscribe: 'foobar'});
+      const room1 = new Room(
+        controller, 'index', 'collection', body, cb, {autoResubscribe: true});
+      const room2 = new Room(
+        controller, 'index', 'collection', body, cb,
+        {autoResubscribe: false});
+      const room3 = new Room(
+        controller, 'index', 'collection', body, cb,
+        {autoResubscribe: 'foobar'});
 
       should(room1.autoResubscribe).be.a.Boolean().and.be.True();
       should(room2.autoResubscribe).be.a.Boolean().and.be.False();
@@ -105,19 +103,17 @@ describe('Room', () => {
     });
 
     it('should handle subscribeToSelf option', () => {
-      const
-      body = {foo: 'bar'},
-        cb = sinon.stub();
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
 
-      const
-      room1 = new Room(
-        controller, 'index', 'collection', body, cb, {subscribeToSelf: true}),
-        room2 = new Room(
-          controller, 'index', 'collection', body, cb,
-          {subscribeToSelf: false}),
-        room3 = new Room(
-          controller, 'index', 'collection', body, cb,
-          {subscribeToSelf: 'foobar'});
+      const room1 = new Room(
+        controller, 'index', 'collection', body, cb, {subscribeToSelf: true});
+      const room2 = new Room(
+        controller, 'index', 'collection', body, cb,
+        {subscribeToSelf: false});
+      const room3 = new Room(
+        controller, 'index', 'collection', body, cb,
+        {subscribeToSelf: 'foobar'});
 
       should(room1.subscribeToSelf).be.a.Boolean().and.be.True();
       should(room2.subscribeToSelf).be.a.Boolean().and.be.False();

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -339,7 +339,7 @@ describe('Room', () => {
 
       should(controller.kuzzle.emit)
         .be.calledOnce()
-        .be.calledWithMatch('callbackError');
+        .be.calledWithMatch('callbackError', { error: callbackError });
     });
   });
 });

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -1,7 +1,8 @@
-const Room = require('../../src/core/Room');
-const { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter');
 const sinon = require('sinon');
 const should = require('should');
+
+const Room = require('../../src/core/Room');
+const { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter');
 
 describe('Room', () => {
   const eventEmitter = new KuzzleEventEmitter();
@@ -336,7 +337,9 @@ describe('Room', () => {
         .be.calledOnce()
         .be.calledWith(data);
 
-      should(controller.kuzzle.emit).be.called();
+      should(controller.kuzzle.emit)
+        .be.calledOnce()
+        .be.calledWithMatch('callbackError');
     });
   });
 });

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -1,12 +1,12 @@
 const
-  Room = require('../../src/core/Room'),
+Room = require('../../src/core/Room'),
   { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter'),
   sinon = require('sinon'),
   should = require('should');
 
 describe('Room', () => {
   const
-    eventEmitter = new KuzzleEventEmitter(),
+  eventEmitter = new KuzzleEventEmitter(),
     options = {opt: 'in'};
 
   let controller;
@@ -33,7 +33,7 @@ describe('Room', () => {
   describe('constructor', () => {
     it('should create a Room instance with good properties', () => {
       const
-        body = {foo: 'bar'},
+      body = {foo: 'bar'},
         cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
@@ -86,14 +86,14 @@ describe('Room', () => {
 
     it('should handle autoResubscribe option', () => {
       const
-        body = {foo: 'bar'},
+      body = {foo: 'bar'},
         cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
 
       const
-        room1 = new Room(
-          controller, 'index', 'collection', body, cb, {autoResubscribe: true}),
+      room1 = new Room(
+        controller, 'index', 'collection', body, cb, {autoResubscribe: true}),
         room2 = new Room(
           controller, 'index', 'collection', body, cb,
           {autoResubscribe: false}),
@@ -108,12 +108,12 @@ describe('Room', () => {
 
     it('should handle subscribeToSelf option', () => {
       const
-        body = {foo: 'bar'},
+      body = {foo: 'bar'},
         cb = sinon.stub();
 
       const
-        room1 = new Room(
-          controller, 'index', 'collection', body, cb, {subscribeToSelf: true}),
+      room1 = new Room(
+        controller, 'index', 'collection', body, cb, {subscribeToSelf: true}),
         room2 = new Room(
           controller, 'index', 'collection', body, cb,
           {subscribeToSelf: false}),
@@ -141,13 +141,13 @@ describe('Room', () => {
 
     it('should call realtime/subscribe action with subscribe filters and return a promise that resolve the roomId and channel', () => {
       const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
+      opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      },
         body = {foo: 'bar'},
         cb = sinon.stub(),
         room = new Room(controller, 'index', 'collection', body, cb, opts);
@@ -174,13 +174,13 @@ describe('Room', () => {
 
     it('should set "id" and "channel" properties', () => {
       const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
+      opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      },
         body = {foo: 'bar'},
         cb = sinon.stub(),
         room = new Room(controller, 'index', 'collection', body, cb, opts);
@@ -194,13 +194,13 @@ describe('Room', () => {
 
     it('should call _channelListener while receiving data on the current channel', () => {
       const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
+      opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      },
         body = {foo: 'bar'},
         cb = sinon.stub(),
         room = new Room(controller, 'index', 'collection', body, cb, opts);
@@ -249,7 +249,7 @@ describe('Room', () => {
 
   describe('_channelListener', () => {
     let
-      cb,
+    cb,
       room;
 
     beforeEach(() => {
@@ -276,6 +276,27 @@ describe('Room', () => {
       should(cb)
         .be.calledOnce()
         .be.calledWith(data);
+    });
+
+    it('should emit an event on callback error', () => {
+      room.kuzzle.emit = sinon.stub();
+
+      const callbackError = new Error("callbackTestError");
+      cb.throws(callbackError);
+
+      room.subscribeToSelf = true;
+
+      const data = {foo: 'bar'};
+
+      room._channelListener(data);
+
+      should(cb)
+        .be.calledOnce()
+        .be.calledWith(data);
+
+      should(room.kuzzle.emit)
+        .be.calledOnce()
+        .be.calledWithMatch('callbackError');
     });
 
     it('should call the callback if subscribeToSelf option is FALSE and the notification message comes from another user', () => {
@@ -333,6 +354,26 @@ describe('Room', () => {
       should(cb).not.be.called();
       should(controller.kuzzle.tokenExpired).be.called();
     });
-  });
 
+    it('should emit an event on callback error', () => {
+      room.kuzzle.emit = sinon.stub();
+
+      const callbackError = new Error("callbackTestError");
+      cb.throws(callbackError);
+
+      room.subscribeToSelf = true;
+
+      const data = {foo: 'bar'};
+
+      room._channelListener(data);
+
+      should(cb)
+        .be.calledOnce()
+        .be.calledWith(data);
+
+      should(room.kuzzle.emit)
+        .be.calledOnce()
+        .be.calledWithMatch('callbackError');
+    });
+  });
 });

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -337,7 +337,7 @@ describe('Room', () => {
     it('should emit an event on callback error', () => {
       room.kuzzle.emit = sinon.stub();
 
-      const callbackError = new Error("callbackTestError");
+      const callbackError = new Error('callbackTestError');
       cb.throws(callbackError);
 
       room.subscribeToSelf = true;

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -1,13 +1,11 @@
-const
-  Room = require('../../src/core/Room'),
-  { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter'),
-  sinon = require('sinon'),
-  should = require('should');
+const Room = require('../../src/core/Room');
+const { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter');
+const sinon = require('sinon');
+const should = require('should');
 
 describe('Room', () => {
-  const
-    eventEmitter = new KuzzleEventEmitter(),
-    options = {opt: 'in'};
+  const eventEmitter = new KuzzleEventEmitter();
+  const options = {opt: 'in'};
 
   let controller;
 
@@ -22,7 +20,8 @@ describe('Room', () => {
           eventEmitter.removeListener(evt, listener);
         },
         tokenExpired: sinon.stub(),
-        protocol: new KuzzleEventEmitter()
+        protocol: new KuzzleEventEmitter(),
+        emit: sinon.stub(),
       },
       tokenExpired: sinon.stub()
     };
@@ -32,9 +31,8 @@ describe('Room', () => {
 
   describe('constructor', () => {
     it('should create a Room instance with good properties', () => {
-      const
-        body = {foo: 'bar'},
-        cb = sinon.stub();
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
 
@@ -86,14 +84,14 @@ describe('Room', () => {
 
     it('should handle autoResubscribe option', () => {
       const
-        body = {foo: 'bar'},
+      body = {foo: 'bar'},
         cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
 
       const
-        room1 = new Room(
-          controller, 'index', 'collection', body, cb, {autoResubscribe: true}),
+      room1 = new Room(
+        controller, 'index', 'collection', body, cb, {autoResubscribe: true}),
         room2 = new Room(
           controller, 'index', 'collection', body, cb,
           {autoResubscribe: false}),
@@ -108,12 +106,12 @@ describe('Room', () => {
 
     it('should handle subscribeToSelf option', () => {
       const
-        body = {foo: 'bar'},
+      body = {foo: 'bar'},
         cb = sinon.stub();
 
       const
-        room1 = new Room(
-          controller, 'index', 'collection', body, cb, {subscribeToSelf: true}),
+      room1 = new Room(
+        controller, 'index', 'collection', body, cb, {subscribeToSelf: true}),
         room2 = new Room(
           controller, 'index', 'collection', body, cb,
           {subscribeToSelf: false}),
@@ -140,17 +138,16 @@ describe('Room', () => {
     });
 
     it('should call realtime/subscribe action with subscribe filters and return a promise that resolve the roomId and channel', () => {
-      const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
-        body = {foo: 'bar'},
-        cb = sinon.stub(),
-        room = new Room(controller, 'index', 'collection', body, cb, opts);
+      const opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      };
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
+      const room = new Room(controller, 'index', 'collection', body, cb, opts);
 
       return room.subscribe()
         .then(res => {
@@ -173,17 +170,16 @@ describe('Room', () => {
     });
 
     it('should set "id" and "channel" properties', () => {
-      const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
-        body = {foo: 'bar'},
-        cb = sinon.stub(),
-        room = new Room(controller, 'index', 'collection', body, cb, opts);
+      const opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      };
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
+      const room = new Room(controller, 'index', 'collection', body, cb, opts);
 
       return room.subscribe()
         .then(() => {
@@ -193,17 +189,16 @@ describe('Room', () => {
     });
 
     it('should call _channelListener while receiving data on the current channel', () => {
-      const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
-        body = {foo: 'bar'},
-        cb = sinon.stub(),
-        room = new Room(controller, 'index', 'collection', body, cb, opts);
+      const opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      };
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
+      const room = new Room(controller, 'index', 'collection', body, cb, opts);
 
       room._channelListener = sinon.stub();
 
@@ -248,9 +243,8 @@ describe('Room', () => {
   });
 
   describe('_channelListener', () => {
-    let
-      cb,
-      room;
+    let cb;
+    let room;
 
     beforeEach(() => {
       cb = sinon.stub();
@@ -334,25 +328,19 @@ describe('Room', () => {
       should(controller.kuzzle.tokenExpired).be.called();
     });
 
-    it('should emit an event on callback error', () => {
-      room.kuzzle.emit = sinon.stub();
-
-      const callbackError = new Error('callbackTestError');
-      cb.throws(callbackError);
-
-      room.subscribeToSelf = true;
-
+    it('should emit an event on callback promise rejection', async () => {
       const data = {foo: 'bar'};
+      const callbackError = new Error('callbackPromiseRejection');
 
-      room._channelListener(data);
+      cb.rejects(callbackError);
+
+      await room._channelListener(data);
 
       should(cb)
         .be.calledOnce()
         .be.calledWith(data);
 
-      should(room.kuzzle.emit)
-        .be.calledOnce()
-        .be.calledWithMatch('callbackError');
+      should(controller.kuzzle.emit).be.called();
     });
   });
 });

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -21,6 +21,7 @@ describe('Kuzzle listeners management', () => {
 
   it('should only listen to allowed events', () => {
     const knownEvents = [
+      'callbackError',
       'connected',
       'discarded',
       'disconnected',
@@ -34,7 +35,6 @@ describe('Kuzzle listeners management', () => {
       'reconnected',
       'reconnectionError',
       'tokenExpired',
-      'callbackError',
     ];
 
     should(function() {

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -34,6 +34,7 @@ describe('Kuzzle listeners management', () => {
       'reconnected',
       'reconnectionError',
       'tokenExpired',
+      'callbackError',
     ];
 
     should(function() {


### PR DESCRIPTION
#682 

## What does this PR do ?

Add event at callback error in subscription.

An new event type has been created.

## How to test

Considering `index1:collection1` exist, this code:

```js
const {
  Kuzzle,
  WebSocket,
} = require('kuzzle-sdk');

const kuzzle = new Kuzzle(
  new WebSocket('localhost')
);

kuzzle.on('networkError', error => {
  console.error('Network Error:', error);
});

const run = async () => {
  try {
    await kuzzle.connect();

    console.log('--- Subscribe to event');
    kuzzle.on(
      'callbackError',
      (error) => console.log(
        `Error message "${error.error.message}" on "${error.room.index}:${error.room.collection}"`)
    );

    const cb = () => {throw new Error("I am a callback and I threw an error")};
    const fieldA = 'callbackErrorTest';
    const filter = {
      equals: {
        fieldA
      }
    };

    console.log('--- Subscribe with callback');
    await kuzzle.realtime.subscribe('index1', 'collection1', filter, cb);

    const newDocument = { fieldA };
    await kuzzle.document.create('index1', 'collection1', newDocument);

  } finally {
    kuzzle.disconnect();
  }
};

run();
```

Should log:

```js
--- Subscribe to event
--- Subscribe with callback
Error message "I am a callback and I threw an error" on "index1:collection1"
```