### PR TITLE
Improve typings

### DIFF
--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -1,4 +1,4 @@
-import { KuzzleEventEmitter } from "./core/KuzzleEventEmitter";
+import { KuzzleEventEmitter, KuzzleSDKEvents } from "./core/KuzzleEventEmitter";
 import { KuzzleAbstractProtocol } from "./protocols/abstract/Base";
 
 import { AuthController } from "./controllers/Auth";
@@ -542,7 +542,7 @@ export class Kuzzle extends KuzzleEventEmitter {
    * Emit an event to all registered listeners
    * An event cannot be emitted multiple times before a timeout has been reached.
    */
-  emit(eventName: string, ...payload) {
+  emit(eventName: KuzzleSDKEvents, ...payload: unknown[]) {
     const now = Date.now(),
       protectedEvent = this._protectedEvents[eventName];
 

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -1,4 +1,8 @@
-import { KuzzleEventEmitter, KuzzleSDKEvents } from "./core/KuzzleEventEmitter";
+import {
+  KuzzleEventEmitter,
+  PrivateAndPublicSDKEvents,
+  PublicKuzzleEvents,
+} from "./core/KuzzleEventEmitter";
 import { KuzzleAbstractProtocol } from "./protocols/abstract/Base";
 
 import { AuthController } from "./controllers/Auth";
@@ -15,11 +19,13 @@ import { Deprecation } from "./utils/Deprecation";
 import { uuidv4 } from "./utils/uuidv4";
 import { proxify } from "./utils/proxify";
 import { debug } from "./utils/debug";
-import { BaseRequest, JSONObject } from "./types";
+import { BaseRequest, JSONObject, Notification } from "./types";
 import { RequestPayload } from "./types/RequestPayload";
 import { ResponsePayload } from "./types/ResponsePayload";
 import { RequestTimeoutError } from "./RequestTimeoutError";
 import { BaseProtocolRealtime } from "./protocols/abstract/Realtime";
+import { KuzzleError } from "./KuzzleError";
+import { DisconnectionOrigin } from "./protocols/DisconnectionOrigin";
 
 // Defined by webpack plugin
 declare const SDKVERSION: any;
@@ -72,7 +78,7 @@ export class Kuzzle extends KuzzleEventEmitter {
   /**
    * List of every events emitted by the SDK.
    */
-  public events = [
+  public events: PublicKuzzleEvents[] = [
     "callbackError",
     "connected",
     "discarded",
@@ -542,7 +548,7 @@ export class Kuzzle extends KuzzleEventEmitter {
    * Emit an event to all registered listeners
    * An event cannot be emitted multiple times before a timeout has been reached.
    */
-  emit(eventName: KuzzleSDKEvents, ...payload: unknown[]) {
+  public emit(eventName: PrivateAndPublicSDKEvents, ...payload: unknown[]) {
     const now = Date.now(),
       protectedEvent = this._protectedEvents[eventName];
 
@@ -561,6 +567,48 @@ export class Kuzzle extends KuzzleEventEmitter {
 
   private _superEmit(eventName, ...payload) {
     return super.emit(eventName, ...payload);
+  }
+
+  on(
+    eventName: "connected" | "reconnected" | "reAuthenticated" | "tokenExpired",
+    listener: () => void
+  ): this;
+
+  on(
+    eventName: "logoutAttempt",
+    listener: (status: { success: true }) => void
+  ): this;
+  on(
+    eventName: "loginAttempt",
+    listener: (data: { success: boolean; error: string }) => void
+  ): this;
+  on(eventName: "discarded", listener: (request: RequestPayload) => void): this;
+  on(
+    eventName: "disconnected",
+    listener: (context: { origin: DisconnectionOrigin }) => void
+  ): this;
+  on(
+    eventName: "networkError" | "reconnectionError",
+    listener: (error: Error) => void
+  ): this;
+  on(
+    eventName: "offlineQueuePop",
+    listener: (request: RequestPayload) => void
+  ): this;
+  on(
+    eventName: "offlineQueuePush",
+    listener: (data: { request: RequestPayload }) => void
+  ): this;
+  on(
+    eventName: "queryError",
+    listener: (data: { error: KuzzleError; request: RequestPayload }) => void
+  ): this;
+  on(
+    eventName: "callbackError",
+    listener: (data: { error: KuzzleError; notification: Notification }) => void
+  ): this;
+  on(eventName: PublicKuzzleEvents, listener: (args: any) => void): this {
+    return super.on(eventName, listener);
   }
 
   /**

--- a/src/protocols/DisconnectionOrigin.ts
+++ b/src/protocols/DisconnectionOrigin.ts
@@ -1,5 +1,5 @@
-const WEBSOCKET_AUTH_RENEWAL = "websocket/auth-renewal";
-const USER_CONNECTION_CLOSED = "user/connection-closed";
-const NETWORK_ERROR = "network/error";
-
-export { WEBSOCKET_AUTH_RENEWAL, USER_CONNECTION_CLOSED, NETWORK_ERROR };
+export enum DisconnectionOrigin {
+  WEBSOCKET_AUTH_RENEWAL = "websocket/auth-renewal",
+  USER_CONNECTION_CLOSED = "user/connection-closed",
+  NETWORK_ERROR = "network/error",
+}

--- a/src/protocols/WebSocket.ts
+++ b/src/protocols/WebSocket.ts
@@ -5,7 +5,7 @@ import { BaseProtocolRealtime } from "./abstract/Realtime";
 import { JSONObject } from "../types";
 import { RequestPayload } from "../types/RequestPayload";
 import HttpProtocol from "./Http";
-import * as DisconnectionOrigin from "./DisconnectionOrigin";
+import { DisconnectionOrigin } from "./DisconnectionOrigin";
 
 /**
  * WebSocket protocol used to connect to a Kuzzle server.
@@ -285,7 +285,7 @@ export default class WebSocketProtocol extends BaseProtocolRealtime {
   /**
    * @override
    */
-  clientDisconnected(origin: string) {
+  clientDisconnected(origin: DisconnectionOrigin) {
     clearInterval(this.pingIntervalId);
     this.pingIntervalId = null;
     super.clientDisconnected(origin);

--- a/src/protocols/abstract/Realtime.ts
+++ b/src/protocols/abstract/Realtime.ts
@@ -1,8 +1,9 @@
 "use strict";
 
 import { KuzzleAbstractProtocol } from "./Base";
-import * as DisconnectionOrigin from "../DisconnectionOrigin";
 import { getBrowserWindow, isBrowser } from "../../utils/browser";
+import { DisconnectionOrigin } from "../DisconnectionOrigin";
+import { KuzzleError } from "../../KuzzleError";
 
 export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
   protected _reconnectionDelay: number;
@@ -56,7 +57,7 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
    *
    * @param {string} origin String that describe what is causing the disconnection
    */
-  clientDisconnected(origin: string) {
+  clientDisconnected(origin: DisconnectionOrigin) {
     this.clear();
     this.emit("disconnect", { origin });
   }
@@ -64,9 +65,9 @@ export abstract class BaseProtocolRealtime extends KuzzleAbstractProtocol {
   /**
    * Called when the client's connection is closed with an error state
    *
-   * @param {Error} error
+   * @param {KuzzleError} error
    */
-  clientNetworkError(error) {
+  clientNetworkError(error: KuzzleError) {
     // Only emit disconnect once, if the connection was ready before
     if (this.isReady()) {
       this.emit("disconnect", { origin: DisconnectionOrigin.NETWORK_ERROR });

--- a/src/types/JSONObject.ts
+++ b/src/types/JSONObject.ts
@@ -1,6 +1,4 @@
 /**
  * An interface representing an object with string key and any value
  */
-export interface JSONObject {
-  [key: string]: JSONObject | any;
-}
+export type JSONObject = Record<PropertyKey, any>;

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -6,18 +6,12 @@ import { KDocument, KDocumentContentGeneric } from ".";
  */
 export type NotificationType = "document" | "user" | "TokenExpired";
 
-/**
- * Real-time notifications sent by Kuzzle.
- *
- */
-export interface Notification {
+export interface BaseNotification {
   /**
    * Notification type
    */
   type: NotificationType;
-}
 
-export interface BaseNotification extends Notification {
   /**
    * Controller that triggered the notification
    */
@@ -62,11 +56,13 @@ export interface BaseNotification extends Notification {
  * Notification triggered by a document change.
  * (create, update, delete)
  */
-export interface DocumentNotification extends BaseNotification {
+export interface DocumentNotification<
+  DocContent extends KDocumentContentGeneric = KDocumentContentGeneric
+> extends BaseNotification {
   /**
    * Updated document that triggered the notification
    */
-  result: KDocument<KDocumentContentGeneric>;
+  result: KDocument<DocContent>;
   /**
    * State of the document regarding the scope (`in` or `out`)
    */
@@ -105,3 +101,11 @@ export interface ServerNotification extends BaseNotification {
 
   type: "TokenExpired";
 }
+
+/**
+ * Real-time notifications sent by Kuzzle.
+ */
+export type Notification =
+  | DocumentNotification
+  | UserNotification
+  | ServerNotification;

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -57,12 +57,12 @@ export interface BaseNotification {
  * (create, update, delete)
  */
 export interface DocumentNotification<
-  DocContent extends KDocumentContentGeneric = KDocumentContentGeneric
+  TDocContent extends KDocumentContentGeneric = KDocumentContentGeneric
 > extends BaseNotification {
   /**
    * Updated document that triggered the notification
    */
-  result: KDocument<DocContent>;
+  result: KDocument<TDocContent>;
   /**
    * State of the document regarding the scope (`in` or `out`)
    */

--- a/test/kuzzle-sdk-test.ts
+++ b/test/kuzzle-sdk-test.ts
@@ -1,0 +1,48 @@
+/**
+ * This file only purpose is to check that type remains compliant with the spec for user usage.
+ * This is not meant to be executed. It is only a compilation check along the test battery.
+ *
+ * If you see red warning, it's likely that you broke the code somewhere and introduced a breaking change.
+ *
+ * TODO: This can be safely removed when test will be migrated to TypeScript.
+ *
+ * Inspired by TS standard from DefinitelyTyped
+ * @see https://github.com/DefinitelyTyped/DefinitelyTyped#my-package-teststs
+ */
+import { Kuzzle } from "../src/Kuzzle";
+import WebSocket from "../src/protocols/WebSocket";
+const kuzzle = new Kuzzle(new WebSocket("toto"));
+
+// Events
+kuzzle.on("connected", () => {});
+kuzzle.on("callbackError", ({ error, notification }) => {});
+kuzzle.on(
+  "discarded",
+  ({
+    action,
+    controller,
+    _id,
+    body,
+    collection,
+    index,
+    jwt,
+    requestId,
+    volatile,
+  }) => {}
+);
+kuzzle.on("disconnect", ({ origin }) => {});
+kuzzle.on("loginAttempt", ({ success, error }) => {});
+
+// Methods
+kuzzle.connect().then(() => {});
+kuzzle.disconnect();
+kuzzle.isAuthenticated().then(() => {});
+kuzzle.query({ controller: "auth", action: "login" }).then(() => {});
+
+kuzzle.authenticator = () => Promise.resolve();
+kuzzle.authenticator().then(() => {});
+kuzzle.authenticate().then(() => {});
+kuzzle
+  .login("local", { username: "ScreamZ", password: "some_password" })
+  .then(() => {});
+kuzzle.logout().then(() => {});

--- a/test/kuzzle-sdk-test.ts
+++ b/test/kuzzle-sdk-test.ts
@@ -5,6 +5,7 @@
  * If you see red warning, it's likely that you broke the code somewhere and introduced a breaking change.
  *
  * TODO: This can be safely removed when test will be migrated to TypeScript.
+ * TODO: Due to how the stack actually build and test, this file is not part of the CI, check it on your own before pushing.
  *
  * Inspired by TS standard from DefinitelyTyped
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped#my-package-teststs

--- a/test/kuzzle-sdk-test.ts
+++ b/test/kuzzle-sdk-test.ts
@@ -30,7 +30,7 @@ kuzzle.on(
     volatile,
   }) => {}
 );
-kuzzle.on("disconnect", ({ origin }) => {});
+kuzzle.on("disconnected", ({ origin }) => {});
 kuzzle.on("loginAttempt", ({ success, error }) => {});
 
 // Methods

--- a/test/protocol/WebSocket.test.js
+++ b/test/protocol/WebSocket.test.js
@@ -6,7 +6,8 @@ const NodeWS = require("ws");
 const { default: WS } = require("../../src/protocols/WebSocket");
 const windowMock = require("../mocks/window.mock");
 const { default: HttpProtocol } = require("../../src/protocols/Http");
-const DisconnectionOrigin = require("../../src/protocols/DisconnectionOrigin");
+const DisconnectionOrigin =
+  require("../../src/protocols/DisconnectionOrigin").DisconnectionOrigin;
 
 describe("WebSocket networking module", () => {
   let clock, websocket, wsargs, clientStub;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "esModuleInterop": true
   },
   "rootDir": "src/",
-  "include": ["index.ts", "src/**/*.ts", "test/kuzzle-sdk-test.ts"],
+  "include": ["index.ts", "src/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,6 @@
     "esModuleInterop": true
   },
   "rootDir": "src/",
-  "include": [
-    "index.ts",
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["index.ts", "src/**/*.ts", "test/kuzzle-sdk-test.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Hi[^contact],
[^contact]: You can contact me on Discord if you have any questions and expect a quick answer. I'm already listed as a Contributor on it 😅.

Working on a new project with Kuzzle, I'm fixing some code to improve user experience.


**ℹ️ Note:** I'll keep updating this PR whenever I add new types (probably some in the following weeks).

# ⏩ Initial changes
## Notification type improvement

Improved the Notification type for real-time notification in order to work with type inference.

<details>
  <summary>Read details</summary>

### Before
```ts
kuzzle.realtime.subscribe("index", "messages", {}, (notification) => {
  // Only notification.type available
  if (notification.type === "document") {
    // notification still has no more properties…
  }
});
```
Before `notification` only contains the `type` property which is good because at this step we don't know the kind of notification. To continue further we need to type guard-safe this property in order to get further autocompletion.

To assert that we can make a custom guard or we can just let typescript deduct coherence with something like `notification.type === "document"`

In the previous version due to typing, this was not possible.

### After

Now TS is able to check the type correctly and infer that the notification is a `DocumentNotification` type.

```ts
kuzzle.realtime.subscribe("index", "messages", {}, (notification) => {
  // Only notification.type available
  if (notification.type === "document") {
    // notification is now inferred as a `DocumentNotification` and as access to every props of this type.
  }
});
```

</details>

## JSONObject Type
Typescript has a native type to deal with JSONObject `Record`. Also I could only recommend to check at [this](https://github.com/sindresorhus/type-fest/blob/main/source/basic.d.ts) and more generally about `type-fest` where Sindresorhus the author is a well-known and serious contributor over the internet. Why Not included `type-fest` directly as a deps ?

## Events for KuzzleEventEmitter
This adds a proper overload for KuzzleEventEmitter.
@Aschen I'm just not sure about `RequestPayload` type, because the doc at [this URL](https://docs.kuzzle.io/sdk/js/7/essentials/events) was not really explicit.

# ⏩ 28/02/23 Update

## Added coherence type checking test
`test/kuzzle-sdk-test.ts` is a file waiting for the test battery to be rewritten maybe someday in TypeScript.[^DefinitelyTyped]
[^DefinitelyTyped]: This is based on the same concept as described [here](https://github.com/DefinitelyTyped/DefinitelyTyped#my-package-teststs)

## First pass on typing `KuzzleEventEmitter.emit` and other internal first functions
I've been forced to update accordingly `emit` function with `unknown` in order to let `tsc` pass. Someday could be nice to add strong typing on emit too in order to avoid breaking the `on` API.