### PR TITLE
Fix bug where calling next on search with a from always return the same results

### DIFF
--- a/src/core/searchResult/SearchResultBase.ts
+++ b/src/core/searchResult/SearchResultBase.ts
@@ -164,13 +164,11 @@ export class SearchResultBase<T> implements SearchResult<T> {
       }
 
       return this._kuzzle
-        .query(
-          {
-            ...this._request,
-            action: this._searchAction,
-            from: this.fetched,
-          },
-        )
+        .query({
+          ...this._request,
+          action: this._searchAction,
+          from: this.fetched,
+        })
         .then(({ result }) => this._buildNextSearchResult(result));
     }
 

--- a/src/core/searchResult/SearchResultBase.ts
+++ b/src/core/searchResult/SearchResultBase.ts
@@ -170,7 +170,6 @@ export class SearchResultBase<T> implements SearchResult<T> {
             action: this._searchAction,
             from: this.fetched,
           },
-          this._options
         )
         .then(({ result }) => this._buildNextSearchResult(result));
     }

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -83,11 +83,12 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
       this.retrying = true;
 
       if (
+        window !== null &&
         typeof window === "object" &&
-        typeof window.navigator === "object" &&
-        window.navigator.onLine === false
+        typeof window!.navigator === "object" &&
+        window!.navigator.onLine === false
       ) {
-        window.addEventListener(
+        window!.addEventListener(
           "online",
           () => {
             this.retrying = false;

--- a/test/core/searchResult/document.test.js
+++ b/test/core/searchResult/document.test.js
@@ -332,17 +332,15 @@ describe("DocumentSearchResult", () => {
         return searchResult.next().then((nextSearchResult) => {
           should(kuzzle.query)
             .be.calledOnce()
-            .be.calledWith(
-              {
-                index: "index",
-                collection: "collection",
-                body: { query: { foo: "bar" } },
-                controller: "document",
-                action: "search",
-                size: 2,
-                from: 2,
-              },
-            );
+            .be.calledWith({
+              index: "index",
+              collection: "collection",
+              body: { query: { foo: "bar" } },
+              controller: "document",
+              action: "search",
+              size: 2,
+              from: 2,
+            });
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(DocumentSearchResult);
         });

--- a/test/core/searchResult/document.test.js
+++ b/test/core/searchResult/document.test.js
@@ -342,7 +342,6 @@ describe("DocumentSearchResult", () => {
                 size: 2,
                 from: 2,
               },
-              options
             );
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(DocumentSearchResult);

--- a/test/core/searchResult/profile.test.js
+++ b/test/core/searchResult/profile.test.js
@@ -359,8 +359,7 @@ describe("ProfileSearchResult", () => {
                 action: "searchProfiles",
                 size: 2,
                 from: 2,
-              },
-              options
+              }
             );
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(ProfileSearchResult);

--- a/test/core/searchResult/profile.test.js
+++ b/test/core/searchResult/profile.test.js
@@ -352,15 +352,13 @@ describe("ProfileSearchResult", () => {
         return searchResult.next().then((nextSearchResult) => {
           should(kuzzle.query)
             .be.calledOnce()
-            .be.calledWith(
-              {
-                body: { query: { foo: "bar" } },
-                controller: "security",
-                action: "searchProfiles",
-                size: 2,
-                from: 2,
-              }
-            );
+            .be.calledWith({
+              body: { query: { foo: "bar" } },
+              controller: "security",
+              action: "searchProfiles",
+              size: 2,
+              from: 2,
+            });
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(ProfileSearchResult);
         });

--- a/test/core/searchResult/role.test.js
+++ b/test/core/searchResult/role.test.js
@@ -167,8 +167,7 @@ describe("RoleSearchResult", () => {
                 action: "searchRoles",
                 size: 2,
                 from: 2,
-              },
-              options
+              }
             );
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(RoleSearchResult);

--- a/test/core/searchResult/role.test.js
+++ b/test/core/searchResult/role.test.js
@@ -160,15 +160,13 @@ describe("RoleSearchResult", () => {
         return searchResult.next().then((nextSearchResult) => {
           should(kuzzle.query)
             .be.calledOnce()
-            .be.calledWith(
-              {
-                body: { foo: "bar" },
-                controller: "security",
-                action: "searchRoles",
-                size: 2,
-                from: 2,
-              }
-            );
+            .be.calledWith({
+              body: { foo: "bar" },
+              controller: "security",
+              action: "searchRoles",
+              size: 2,
+              from: 2,
+            });
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(RoleSearchResult);
         });

--- a/test/core/searchResult/specifications.test.js
+++ b/test/core/searchResult/specifications.test.js
@@ -338,8 +338,7 @@ describe("SpecificationsSearchResult", () => {
                 action: "searchSpecifications",
                 size: 2,
                 from: 2,
-              },
-              options
+              }
             );
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(SpecificationsSearchResult);

--- a/test/core/searchResult/specifications.test.js
+++ b/test/core/searchResult/specifications.test.js
@@ -331,15 +331,13 @@ describe("SpecificationsSearchResult", () => {
         return searchResult.next().then((nextSearchResult) => {
           should(kuzzle.query)
             .be.calledOnce()
-            .be.calledWith(
-              {
-                body: { query: { foo: "bar" } },
-                controller: "collection",
-                action: "searchSpecifications",
-                size: 2,
-                from: 2,
-              }
-            );
+            .be.calledWith({
+              body: { query: { foo: "bar" } },
+              controller: "collection",
+              action: "searchSpecifications",
+              size: 2,
+              from: 2,
+            });
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(SpecificationsSearchResult);
         });

--- a/test/core/searchResult/user.test.js
+++ b/test/core/searchResult/user.test.js
@@ -399,8 +399,7 @@ describe("UserSearchResult", () => {
                 action: "searchUsers",
                 size: 2,
                 from: 2,
-              },
-              options
+              }
             );
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(UserSearchResult);

--- a/test/core/searchResult/user.test.js
+++ b/test/core/searchResult/user.test.js
@@ -392,15 +392,13 @@ describe("UserSearchResult", () => {
         return searchResult.next().then((nextSearchResult) => {
           should(kuzzle.query)
             .be.calledOnce()
-            .be.calledWith(
-              {
-                body: { query: { foo: "bar" } },
-                controller: "security",
-                action: "searchUsers",
-                size: 2,
-                from: 2,
-              }
-            );
+            .be.calledWith({
+              body: { query: { foo: "bar" } },
+              controller: "security",
+              action: "searchUsers",
+              size: 2,
+              from: 2,
+            });
           should(nextSearchResult).not.be.equal(searchResult);
           should(nextSearchResult).be.instanceOf(UserSearchResult);
         });


### PR DESCRIPTION
## What does this PR do ?

Fix bug where calling next on search with a from always return the same results

Prior to this change the SDK was always returning the same result each time the `next()` was called because the search was overriding the incremented `from` property with the given `from` property in the options causing each call to `next` to do a search from the begining
```js
const KuzzleSDK = require('kuzzle-sdk');

const kuzzle = new KuzzleSDK.Kuzzle(
  new KuzzleSDK.WebSocket(kuzzleHost),
);

(async () => {
  await kuzzle.connect();

  let results = await kuzzle.document.search('test','test',{},{from: 1, size:1}); 
    
  while (results) {
    console.log('res', results.hits.map(r=>r._id))
    results = await results.next();
  }
})();
```