### PR TITLE
fix(mRepsonse): mResponseError contains a body not a _source property

### DIFF
--- a/src/types/mResponses.ts
+++ b/src/types/mResponses.ts
@@ -6,7 +6,7 @@ type mResponseErrors = Array<{
    */
   document: {
     _id: string;
-    _source: JSONObject;
+    body: JSONObject;
   };
 
   /**


### PR DESCRIPTION
## What does this PR do ?
This PR corrects the type of mResponseError as it returns a 
```
  document: {
    _id: string;
    body: JSONObject;
  };
  ```
and doesn't have any `_source` property