### PR TITLE
Add query typing

### DIFF
--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -116,6 +116,16 @@ Triggered whenever Kuzzle responds with an error
 
 `@param {object} request - Request that caused the error`
 
+## callbackError
+
+Triggered whenever the notification handler's callback returns a rejected promise
+
+**Callback arguments:**
+
+`@param {Error} error - Error details`
+
+`@param {Notification} notification - Notification of the handler`
+
 ## reconnected
 
 Triggered when the current session has reconnected to Kuzzle after a disconnection, and only if `autoReconnect` is set to `true`.

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -15,7 +15,7 @@ import { Deprecation } from './utils/Deprecation';
 import { uuidv4 } from './utils/uuidv4';
 import { proxify } from './utils/proxify';
 import { debug } from './utils/debug';
-import { JSONObject } from './types';
+import { BaseRequest, JSONObject } from './types';
 import { RequestPayload } from './types/RequestPayload';
 import { ResponsePayload } from './types/ResponsePayload';
 import { RequestTimeoutError } from './RequestTimeoutError';
@@ -766,7 +766,10 @@ export class Kuzzle extends KuzzleEventEmitter {
    * @param req
    * @param opts - Optional arguments
    */
-  query (req: RequestPayload = {}, opts: JSONObject = {}): Promise<ResponsePayload> {
+  query<TRequest extends BaseRequest, TResult> (
+    req: TRequest,
+    opts: JSONObject = {},
+  ): Promise<ResponsePayload<TResult>> {
     if (typeof req !== 'object' || Array.isArray(req)) {
       throw new Error(`Kuzzle.query: Invalid request: ${JSON.stringify(req)}`);
     }
@@ -857,7 +860,7 @@ Discarded request: ${JSON.stringify(request)}`));
       requestTimeout,
       request,
       options
-    ).then((response: ResponsePayload) => {
+    ).then((response: ResponsePayload<TResult>) => {
       debug('RESPONSE', response);
 
       return this.deprecationHandler.logDeprecation(response);

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -73,6 +73,7 @@ export class Kuzzle extends KuzzleEventEmitter {
    * List of every events emitted by the SDK.
    */
   public events = [
+    'callbackError',
     'connected',
     'discarded',
     'disconnected',

--- a/src/controllers/Base.ts
+++ b/src/controllers/Base.ts
@@ -1,6 +1,5 @@
 import { Kuzzle } from '../Kuzzle';
 import { JSONObject } from '../types';
-import { RequestPayload } from '../types/RequestPayload';
 
 export class BaseController {
   private _name: string;
@@ -36,7 +35,7 @@ export class BaseController {
    * @param request
    * @param options
   */
-  query (request: RequestPayload = {}, options: any = {}): Promise<JSONObject> {
+  query (request: any, options: any = {}): Promise<JSONObject> {
     request.controller = request.controller || this.name;
 
     return this._kuzzle.query(request, options);

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -80,7 +80,23 @@ class Room {
       data.volatile && data.volatile.sdkInstanceId === this.kuzzle.protocol.id;
 
     if (this.subscribeToSelf || !fromSelf) {
-      this.callback(data);
+      try {
+        const callbackResponse = this.callback(data);
+
+        if ( callbackResponse !== null
+          && typeof callbackResponse === 'object'
+          && typeof callbackResponse.then === 'function'
+          && typeof callbackResponse.catch === 'function'
+        ) {
+          callbackResponse
+            .catch(error => {
+              this.kuzzle.emit('callbackError', { error, notification: data });
+            });
+        }
+      }
+      catch (error) {
+        this.kuzzle.emit('callbackError', { error, notification: data });
+      }
     }
   }
 }

--- a/src/core/searchResult/SearchResultBase.ts
+++ b/src/core/searchResult/SearchResultBase.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from '../../types';
+import { BaseRequest, JSONObject } from '../../types';
 import { RequestPayload } from '../../types/RequestPayload';
 import { Kuzzle } from '../../Kuzzle';
 
@@ -60,7 +60,7 @@ export class SearchResultBase<T> implements SearchResult<T> {
 
   constructor (
     kuzzle: Kuzzle,
-    request: RequestPayload = {},
+    request: BaseRequest,
     options: JSONObject = {},
     result: any = {}
   ) {

--- a/src/types/BaseRequest.ts
+++ b/src/types/BaseRequest.ts
@@ -1,0 +1,9 @@
+import { JSONObject } from './JSONObject';
+
+export interface BaseRequest {
+  controller: string;
+
+  action: string;
+
+  body?: JSONObject;
+}

--- a/src/types/RequestPayload.ts
+++ b/src/types/RequestPayload.ts
@@ -5,16 +5,16 @@ import { JSONObject } from './JSONObject';
  *
  * @see https://docs.kuzzle.io/core/2/api/payloads/request
  */
-export type RequestPayload = {
+export interface RequestPayload {
   /**
    * API controller name
    */
-  controller?: string;
+  controller: string;
 
   /**
    * API action name
    */
-  action?: string;
+  action: string;
 
   /**
    * Index name

--- a/src/types/ResponsePayload.ts
+++ b/src/types/ResponsePayload.ts
@@ -5,7 +5,7 @@ import { JSONObject } from './JSONObject';
  *
  * @see https://docs.kuzzle.io/core/2/api/payloads/response
  */
-export type ResponsePayload = {
+export interface ResponsePayload<TResult extends JSONObject = JSONObject> {
   /**
    * API controller name
    */
@@ -86,7 +86,7 @@ export type ResponsePayload = {
   /**
    * API action result
    */
-  result: any;
+  result: TResult;
 
   /**
    * HTTP status code

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,3 +23,5 @@ export * from './mResponses';
 export * from './KDocument';
 
 export * from './RequestPayload';
+
+export * from './BaseRequest';

--- a/test/core/room.test.js
+++ b/test/core/room.test.js
@@ -1,13 +1,12 @@
-const
-  Room = require('../../src/core/Room'),
-  { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter'),
-  sinon = require('sinon'),
-  should = require('should');
+const sinon = require('sinon');
+const should = require('should');
+
+const Room = require('../../src/core/Room');
+const { KuzzleEventEmitter } = require('../../src/core/KuzzleEventEmitter');
 
 describe('Room', () => {
-  const
-    eventEmitter = new KuzzleEventEmitter(),
-    options = {opt: 'in'};
+  const eventEmitter = new KuzzleEventEmitter();
+  const options = {opt: 'in'};
 
   let controller;
 
@@ -22,7 +21,8 @@ describe('Room', () => {
           eventEmitter.removeListener(evt, listener);
         },
         tokenExpired: sinon.stub(),
-        protocol: new KuzzleEventEmitter()
+        protocol: new KuzzleEventEmitter(),
+        emit: sinon.stub(),
       },
       tokenExpired: sinon.stub()
     };
@@ -32,9 +32,8 @@ describe('Room', () => {
 
   describe('constructor', () => {
     it('should create a Room instance with good properties', () => {
-      const
-        body = {foo: 'bar'},
-        cb = sinon.stub();
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
 
@@ -85,21 +84,19 @@ describe('Room', () => {
     });
 
     it('should handle autoResubscribe option', () => {
-      const
-        body = {foo: 'bar'},
-        cb = sinon.stub();
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
 
       controller.kuzzle.autoResubscribe = 'default';
 
-      const
-        room1 = new Room(
-          controller, 'index', 'collection', body, cb, {autoResubscribe: true}),
-        room2 = new Room(
-          controller, 'index', 'collection', body, cb,
-          {autoResubscribe: false}),
-        room3 = new Room(
-          controller, 'index', 'collection', body, cb,
-          {autoResubscribe: 'foobar'});
+      const room1 = new Room(
+        controller, 'index', 'collection', body, cb, {autoResubscribe: true});
+      const room2 = new Room(
+        controller, 'index', 'collection', body, cb,
+        {autoResubscribe: false});
+      const room3 = new Room(
+        controller, 'index', 'collection', body, cb,
+        {autoResubscribe: 'foobar'});
 
       should(room1.autoResubscribe).be.a.Boolean().and.be.True();
       should(room2.autoResubscribe).be.a.Boolean().and.be.False();
@@ -107,19 +104,17 @@ describe('Room', () => {
     });
 
     it('should handle subscribeToSelf option', () => {
-      const
-        body = {foo: 'bar'},
-        cb = sinon.stub();
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
 
-      const
-        room1 = new Room(
-          controller, 'index', 'collection', body, cb, {subscribeToSelf: true}),
-        room2 = new Room(
-          controller, 'index', 'collection', body, cb,
-          {subscribeToSelf: false}),
-        room3 = new Room(
-          controller, 'index', 'collection', body, cb,
-          {subscribeToSelf: 'foobar'});
+      const room1 = new Room(
+        controller, 'index', 'collection', body, cb, {subscribeToSelf: true});
+      const room2 = new Room(
+        controller, 'index', 'collection', body, cb,
+        {subscribeToSelf: false});
+      const room3 = new Room(
+        controller, 'index', 'collection', body, cb,
+        {subscribeToSelf: 'foobar'});
 
       should(room1.subscribeToSelf).be.a.Boolean().and.be.True();
       should(room2.subscribeToSelf).be.a.Boolean().and.be.False();
@@ -140,17 +135,16 @@ describe('Room', () => {
     });
 
     it('should call realtime/subscribe action with subscribe filters and return a promise that resolve the roomId and channel', () => {
-      const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
-        body = {foo: 'bar'},
-        cb = sinon.stub(),
-        room = new Room(controller, 'index', 'collection', body, cb, opts);
+      const opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      };
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
+      const room = new Room(controller, 'index', 'collection', body, cb, opts);
 
       return room.subscribe()
         .then(res => {
@@ -173,17 +167,16 @@ describe('Room', () => {
     });
 
     it('should set "id" and "channel" properties', () => {
-      const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
-        body = {foo: 'bar'},
-        cb = sinon.stub(),
-        room = new Room(controller, 'index', 'collection', body, cb, opts);
+      const opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      };
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
+      const room = new Room(controller, 'index', 'collection', body, cb, opts);
 
       return room.subscribe()
         .then(() => {
@@ -193,17 +186,16 @@ describe('Room', () => {
     });
 
     it('should call _channelListener while receiving data on the current channel', () => {
-      const
-        opts = {
-          opt: 'in',
-          scope: 'in',
-          state: 'done',
-          users: 'all',
-          volatile: {bar: 'foo'}
-        },
-        body = {foo: 'bar'},
-        cb = sinon.stub(),
-        room = new Room(controller, 'index', 'collection', body, cb, opts);
+      const opts = {
+        opt: 'in',
+        scope: 'in',
+        state: 'done',
+        users: 'all',
+        volatile: {bar: 'foo'}
+      };
+      const body = {foo: 'bar'};
+      const cb = sinon.stub();
+      const room = new Room(controller, 'index', 'collection', body, cb, opts);
 
       room._channelListener = sinon.stub();
 
@@ -248,9 +240,8 @@ describe('Room', () => {
   });
 
   describe('_channelListener', () => {
-    let
-      cb,
-      room;
+    let cb;
+    let room;
 
     beforeEach(() => {
       cb = sinon.stub();
@@ -333,6 +324,22 @@ describe('Room', () => {
       should(cb).not.be.called();
       should(controller.kuzzle.tokenExpired).be.called();
     });
-  });
 
+    it('should emit an event on callback promise rejection', async () => {
+      const data = {foo: 'bar'};
+      const callbackError = new Error('callbackPromiseRejection');
+
+      cb.rejects(callbackError);
+
+      await room._channelListener(data);
+
+      should(cb)
+        .be.calledOnce()
+        .be.calledWith(data);
+
+      should(controller.kuzzle.emit)
+        .be.calledOnce()
+        .be.calledWithMatch('callbackError', { error: callbackError });
+    });
+  });
 });

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -21,6 +21,7 @@ describe('Kuzzle listeners management', () => {
 
   it('should only listen to allowed events', () => {
     const knownEvents = [
+      'callbackError',
       'connected',
       'discarded',
       'disconnected',


### PR DESCRIPTION
## What does this PR do ?

Implements https://github.com/kuzzleio/sdk-javascript/issues/706

A new `BaseRequest` interface can be extended to define the request type.

```js
export interface NotificationSmsRequest extends BaseRequest {
  controller: 'notification',
  action: 'sms',
  engineId: string;
  body: {
    smsContent: string;
  }
};

interface NotificationSmsResult {
    smsCount: number;
}

const { result } = await sdk.query<NotificationSmsRequest, NotificationSmsResult>({
  controller: 'notification',
  action: 'sms',
  engineId: 'tenant-worksite-kuzzle',
  body: {
    smsContent: 'Hello, world',
  }
});

result.smsCount; // number
```