### PR TITLE
Add index and collection fields to KHit

### DIFF
--- a/src/types/KDocument.ts
+++ b/src/types/KDocument.ts
@@ -70,11 +70,13 @@ export interface KHit<TKDocumentContent extends KDocumentContent>
 
   /**
    * Document index
+   * Present only in the case of a multi search
    */
-  index: string;
+  index?: string;
 
   /**
    * Document collection
+   * Present only in the case of a multi search
    */
-  collection: string;
+  collection?: string;
 }

--- a/src/types/KDocument.ts
+++ b/src/types/KDocument.ts
@@ -67,4 +67,14 @@ export interface KHit<TKDocumentContent extends KDocumentContent>
    * Elasticsearch relevance score
    */
   _score: number;
+
+  /**
+   * Document index
+   */
+  index: string;
+
+  /**
+   * Document collection
+   */
+  collection: string;
 }


### PR DESCRIPTION
## What does this PR do ?
It adds `index` and `collection` to `KHit<>`.
Those fields are necessary for the multi-search results.