### PR TITLE
Allows to specify only request type in query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.10.5",
+  "version": "7.10.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-sdk",
-      "version": "7.10.5",
+      "version": "7.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "min-req-promise": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.10.5",
+  "version": "7.10.6",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -780,7 +780,7 @@ export class Kuzzle extends KuzzleEventEmitter {
    * @param req
    * @param opts - Optional arguments
    */
-  query<TRequest extends BaseRequest, TResult>(
+  query<TRequest extends BaseRequest = BaseRequest, TResult = JSONObject>(
     req: TRequest,
     opts: JSONObject = {}
   ): Promise<ResponsePayload<TResult>> {


### PR DESCRIPTION
## What does this PR do ?

Allows to specify only the request type without the result
```
await sdk.query<ApiDeviceLinkAssetRequest>({ ... });
```
