### PR TITLE
Add a safer check to know if we are inside of a browser

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,9 @@
+import { isBrowser } from 'src/utils/browser';
+
 // defined by webpack plugin
 declare var BUILT: any;
 
-if (typeof window !== 'undefined' && typeof BUILT === 'undefined') {
+if (isBrowser() && typeof BUILT === 'undefined') {
   throw new Error('It looks like you are using the Nodejs version of Kuzzle SDK ' +
                'in a browser. ' +
                'It is strongly recommended to use the browser-specific build instead. ' +

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { isBrowser } from 'src/utils/browser';
+import { isBrowser } from './src/utils/browser';
 
 // defined by webpack plugin
 declare var BUILT: any;

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -2,6 +2,7 @@
 
 import { KuzzleAbstractProtocol } from "./Base";
 import * as DisconnectionOrigin from "../DisconnectionOrigin";
+import { getBrowserWindow, isBrowser } from "src/utils/browser";
 
 export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
   protected _reconnectionDelay: number;
@@ -83,12 +84,11 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
       this.retrying = true;
 
       if (
-        window !== null &&
-        typeof window === "object" &&
-        typeof window!.navigator === "object" &&
-        window!.navigator.onLine === false
+        isBrowser() &&
+        typeof getBrowserWindow()!.navigator === "object" &&
+        getBrowserWindow()!.navigator.onLine === false
       ) {
-        window!.addEventListener(
+        getBrowserWindow()!.addEventListener(
           "online",
           () => {
             this.retrying = false;

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -2,7 +2,7 @@
 
 import { KuzzleAbstractProtocol } from "./Base";
 import * as DisconnectionOrigin from "../DisconnectionOrigin";
-import { getBrowserWindow, isBrowser } from "src/utils/browser";
+import { getBrowserWindow, isBrowser } from "../../utils/browser";
 
 export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
   protected _reconnectionDelay: number;

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -83,12 +83,13 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
     if (this.autoReconnect && !this.retrying && !this.stopRetryingToConnect) {
       this.retrying = true;
 
+      const window = getBrowserWindow();
       if (
         isBrowser() &&
-        typeof getBrowserWindow()!.navigator === "object" &&
-        getBrowserWindow()!.navigator.onLine === false
+        typeof window.navigator === "object" &&
+        window.navigator.onLine === false
       ) {
-        getBrowserWindow()!.addEventListener(
+        window.addEventListener(
           "online",
           () => {
             this.retrying = false;

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,32 +1,32 @@
-let windowObject: Window | undefined;
-
-let cachedWindowObject = false;
-
 export function getBrowserWindow(): Window | undefined {
-  if (cachedWindowObject) {
-    return windowObject;
-  }
+  let windowObject: Window | undefined;
 
   try {
     windowObject ||= globalThis.window;
+    if (windowObject) {
+      return windowObject;
+    }
   } catch {
-    // do nothing
+    // Check next variable
   }
 
   try {
     windowObject ||= global.window;
+    if (windowObject) {
+      return windowObject;
+    }
   } catch {
-    // do nothing
+    // Check next variable
   }
 
   try {
     windowObject ||= window;
+    if (windowObject) {
+      return windowObject;
+    }
   } catch {
-    // do nothing
+    // return undefined
   }
-
-  cachedWindowObject = true;
-  return windowObject;
 }
 
 export function isBrowser(): boolean {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,0 +1,30 @@
+export function getBrowserWindow() {
+  let windowObject;
+  
+  try {
+    windowObject ||= globalThis.window;
+  } catch {
+    // do nothing
+  }
+
+  try {
+    windowObject ||= global.window;
+  } catch {
+    // do nothing
+  }
+
+  try {
+    windowObject ||= window;
+  } catch {
+    // do nothing
+  }
+
+  return windowObject;
+}
+
+export function isBrowser() {
+  const window = getBrowserWindow()
+
+  return window !== undefined
+  && typeof window === 'object';
+}

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,6 +1,12 @@
-export function getBrowserWindow() {
-  let windowObject;
-  
+let windowObject: Window | undefined;
+
+let cachedWindowObject = false;
+
+export function getBrowserWindow(): Window | undefined {
+  if (cachedWindowObject) {
+    return windowObject;
+  }
+
   try {
     windowObject ||= globalThis.window;
   } catch {
@@ -19,10 +25,11 @@ export function getBrowserWindow() {
     // do nothing
   }
 
+  cachedWindowObject = true;
   return windowObject;
 }
 
-export function isBrowser() {
+export function isBrowser(): boolean {
   const window = getBrowserWindow()
 
   return window !== undefined

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -30,8 +30,7 @@ export function getBrowserWindow(): Window | undefined {
 }
 
 export function isBrowser(): boolean {
-  const window = getBrowserWindow()
+  const window = getBrowserWindow();
 
-  return window !== undefined
-  && typeof window === 'object';
+  return window !== undefined && window !== null && typeof window === "object";
 }

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -52,7 +52,7 @@ function debug(message, obj) {
 
   if (obj) {
     // Browser console can print directly objects
-    const toPrint = isBrowser() ? JSON.stringify(obj) : obj;
+    const toPrint = !isBrowser() ? JSON.stringify(obj) : obj;
 
     // eslint-disable-next-line no-console
     console.log(toPrint);

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -1,5 +1,7 @@
 let NODE_DEBUG;
 
+const { isBrowser, getBrowserWindow } = require("./browser");
+
 /* eslint no-undef: 0 */
 
 function shouldDebug() {
@@ -13,7 +15,7 @@ function shouldDebug() {
    * If something went wrong, be sure to return false to avoid any error.
    */
   try {
-    if (typeof window === "undefined") {
+    if (!isBrowser()) {
       // Avoid multiple calls to process.env
       if (!NODE_DEBUG) {
         NODE_DEBUG = (process.env.DEBUG || "").includes("kuzzle-sdk");
@@ -21,7 +23,8 @@ function shouldDebug() {
 
       return NODE_DEBUG;
     }
-
+    
+    const window = getBrowserWindow();
     return (
       window.debugKuzzleSdk ||
       (window.location &&
@@ -49,7 +52,7 @@ function debug(message, obj) {
 
   if (obj) {
     // Browser console can print directly objects
-    const toPrint = typeof window === "undefined" ? JSON.stringify(obj) : obj;
+    const toPrint = isBrowser() ? JSON.stringify(obj) : obj;
 
     // eslint-disable-next-line no-console
     console.log(toPrint);

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -23,7 +23,7 @@ function shouldDebug() {
 
       return NODE_DEBUG;
     }
-    
+
     const window = getBrowserWindow();
     return (
       window.debugKuzzleSdk ||

--- a/test/mocks/window.mock.js
+++ b/test/mocks/window.mock.js
@@ -1,12 +1,13 @@
 const sinon = require("sinon"),
   { KuzzleEventEmitter } = require("../../src/core/KuzzleEventEmitter");
+const { getBrowserWindow } = require("../../src/utils/browser");
 
 // A class to mock the global window object
 class WindowMock extends KuzzleEventEmitter {
   constructor() {
     super();
 
-    if (typeof window !== "undefined") {
+    if (typeof getBrowserWindow() !== "undefined") {
       throw new Error(
         'Cannot mock add a global "window" object: already defined'
       );
@@ -21,11 +22,11 @@ class WindowMock extends KuzzleEventEmitter {
   }
 
   static restore() {
-    delete global.window;
+    delete getBrowserWindow().window;
   }
 
   static inject() {
-    Object.defineProperty(global, "window", {
+    Object.defineProperty(getBrowserWindow(), "window", {
       value: new this(),
       enumerable: false,
       writable: false,

--- a/test/mocks/window.mock.js
+++ b/test/mocks/window.mock.js
@@ -22,11 +22,11 @@ class WindowMock extends KuzzleEventEmitter {
   }
 
   static restore() {
-    delete getBrowserWindow().window;
+    delete global.window;
   }
 
   static inject() {
-    Object.defineProperty(getBrowserWindow(), "window", {
+    Object.defineProperty(global, "window", {
       value: new this(),
       enumerable: false,
       writable: false,

--- a/test/mocks/window.mock.js
+++ b/test/mocks/window.mock.js
@@ -1,13 +1,12 @@
 const sinon = require("sinon"),
   { KuzzleEventEmitter } = require("../../src/core/KuzzleEventEmitter");
-const { getBrowserWindow } = require("../../src/utils/browser");
 
 // A class to mock the global window object
 class WindowMock extends KuzzleEventEmitter {
   constructor() {
     super();
 
-    if (typeof getBrowserWindow() !== "undefined") {
+    if (typeof window !== "undefined") {
       throw new Error(
         'Cannot mock add a global "window" object: already defined'
       );


### PR DESCRIPTION
## What does this PR do ?

Add an helper that adds safer methods to obtain the `window` scope and to check if we are running inside of a browser.