### PR TITLE
Reapply current JWT before executing offlineQueue requests

### DIFF
--- a/.ci/doc/config.yml
+++ b/.ci/doc/config.yml
@@ -1,5 +1,4 @@
 ---
-
 snippets:
   mount: /mnt
   path: doc/**/snippets/*.test.yml
@@ -24,7 +23,7 @@ runners:
     path: /var/snippets/web
     lint:
       global: true
-      cmd: eslint -c /mnt/.ci/doc/eslint.json {{ snippet.dir }}/*.html
+      cmd: eslint -c /mnt/.ci/doc/eslint.json --parser-options ecmaVersion:12 {{ snippet.dir }}/*.html
       before: timeout 600 bash -c 'until stat /tmp/runner_ready_to_lint; do sleep 1; done'
     run:
       cmd: node puppeteer.js {{ snippet.dir }}/{{ snippet.source }}

--- a/.ci/doc/docker-compose.yml
+++ b/.ci/doc/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - CONFIG_FILE=/mnt/.ci/doc/config.yml
 
   doc-runner-node:
-    image: node:12-alpine
+    image: node:18-alpine
     command: >
       ash -c '
         mkdir -p /var/snippets/node;

--- a/.ci/doc/eslint.json
+++ b/.ci/doc/eslint.json
@@ -1,43 +1,98 @@
 {
   "parserOptions": {
-    "ecmaVersion": 9,
+    "ecmaVersion": 12,
     "ecmaFeatures": {
       "jsx": true
     },
     "sourceType": "module"
   },
-
   "env": {
     "es6": true,
     "node": true,
     "browser": true
   },
-
-  "plugins": ["import", "node", "promise", "standard", "html"],
-
+  "plugins": [
+    "import",
+    "node",
+    "promise",
+    "standard",
+    "html"
+  ],
   "globals": {
     "document": false,
     "navigator": false,
     "window": false,
     "KuzzleSDK": true
   },
-
   "rules": {
     "accessor-pairs": "error",
-    "arrow-spacing": ["error", { "before": true, "after": true }],
-    "block-spacing": ["error", "always"],
-    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
-    "camelcase": ["error", { "properties": "never" }],
-    "comma-spacing": ["error", { "before": false, "after": true }],
-    "comma-style": ["error", "last"],
+    "arrow-spacing": [
+      "error",
+      {
+        "before": true,
+        "after": true
+      }
+    ],
+    "block-spacing": [
+      "error",
+      "always"
+    ],
+    "brace-style": [
+      "error",
+      "1tbs",
+      {
+        "allowSingleLine": true
+      }
+    ],
+    "camelcase": [
+      "error",
+      {
+        "properties": "never"
+      }
+    ],
+    "comma-spacing": [
+      "error",
+      {
+        "before": false,
+        "after": true
+      }
+    ],
+    "comma-style": [
+      "error",
+      "last"
+    ],
     "constructor-super": "error",
-    "curly": ["error", "multi-line"],
-    "dot-location": ["error", "property"],
+    "curly": [
+      "error",
+      "multi-line"
+    ],
+    "dot-location": [
+      "error",
+      "property"
+    ],
     "eol-last": "error",
-    "eqeqeq": ["error", "always", { "null": "ignore" }],
-    "func-call-spacing": ["error", "never"],
-    "generator-star-spacing": ["error", { "before": true, "after": true }],
-    "handle-callback-err": ["error", "^(err|error)$"],
+    "eqeqeq": [
+      "error",
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "func-call-spacing": [
+      "error",
+      "never"
+    ],
+    "generator-star-spacing": [
+      "error",
+      {
+        "before": true,
+        "after": true
+      }
+    ],
+    "handle-callback-err": [
+      "error",
+      "^(err|error)$"
+    ],
     "indent": [
       "error",
       2,
@@ -46,9 +101,17 @@
         "VariableDeclarator": 1,
         "outerIIFEBody": 1,
         "MemberExpression": 1,
-        "FunctionDeclaration": { "parameters": 1, "body": 1 },
-        "FunctionExpression": { "parameters": 1, "body": 1 },
-        "CallExpression": { "arguments": 1 },
+        "FunctionDeclaration": {
+          "parameters": 1,
+          "body": 1
+        },
+        "FunctionExpression": {
+          "parameters": 1,
+          "body": 1
+        },
+        "CallExpression": {
+          "arguments": 1
+        },
         "ArrayExpression": 1,
         "ObjectExpression": 1,
         "ImportDeclaration": 1,
@@ -56,9 +119,27 @@
         "ignoreComments": false
       }
     ],
-    "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
-    "keyword-spacing": ["error", { "before": true, "after": true }],
-    "new-cap": ["error", { "newIsCap": true, "capIsNew": false }],
+    "key-spacing": [
+      "error",
+      {
+        "beforeColon": false,
+        "afterColon": true
+      }
+    ],
+    "keyword-spacing": [
+      "error",
+      {
+        "before": true,
+        "after": true
+      }
+    ],
+    "new-cap": [
+      "error",
+      {
+        "newIsCap": true,
+        "capIsNew": false
+      }
+    ],
     "new-parens": "error",
     "no-array-constructor": "error",
     "no-caller": "error",
@@ -66,7 +147,12 @@
     "no-compare-neg-zero": "error",
     "no-cond-assign": "error",
     "no-const-assign": "error",
-    "no-constant-condition": ["error", { "checkLoops": false }],
+    "no-constant-condition": [
+      "error",
+      {
+        "checkLoops": false
+      }
+    ],
     "no-control-regex": "error",
     "no-debugger": "error",
     "no-delete-var": "error",
@@ -81,26 +167,53 @@
     "no-extend-native": "error",
     "no-extra-bind": "error",
     "no-extra-boolean-cast": "error",
-    "no-extra-parens": ["error", "functions"],
+    "no-extra-parens": [
+      "error",
+      "functions"
+    ],
     "no-fallthrough": "error",
     "no-floating-decimal": "error",
     "no-func-assign": "error",
     "no-global-assign": "error",
     "no-implied-eval": "error",
-    "no-inner-declarations": ["error", "functions"],
+    "no-inner-declarations": [
+      "error",
+      "functions"
+    ],
     "no-invalid-regexp": "error",
     "no-irregular-whitespace": "error",
     "no-iterator": "error",
     "no-label-var": "error",
-    "no-labels": ["error", { "allowLoop": false, "allowSwitch": false }],
+    "no-labels": [
+      "error",
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
     "no-lone-blocks": "error",
     "no-mixed-operators": [
       "error",
       {
         "groups": [
-          ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
-          ["&&", "||"],
-          ["in", "instanceof"]
+          [
+            "==",
+            "!=",
+            "===",
+            "!==",
+            ">",
+            ">=",
+            "<",
+            "<="
+          ],
+          [
+            "&&",
+            "||"
+          ],
+          [
+            "in",
+            "instanceof"
+          ]
         ],
         "allowSamePrecedence": true
       }
@@ -108,7 +221,13 @@
     "no-mixed-spaces-and-tabs": "error",
     "no-multi-spaces": "error",
     "no-multi-str": "error",
-    "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0 }],
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1,
+        "maxEOF": 0
+      }
+    ],
     "no-negated-in-lhs": "error",
     "no-new": "error",
     "no-new-func": "error",
@@ -123,7 +242,10 @@
     "no-proto": "error",
     "no-redeclare": "error",
     "no-regex-spaces": "error",
-    "no-return-assign": ["error", "except-parens"],
+    "no-return-assign": [
+      "error",
+      "except-parens"
+    ],
     "no-return-await": "error",
     "no-self-assign": "error",
     "no-self-compare": "error",
@@ -139,7 +261,12 @@
     "no-undef-init": "error",
     "no-unexpected-multiline": "error",
     "no-unmodified-loop-condition": "error",
-    "no-unneeded-ternary": ["error", { "defaultAssignment": false }],
+    "no-unneeded-ternary": [
+      "error",
+      {
+        "defaultAssignment": false
+      }
+    ],
     "no-unreachable": "error",
     "no-unsafe-finally": "error",
     "no-unsafe-negation": "error",
@@ -153,7 +280,11 @@
     ],
     "no-use-before-define": [
       "error",
-      { "functions": false, "classes": false, "variables": false }
+      {
+        "functions": false,
+        "classes": false,
+        "variables": false
+      }
     ],
     "no-useless-call": "error",
     "no-useless-computed-key": "error",
@@ -165,62 +296,149 @@
     "no-with": "error",
     "object-property-newline": [
       "error",
-      { "allowMultiplePropertiesPerLine": true }
+      {
+        "allowMultiplePropertiesPerLine": true
+      }
     ],
-    "one-var": ["error", { "initialized": "never" }],
+    "one-var": [
+      "error",
+      {
+        "initialized": "never"
+      }
+    ],
     "operator-linebreak": [
       "error",
       "after",
-      { "overrides": { "?": "before", ":": "before" } }
+      {
+        "overrides": {
+          "?": "before",
+          ":": "before"
+        }
+      }
     ],
     "prefer-promise-reject-errors": "error",
     "quotes": [
       "error",
       "single",
-      { "avoidEscape": true, "allowTemplateLiterals": true }
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
     ],
-    "rest-spread-spacing": ["error", "never"],
-    "semi-spacing": ["error", { "before": false, "after": true }],
-    "space-before-blocks": ["error", "always"],
-    "space-before-function-paren": ["error", "always"],
-    "space-in-parens": ["error", "never"],
+    "rest-spread-spacing": [
+      "error",
+      "never"
+    ],
+    "semi-spacing": [
+      "error",
+      {
+        "before": false,
+        "after": true
+      }
+    ],
+    "space-before-blocks": [
+      "error",
+      "always"
+    ],
+    "space-before-function-paren": [
+      "error",
+      "always"
+    ],
+    "space-in-parens": [
+      "error",
+      "never"
+    ],
     "space-infix-ops": "error",
-    "space-unary-ops": ["error", { "words": true, "nonwords": false }],
+    "space-unary-ops": [
+      "error",
+      {
+        "words": true,
+        "nonwords": false
+      }
+    ],
     "spaced-comment": [
       "error",
       "always",
       {
-        "line": { "markers": ["*package", "!", "/", ",", "="] },
+        "line": {
+          "markers": [
+            "*package",
+            "!",
+            "/",
+            ",",
+            "="
+          ]
+        },
         "block": {
           "balanced": true,
-          "markers": ["*package", "!", ",", ":", "::", "flow-include"],
-          "exceptions": ["*"]
+          "markers": [
+            "*package",
+            "!",
+            ",",
+            ":",
+            "::",
+            "flow-include"
+          ],
+          "exceptions": [
+            "*"
+          ]
         }
       }
     ],
     "symbol-description": "error",
-    "template-curly-spacing": ["error", "never"],
-    "template-tag-spacing": ["error", "never"],
-    "unicode-bom": ["error", "never"],
+    "template-curly-spacing": [
+      "error",
+      "never"
+    ],
+    "template-tag-spacing": [
+      "error",
+      "never"
+    ],
+    "unicode-bom": [
+      "error",
+      "never"
+    ],
     "use-isnan": "error",
-    "valid-typeof": ["error", { "requireStringLiterals": true }],
-    "wrap-iife": ["error", "any", { "functionPrototypeMethods": true }],
-    "yield-star-spacing": ["error", "both"],
-    "yoda": ["error", "never"],
-
+    "valid-typeof": [
+      "error",
+      {
+        "requireStringLiterals": true
+      }
+    ],
+    "wrap-iife": [
+      "error",
+      "any",
+      {
+        "functionPrototypeMethods": true
+      }
+    ],
+    "yield-star-spacing": [
+      "error",
+      "both"
+    ],
+    "yoda": [
+      "error",
+      "never"
+    ],
     "import/export": "error",
     "import/first": "error",
     "import/no-duplicates": "error",
     "import/no-webpack-loader-syntax": "error",
-
     "node/no-deprecated-api": "error",
     "node/process-exit-as-throw": "error",
-
     "promise/param-names": "error",
-
-    "standard/array-bracket-even-spacing": ["error", "either"],
-    "standard/computed-property-even-spacing": ["error", "even"],
+    "standard/array-bracket-even-spacing": [
+      "error",
+      "either"
+    ],
+    "standard/computed-property-even-spacing": [
+      "error",
+      "even"
+    ],
     "standard/no-callback-literal": "error",
-    "standard/object-curly-even-spacing": ["error", "either"]
+    "standard/object-curly-even-spacing": [
+      "error",
+      "either"
+    ]
   }
 }

--- a/.ci/doc/eslint.json
+++ b/.ci/doc/eslint.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": "latest",
+    "ecmaVersion": 9,
     "ecmaFeatures": {
       "jsx": true
     },

--- a/.ci/doc/eslint.json
+++ b/.ci/doc/eslint.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 12,
+    "ecmaVersion": "latest",
     "ecmaFeatures": {
       "jsx": true
     },

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -85,9 +85,6 @@ jobs:
      name: Documentation Snippet Tests
      needs: [unit-tests]
      runs-on: ubuntu-20.04
-     strategy:
-      matrix:
-        node-version: ["16", "18"]
      steps:
        - uses: actions/checkout@v3
        - name: Cache node modules
@@ -103,7 +100,7 @@ jobs:
              ${{ runner.os }}-
        - uses: actions/setup-node@v3
          with:
-           node-version: ${{ matrix.node-version }}
+           node-version: '18'
        - uses: ./.github/actions/snippet-tests
          with:
           CYPRESS_RECORD_KEY_DOC: ${{ secrets.CYPRESS_RECORD_KEY_DOC }}

--- a/doc/7/essentials/offline-tools/index.md
+++ b/doc/7/essentials/offline-tools/index.md
@@ -38,6 +38,10 @@ await kuzzle.realtime.subscribe('test', 'test', {}, () => {
 
 </details>
 
+:::info
+Note that the offline tools will use the current authentication token to replay the requests in the queue.
+:::
+
 ## Contructor options and properties
 
 These properties can be set in the `options` object when [instantiating a new SDK](/sdk/js/7/core-classes/kuzzle/constructor#arguments).

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -1104,6 +1104,9 @@ Discarded request: ${JSON.stringify(request)}`)
     const uniqueQueue = {},
       dequeuingProcess = () => {
         if (this.offlineQueue.length > 0) {
+          // Reapply the jwt to the request since it could have been expired
+          this.offlineQueue[0].request.jwt = this.jwt;
+
           this._timeoutRequest(
             this.offlineQueue[0].timeout,
             this.offlineQueue[0].request


### PR DESCRIPTION
## What does this PR do ?
Reapply current JWT before executing offlineQueue requests.

Since the final user could use the authenticator with a short JWT TTL or being disconnected for a big amount of time from his Kuzzle backend.

