### PR TITLE
Allow to call custom GET HTTP method with index and collection args

### DIFF
--- a/src/protocols/Http.ts
+++ b/src/protocols/Http.ts
@@ -277,7 +277,10 @@ export default class HttpProtocol extends KuzzleAbstractProtocol {
       } else if (key === "index" || key === "collection") {
         // If we're calling a non-native route that answer to a GET request
         // we need to add the index and collection (if provided) to the query string
-        if (!staticHttpRoutes[request.controller][request.action] && method === "GET") {
+        if (
+          !staticHttpRoutes[request.controller][request.action] &&
+          method === "GET"
+        ) {
           queryArgs[key] = value;
         } else {
           payload[key] = value;

--- a/src/protocols/Http.ts
+++ b/src/protocols/Http.ts
@@ -274,6 +274,14 @@ export default class HttpProtocol extends KuzzleAbstractProtocol {
         payload.headers.authorization = "Bearer " + value;
       } else if (key === "volatile") {
         payload.headers["x-kuzzle-volatile"] = JSON.stringify(value);
+      } else if (key === "index" || key === "collection") {
+        // If we're calling a non-native route that answer to a GET request
+        // we need to add the index and collection (if provided) to the query string
+        if (!staticHttpRoutes[request.controller][request.action] && method === "GET") {
+          queryArgs[key] = value;
+        } else {
+          payload[key] = value;
+        }
       } else if (Object.prototype.hasOwnProperty.call(payload, key)) {
         payload[key] = value;
       } else if (value !== undefined && value !== null) {

--- a/src/protocols/Http.ts
+++ b/src/protocols/Http.ts
@@ -277,10 +277,7 @@ export default class HttpProtocol extends KuzzleAbstractProtocol {
       } else if (key === "index" || key === "collection") {
         // If we're calling a non-native route that answer to a GET request
         // we need to add the index and collection (if provided) to the query string
-        if (
-          !staticHttpRoutes[request.controller] &&
-          method === "GET"
-        ) {
+        if (!staticHttpRoutes[request.controller] && method === "GET") {
           queryArgs[key] = value;
         } else {
           payload[key] = value;

--- a/src/protocols/Http.ts
+++ b/src/protocols/Http.ts
@@ -278,7 +278,7 @@ export default class HttpProtocol extends KuzzleAbstractProtocol {
         // If we're calling a non-native route that answer to a GET request
         // we need to add the index and collection (if provided) to the query string
         if (
-          !staticHttpRoutes[request.controller][request.action] &&
+          !staticHttpRoutes[request.controller] &&
           method === "GET"
         ) {
           queryArgs[key] = value;

--- a/test/protocol/Http.test.js
+++ b/test/protocol/Http.test.js
@@ -284,8 +284,8 @@ describe("HTTP networking module", () => {
     it("should send an HTTP request to the backend", (done) => {
       const data = {
         requestId: "requestId",
-        controller: "index",
-        action: "create",
+        controller: "foo",
+        action: "bar",
         index: "index",
         collection: "collection",
         meta: "meta",
@@ -298,14 +298,14 @@ describe("HTTP networking module", () => {
 
           should(protocol._sendHttpRequest.firstCall).be.calledWithMatch({
             method: "VERB",
-            path: "/index/_create",
+            path: "/foo/bar",
             payload: {
               requestId: "requestId",
               headers: {
                 "Content-Type": "application/json",
               },
-              controller: "index",
-              action: "create",
+              controller: "foo",
+              action: "bar",
               index: "index",
               collection: "collection",
               meta: "meta",
@@ -325,9 +325,8 @@ describe("HTTP networking module", () => {
     it("should inject JWT header to the HTTP request", (done) => {
       const data = {
         requestId: "requestId",
-        controller: "index",
-        action: "create",
-        index: "index",
+        controller: "foo",
+        action: "bar",
         jwt: "fake-jwt",
       };
 
@@ -337,15 +336,14 @@ describe("HTTP networking module", () => {
             .be.calledOnce()
             .and.be.calledWithMatch({
               method: "VERB",
-              path: "/index/_create",
+              path: "/foo/bar",
               payload: {
                 requestId: "requestId",
                 headers: {
                   authorization: "Bearer fake-jwt",
                 },
-                controller: "index",
-                action: "create",
-                index: "index",
+                controller: "foo",
+                action: "bar",
               },
             });
 

--- a/test/protocol/Http.test.js
+++ b/test/protocol/Http.test.js
@@ -284,8 +284,8 @@ describe("HTTP networking module", () => {
     it("should send an HTTP request to the backend", (done) => {
       const data = {
         requestId: "requestId",
-        controller: "foo",
-        action: "bar",
+        controller: "index",
+        action: "create",
         index: "index",
         collection: "collection",
         meta: "meta",
@@ -298,14 +298,14 @@ describe("HTTP networking module", () => {
 
           should(protocol._sendHttpRequest.firstCall).be.calledWithMatch({
             method: "VERB",
-            path: "/foo/bar",
+            path: "/index/_create",
             payload: {
               requestId: "requestId",
               headers: {
                 "Content-Type": "application/json",
               },
-              controller: "foo",
-              action: "bar",
+              controller: "index",
+              action: "create",
               index: "index",
               collection: "collection",
               meta: "meta",
@@ -325,8 +325,9 @@ describe("HTTP networking module", () => {
     it("should inject JWT header to the HTTP request", (done) => {
       const data = {
         requestId: "requestId",
-        controller: "foo",
-        action: "bar",
+        controller: "index",
+        action: "create",
+        index: "index",
         jwt: "fake-jwt",
       };
 
@@ -336,14 +337,15 @@ describe("HTTP networking module", () => {
             .be.calledOnce()
             .and.be.calledWithMatch({
               method: "VERB",
-              path: "/foo/bar",
+              path: "/index/_create",
               payload: {
                 requestId: "requestId",
                 headers: {
                   authorization: "Bearer fake-jwt",
                 },
-                controller: "foo",
-                action: "bar",
+                controller: "index",
+                action: "create",
+                index: "index",
               },
             });
 
@@ -633,6 +635,33 @@ describe("HTTP networking module", () => {
       protocol.on("requestId", (error) => {
         should(protocol._sendHttpRequest).not.be.called();
         should(error.status).be.eql(400);
+
+        done();
+      });
+
+      protocol.send(data);
+    });
+
+    it("should add index and collection to the query args if they are defined when using a custom GET route", (done) => {
+      const data = {
+        requestId: "requestId",
+        controller: "foo",
+        action: "bar",
+        index: "index",
+        collection: "collection",
+      };
+
+      protocol._routes = {
+        foo: { bar: { verb: "GET", url: "/foo/bar" } },
+      };
+
+      protocol.on("requestId", () => {
+        should(protocol._sendHttpRequest)
+          .be.calledOnce()
+          .and.be.calledWithMatch({
+            method: "GET",
+            path: "/foo/bar?index=index&collection=collection",
+          });
 
         done();
       });


### PR DESCRIPTION
# Why?
Intend to fix #713 by adding a edge case handling in the request [payload forging loop](https://github.com/kuzzleio/sdk-javascript/blob/6aaf6e1630187a885191fd57123b7b25d946fb40/src/protocols/Http.ts#L264-L283) that allow user to call a custom HTTP GET route that expects to receive queries named index and/or collection.