### PR TITLE
Fix error with React Native

### DIFF
--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -3,19 +3,33 @@ let NODE_DEBUG;
 /* eslint no-undef: 0 */
 
 function shouldDebug() {
-  if (typeof window === "undefined") {
-    // Avoid multiple calls to process.env
-    if (!NODE_DEBUG) {
-      NODE_DEBUG = (process.env.DEBUG || "").includes("kuzzle-sdk");
+  /**
+   * Some framework like react-native or other might emulate the window object
+   * but when on plateforms like iOS / Android, the window.location is undefined.
+   *
+   * So we need to check if window.location is defined before using it otherwise
+   * we will get an error.
+   *
+   * If something went wrong, be sure to return false to avoid any error.
+   */
+  try {
+    if (typeof window === "undefined") {
+      // Avoid multiple calls to process.env
+      if (!NODE_DEBUG) {
+        NODE_DEBUG = (process.env.DEBUG || "").includes("kuzzle-sdk");
+      }
+
+      return NODE_DEBUG;
     }
 
-    return NODE_DEBUG;
+    return (
+      window.debugKuzzleSdk ||
+      (window.location &&
+        new URL(window.location).searchParams.get("debugKuzzleSdk") !== null)
+    );
+  } catch (e) {
+    return false;
   }
-
-  return (
-    window.debugKuzzleSdk ||
-    new URL(window.location).searchParams.get("debugKuzzleSdk") !== null
-  );
 }
 
 /**


### PR DESCRIPTION
## What does this PR do ?

Fixes an edge case happening with react-native.

Frameworks like react-native sometimes emulate the `window` object when running outside of the browser,
this causes an edge case where the `window` object exists but `window.location` doesn't since there is no pages in an iOS / Android application for example.
This caused our debug utility to call `new URL` on an undefined value throwing an error, 
This was preventing the usage of the SDK with react-native like in the issue #703.

