### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [7.17.1-beta.1](https://github.com/kuzzleio/sdk-javascript/compare/v7.17.0...v7.17.1-beta.1) (2025-12-29)
+
+### Bug Fixes
+
+* export files that are used by other libs ([2b0369d](https://github.com/kuzzleio/sdk-javascript/commit/2b0369d0f006e7ef5ab7460cdd280f9c00aa76f2))
+
 ## [7.17.0](https://github.com/kuzzleio/sdk-javascript/compare/v7.16.0...v7.17.0) (2025-12-16)
 
 ### Features

--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,20 @@
 export * from "./src/Kuzzle";
 export * from "./src/protocols";
 export * from "./src/protocols/abstract/Base";
-export * from "./src/core/KuzzleEventEmitter";
 
-export * from "./src/core/searchResult/SearchResultBase";
+export * from "./src/core/batchWriter/BatchController";
+export * from "./src/core/KuzzleEventEmitter";
+export * from "./src/core/Observer";
+export * from "./src/core/RealtimeDocument";
 export * from "./src/core/searchResult/Document";
 export * from "./src/core/searchResult/Profile";
 export * from "./src/core/searchResult/Role";
+export * from "./src/core/searchResult/SearchResultBase";
 export * from "./src/core/searchResult/Specifications";
 export * from "./src/core/searchResult/User";
-export * from "./src/core/Observer";
-export * from "./src/core/RealtimeDocument";
-export * from "./src/core/batchWriter/BatchController";
+export * from "./src/core/security/Profile";
+export * from "./src/core/security/Role";
+export * from "./src/core/security/User";
 
 export * from "./src/types";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.17.0",
+  "version": "7.17.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-sdk",
-      "version": "7.17.0",
+      "version": "7.17.1-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "8.18.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-sdk",
-  "version": "7.17.0",
+  "version": "7.17.1-beta.1",
   "description": "Official Javascript SDK for Kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "repository": {


### PR DESCRIPTION
# Overview

Fix an import that was not properly done, resulting of us importing it directly by the name of the file. It was resulting in an error in the latest version of the SDK because of how it is now exported.

This PR fix the issue