### PR TITLE
feat(auth): improve auth events

### DIFF
--- a/.ci/start_kuzzle.sh
+++ b/.ci/start_kuzzle.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "[$(date --rfc-3339 seconds)] - Start Kuzzle stack"
 
-docker-compose -f .ci/docker-compose.yml up -d
+docker compose -f .ci/docker-compose.yml up -d
 
 spinner="/"
 until $(curl --output /dev/null --silent --head --fail http://localhost:7512); do

--- a/.ci/test-docs.sh
+++ b/.ci/test-docs.sh
@@ -5,7 +5,7 @@ set -ex
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$here"
 
-docker-compose -f ./doc/docker-compose.yml pull
-docker-compose -f ./doc/docker-compose.yml run doc-tests node index
+docker compose -f ./doc/docker-compose.yml pull
+docker compose -f ./doc/docker-compose.yml run doc-tests node index
 EXIT=$?
-docker-compose -f ./doc/docker-compose.yml down
+docker compose -f ./doc/docker-compose.yml down

--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -72,6 +72,27 @@ Triggered when a login attempt completes, either with a success or a failure res
 | `success` | <pre>boolean</pre> | Indicate if login attempt succeed |
 | `error`   | <pre>string</pre>  | Error message when login fail     |
 
+## beforeLogout
+
+Triggered before logout attempt.
+
+## afterLogout
+
+Triggered when a logout attempt completes, either with a success or a failure result.
+
+## logoutAttempt
+
+Legacy event triggered when a logout attempt completes, either with a success or a failure result.
+
+**Callback arguments:**
+
+`@param {object} data`
+
+| Property  | Type               | Description                       |
+| --------- | ------------------ | --------------------------------- |
+| `success` | <pre>boolean</pre> | Indicate if logout attempt succeed |
+| `error`   | <pre>string</pre>  | Error message when logout fail     |
+
 ## networkError
 
 Triggered when the SDK has failed to connect to Kuzzle.

--- a/doc/7/essentials/events/index.md
+++ b/doc/7/essentials/events/index.md
@@ -59,9 +59,18 @@ Triggered when the current session has been unexpectedly disconnected.
 | `websocket/auth-renewal` | The websocket protocol si reconnecting to renew the token. See [Websocket Cookie Authentication](sdk/js/7/protocols/websocket/introduction#cookie-authentication). |
 | `user/connection-closed` | The disconnection is done by the user.                                                                                                                             |
 | `network/error`          | An network error occured and caused a disconnection.                                                                                                               |
-## loginAttempt
+
+## beforeLogin
+
+Triggered before login attempt.
+
+## afterLogin
 
 Triggered when a login attempt completes, either with a success or a failure result.
+
+## loginAttempt
+
+Legacy event triggered when a login attempt completes, either with a success or a failure result.
 
 **Callback arguments:**
 

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -241,11 +241,11 @@ export class Kuzzle extends KuzzleEventEmitter {
     this.protocol = protocol;
 
     this._protectedEvents = {
+      afterLogin: {},
       connected: {},
       disconnected: {},
       error: {},
       loginAttempt: {},
-      afterLogin: {},
       reconnected: {},
       tokenExpired: {},
     };
@@ -582,18 +582,12 @@ export class Kuzzle extends KuzzleEventEmitter {
     listener: () => void
   ): this;
 
-  on(
-    eventName: "beforeLogout",
-    listener: () => void
-  ): this;
+  on(eventName: "beforeLogout", listener: () => void): this;
   on(
     eventName: "logoutAttempt" | "afterLogout",
     listener: (status: { success: true }) => void
   ): this;
-  on(
-    eventName: "beforeLogin",
-    listener: () => void
-  ): this;
+  on(eventName: "beforeLogin", listener: () => void): this;
   on(
     eventName: "loginAttempt" | "afterLogin",
     listener: (data: { success: boolean; error: string }) => void

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -84,6 +84,8 @@ export class Kuzzle extends KuzzleEventEmitter {
     "discarded",
     "disconnected",
     "loginAttempt",
+    "beforeLogin",
+    "afterLogin",
     "logoutAttempt",
     "beforeLogout",
     "afterLogout",
@@ -243,6 +245,7 @@ export class Kuzzle extends KuzzleEventEmitter {
       disconnected: {},
       error: {},
       loginAttempt: {},
+      afterLogin: {},
       reconnected: {},
       tokenExpired: {},
     };
@@ -352,7 +355,10 @@ export class Kuzzle extends KuzzleEventEmitter {
 
     this._loggedIn = false;
 
-    this.on("loginAttempt", async (status) => {
+    /**
+     * When successfuly logged in
+     */
+    this.on("afterLogin", async (status) => {
       if (status.success) {
         this._loggedIn = true;
         return;
@@ -585,7 +591,11 @@ export class Kuzzle extends KuzzleEventEmitter {
     listener: (status: { success: true }) => void
   ): this;
   on(
-    eventName: "loginAttempt",
+    eventName: "beforeLogin",
+    listener: () => void
+  ): this;
+  on(
+    eventName: "loginAttempt" | "afterLogin",
     listener: (data: { success: boolean; error: string }) => void
   ): this;
   on(eventName: "discarded", listener: (request: RequestPayload) => void): this;

--- a/src/Kuzzle.ts
+++ b/src/Kuzzle.ts
@@ -85,6 +85,8 @@ export class Kuzzle extends KuzzleEventEmitter {
     "disconnected",
     "loginAttempt",
     "logoutAttempt",
+    "beforeLogout",
+    "afterLogout",
     "networkError",
     "offlineQueuePush",
     "offlineQueuePop",
@@ -369,7 +371,7 @@ export class Kuzzle extends KuzzleEventEmitter {
     /**
      * When successfuly logged out
      */
-    this.on("logoutAttempt", (status) => {
+    this.on("afterLogout", (status) => {
       if (status.success) {
         this._loggedIn = false;
       }
@@ -575,7 +577,11 @@ export class Kuzzle extends KuzzleEventEmitter {
   ): this;
 
   on(
-    eventName: "logoutAttempt",
+    eventName: "beforeLogout",
+    listener: () => void
+  ): this;
+  on(
+    eventName: "logoutAttempt" | "afterLogout",
     listener: (status: { success: true }) => void
   ): this;
   on(

--- a/src/controllers/Auth.ts
+++ b/src/controllers/Auth.ts
@@ -447,6 +447,7 @@ export class AuthController extends BaseController {
       strategy,
     };
 
+    this.kuzzle.emit("beforeLogin");
     return this.query(request, { queuable: false, timeout: -1, verb: "POST" })
       .then((response) => {
         if (this.kuzzle.cookieAuthentication) {
@@ -458,16 +459,22 @@ export class AuthController extends BaseController {
               error: err.message,
               success: false,
             });
+            this.kuzzle.emit("afterLogin", {
+              error: err.message,
+              success: false,
+            });
             throw err;
           }
 
           this.kuzzle.emit("loginAttempt", { success: true });
+          this.kuzzle.emit("afterLogin", { success: true });
           return;
         }
 
         this._authenticationToken = new Jwt(response.result.jwt);
 
         this.kuzzle.emit("loginAttempt", { success: true });
+        this.kuzzle.emit("afterLogin", { success: true });
 
         return response.result.jwt;
       })
@@ -476,6 +483,11 @@ export class AuthController extends BaseController {
           error: err.message,
           success: false,
         });
+        this.kuzzle.emit("afterLogin", {
+          error: err.message,
+          success: false,
+        });
+
         throw err;
       });
   }

--- a/src/controllers/Auth.ts
+++ b/src/controllers/Auth.ts
@@ -517,8 +517,14 @@ export class AuthController extends BaseController {
       /**
        * @deprecated logout `logoutAttempt` is legacy event. Use afterLogout instead.
        */
-      this.kuzzle.emit("logoutAttempt", { success: false, error: (error as Error).message });
-      this.kuzzle.emit("afterLogout", { success: false, error: (error as Error).message });
+      this.kuzzle.emit("logoutAttempt", {
+        error: (error as Error).message,
+        success: false,
+      });
+      this.kuzzle.emit("afterLogout", {
+        error: (error as Error).message,
+        success: false,
+      });
 
       throw error;
     }

--- a/src/core/KuzzleEventEmitter.ts
+++ b/src/core/KuzzleEventEmitter.ts
@@ -16,6 +16,8 @@ export type PublicKuzzleEvents =
   | "discarded"
   | "disconnected"
   | "loginAttempt"
+  | "beforeLogin"
+  | "afterLogin"
   | "logoutAttempt"
   | "beforeLogout"
   | "afterLogout"

--- a/src/core/KuzzleEventEmitter.ts
+++ b/src/core/KuzzleEventEmitter.ts
@@ -17,6 +17,8 @@ export type PublicKuzzleEvents =
   | "disconnected"
   | "loginAttempt"
   | "logoutAttempt"
+  | "beforeLogout"
+  | "afterLogout"
   | "networkError"
   | "offlineQueuePush"
   | "offlineQueuePop"

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -506,28 +506,33 @@ describe("Auth Controller", () => {
         });
     });
 
-    it('should trigger a login events the user is logged in', async () => {
+    it("should trigger a login events the user is logged in", async () => {
       kuzzle.emit = sinon.stub();
 
-      await kuzzle.auth
-        .login("strategy", credentials, "expiresIn")
-        .then(() => {
-          should(kuzzle.emit).be.calledWith("beforeLogin");
-          should(kuzzle.emit).be.calledWith("afterLogin", { success: true });
-          should(kuzzle.emit).be.calledWith("loginAttempt", { success: true });
-        });
+      await kuzzle.auth.login("strategy", credentials, "expiresIn").then(() => {
+        should(kuzzle.emit).be.calledWith("beforeLogin");
+        should(kuzzle.emit).be.calledWith("afterLogin", { success: true });
+        should(kuzzle.emit).be.calledWith("loginAttempt", { success: true });
+      });
       kuzzle.emit.reset();
 
       kuzzle.query.rejects();
-      await kuzzle.auth.login("strategy", credentials, "expiresIn")
+      await kuzzle.auth
+        .login("strategy", credentials, "expiresIn")
         .catch(() => {
           should(kuzzle.emit).be.calledWith("beforeLogin");
-          should(kuzzle.emit).be.calledWith("afterLogin", { success: false, error: "Error" });
-          should(kuzzle.emit).be.calledWith("loginAttempt", { success: false, error: "Error" });
+          should(kuzzle.emit).be.calledWith("afterLogin", {
+            success: false,
+            error: "Error",
+          });
+          should(kuzzle.emit).be.calledWith("loginAttempt", {
+            success: false,
+            error: "Error",
+          });
         });
     });
 
-    it('should trigger a login events the user is logged in with cookieAuthentication enabled', async () => {
+    it("should trigger a login events the user is logged in with cookieAuthentication enabled", async () => {
       kuzzle.emit = sinon.stub();
       kuzzle.cookieAuthentication = true;
       kuzzle.query.resolves({
@@ -536,13 +541,11 @@ describe("Auth Controller", () => {
         },
       });
 
-      await kuzzle.auth
-        .login("strategy", credentials, "expiresIn")
-        .then(() => {
-          should(kuzzle.emit).be.calledWith("beforeLogin");
-          should(kuzzle.emit).be.calledWith("afterLogin", { success: true });
-          should(kuzzle.emit).be.calledWith("loginAttempt", { success: true });
-        });
+      await kuzzle.auth.login("strategy", credentials, "expiresIn").then(() => {
+        should(kuzzle.emit).be.calledWith("beforeLogin");
+        should(kuzzle.emit).be.calledWith("afterLogin", { success: true });
+        should(kuzzle.emit).be.calledWith("loginAttempt", { success: true });
+      });
       kuzzle.emit.reset();
 
       kuzzle.query.rejects();
@@ -550,8 +553,14 @@ describe("Auth Controller", () => {
         .be.rejected()
         .catch(() => {
           should(kuzzle.emit).be.calledWith("beforeLogin");
-          should(kuzzle.emit).be.calledWith("afterLogin", { success: false, error: "Error" });
-          should(kuzzle.emit).be.calledWith("loginAttempt", { success: false, error: "Error" });
+          should(kuzzle.emit).be.calledWith("afterLogin", {
+            success: false,
+            error: "Error",
+          });
+          should(kuzzle.emit).be.calledWith("loginAttempt", {
+            success: false,
+            error: "Error",
+          });
         });
     });
 
@@ -616,11 +625,14 @@ describe("Auth Controller", () => {
       // ? Fail logout
       kuzzle.query.rejects();
       await kuzzle.auth.logout().catch(() => {
-        should(kuzzle.emit).be.calledWith("logoutAttempt", { success: false, error: "Error" });
+        should(kuzzle.emit).be.calledWith("logoutAttempt", {
+          success: false,
+          error: "Error",
+        });
       });
     });
 
-    it('should trigger logout events when the user is logged out', async () => {
+    it("should trigger logout events when the user is logged out", async () => {
       kuzzle.emit = sinon.stub();
       await kuzzle.auth.logout().then(() => {
         should(kuzzle.emit).be.calledWith("beforeLogout");
@@ -631,7 +643,10 @@ describe("Auth Controller", () => {
       // ? Fail logout
       kuzzle.query.rejects();
       await kuzzle.auth.logout().catch(() => {
-        should(kuzzle.emit).be.calledWith("afterLogout", { success: false, error: "Error" });
+        should(kuzzle.emit).be.calledWith("afterLogout", {
+          success: false,
+          error: "Error",
+        });
       });
     });
   });

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -7,9 +7,20 @@ const { AuthController } = require("../../src/controllers/Auth");
 const { User } = require("../../src/core/security/User");
 const generateJwt = require("../mocks/generateJwt.mock");
 
+/**
+ * Kuzzle interface
+ *
+ * @typedef {Object} Kuzzle
+ * @property {import("sinon").SinonStub} Kuzzle.query
+ * @property {import("sinon").SinonStub} Kuzzle.emit
+ * @property {boolean} Kuzzle.cookieAuthentication
+ */
+
 describe("Auth Controller", () => {
   const options = { opt: "in" };
-  let jwt, kuzzle;
+  /** @type {Kuzzle} */
+  let kuzzle;
+  let jwt;
 
   beforeEach(() => {
     kuzzle = new KuzzleEventEmitter();
@@ -568,6 +579,36 @@ describe("Auth Controller", () => {
     it("should unset the authenticationToken property", () => {
       return kuzzle.auth.logout().then(() => {
         should(kuzzle.auth.authenticationToken).be.null();
+      });
+    });
+
+    // ? Legacy event
+    it('should trigger a legacy "logoutAttempt" event the user is logged out', async () => {
+      kuzzle.emit = sinon.stub();
+      await kuzzle.auth.logout().then(() => {
+        should(kuzzle.emit).be.calledWith("logoutAttempt", { success: true });
+      });
+      kuzzle.emit.reset();
+
+      // ? Fail logout
+      kuzzle.query.rejects();
+      await kuzzle.auth.logout().catch(() => {
+        should(kuzzle.emit).be.calledWith("logoutAttempt", { success: false, error: "Error" });
+      });
+    });
+
+    it('should trigger logout events when the user is logged out', async () => {
+      kuzzle.emit = sinon.stub();
+      await kuzzle.auth.logout().then(() => {
+        should(kuzzle.emit).be.calledWith("beforeLogout");
+        should(kuzzle.emit).be.calledWith("afterLogout", { success: true });
+      });
+      kuzzle.emit.reset();
+
+      // ? Fail logout
+      kuzzle.query.rejects();
+      await kuzzle.auth.logout().catch(() => {
+        should(kuzzle.emit).be.calledWith("afterLogout", { success: false, error: "Error" });
       });
     });
   });

--- a/test/kuzzle/authenticator.test.js
+++ b/test/kuzzle/authenticator.test.js
@@ -59,7 +59,7 @@ describe("Kuzzle authenticator function mecanisms", () => {
     });
   });
 
-  describe("loginAttempt listener", () => {
+  describe("login listener", () => {
     let resolve;
     let promise;
 
@@ -73,7 +73,7 @@ describe("Kuzzle authenticator function mecanisms", () => {
       });
 
       should(kuzzle._loggedIn).be.false();
-      kuzzle.emit("loginAttempt", { success: true });
+      kuzzle.emit("afterLogin", { success: true });
 
       setTimeout(() => {
         should(kuzzle.auth.checkToken).not.be.calledOnce();
@@ -92,7 +92,7 @@ describe("Kuzzle authenticator function mecanisms", () => {
       kuzzle.auth.checkToken.resolves({ valid: true });
 
       should(kuzzle._loggedIn).be.false();
-      kuzzle.emit("loginAttempt", { success: false, err: new Error("foo") });
+      kuzzle.emit("afterLogin", { success: false, err: new Error("foo") });
 
       setTimeout(() => {
         should(kuzzle.auth.checkToken).be.calledOnce();

--- a/test/kuzzle/authenticator.test.js
+++ b/test/kuzzle/authenticator.test.js
@@ -104,17 +104,17 @@ describe("Kuzzle authenticator function mecanisms", () => {
     });
   });
 
-  describe("logoutAttempt listener", () => {
+  describe("logout listener", () => {
     let resolve;
     let promise;
 
-    it("should set _loggedIn to false on logout", async () => {
+    it("should set _loggedIn to false on afterLogout", async () => {
       promise = new Promise((_resolve) => {
         resolve = _resolve;
       });
 
       kuzzle._loggedIn = true;
-      kuzzle.emit("logoutAttempt", { success: true });
+      kuzzle.emit("afterLogout", { success: true });
 
       setTimeout(() => {
         should(kuzzle.auth.checkToken).not.be.calledOnce();

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -26,6 +26,8 @@ describe("Kuzzle listeners management", () => {
       "discarded",
       "disconnected",
       "loginAttempt",
+      "beforeLogin",
+      "afterLogin",
       "logoutAttempt",
       "beforeLogout",
       "afterLogout",

--- a/test/kuzzle/listenersManagement.test.js
+++ b/test/kuzzle/listenersManagement.test.js
@@ -27,6 +27,8 @@ describe("Kuzzle listeners management", () => {
       "disconnected",
       "loginAttempt",
       "logoutAttempt",
+      "beforeLogout",
+      "afterLogout",
       "networkError",
       "offlineQueuePush",
       "offlineQueuePop",


### PR DESCRIPTION
## What does this PR do ?

Add **before** and **after** events for login and logout events to replace `loginAttempt` and `logoutAttempt` (previous events are keep for legacy).

So add the follow events:

- `beforeLogin` triggered before login attempt
- `afterLogin` triggered after login attempt and work exactly same as `loginAttempt` (same callback arguments)
- `beforeLogout` triggered before logout attempt
- `afterLogout` triggered after logout attempt and work exactly same as `logoutAttempt` (same callback arguments)

### Other changes

- Refactor logout method to handle error and trigger `afterLogout` and `logoutAttempt` in error case

### Boyscout

- Add logout events documentation

KZLPRD-492