### PR TITLE
Add support and documentation to use API keys

### DIFF
--- a/doc/7/controllers/auth/create-api-key/snippets/create-api-key.js
+++ b/doc/7/controllers/auth/create-api-key/snippets/create-api-key.js
@@ -18,6 +18,9 @@ try {
   */
 
   console.log('API key successfully created');
+
+  // Then use it with your client. Note: You don't need to call login after this because this bypasses the authentication system.
+  kuzzle.setAPIKey(apiKey._source.token)
 } catch (e) {
   console.error(e);
 }

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -620,6 +620,19 @@ export class Kuzzle extends KuzzleEventEmitter {
     return this.protocol.connect();
   }
 
+  /**
+   * Set this client to use a specific API key.
+   *
+   * After doing this you don't need to use login as it bypasses the authentication process.
+   */
+  public setAPIKey(apiKey: string) {
+    if (apiKey.match(/^kapikey-/) === null) {
+      throw new Error("Invalid API key. Missing the `kapikey-` prefix.");
+    }
+
+    this.jwt = apiKey;
+  }
+
   async _reconnect() {
     if (this._reconnectInProgress) {
       return;


### PR DESCRIPTION
Simplify the API by adding a helper function to set the JWT only with kuzzle API key format.

ping @Aschen 

### Why `setApiKey` and not `setToken` ?

It looks like it's only used by API Token and this way this has more domain correlation between both. Users shouldn't have to set the JWT on their own generally. This is abstraction of the SDK