### PR TITLE
Allow to use `refresh: false` with `document:upsert|deleteByQuery`

### DIFF
--- a/src/controllers/Document.ts
+++ b/src/controllers/Document.ts
@@ -840,7 +840,7 @@ export interface ArgsDocumentControllerDelete extends ArgsDefault {
 }
 
 export interface ArgsDocumentControllerDeleteByQuery extends ArgsDefault {
-  refresh?: string;
+  refresh?: "wait_for" | "false";
   silent?: boolean;
   lang?: string;
 }
@@ -933,7 +933,7 @@ export interface ArgsDocumentControllerUpdateByQuery extends ArgsDefault {
 export interface ArgsDocumentControllerUpsert<TKDocumentContent>
   extends ArgsDefault {
   default?: Partial<TKDocumentContent>;
-  refresh?: string;
+  refresh?: "wait_for" | "false";
   silent?: boolean;
   retryOnConflict?: boolean;
   source?: boolean;


### PR DESCRIPTION
# Why?
As mentioned in #700 , the `refresh` option type was not well defined in this section. This as been fixed by @Aschen in the past month but when checking the code before closing the issue, I noticed there were still two action of the `document` controller that still have a wrongly defined type for this field. In order to close #700, this PR aim to update these